### PR TITLE
feat: use sha256 for password checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,37 +1,41 @@
 # LogDeck Environment Configuration
-# Copy this file to .env and adjust values as needed
-# Note: .env is gitignored and safe for local secrets
 
 # =============================================================================
-# Backend Configuration
+# Authentication Settings (Required)
 # =============================================================================
 
-# Port for the backend API server
+# JWT Secret Key - Use a strong, random string (minimum 32 characters)
+# Generate one with: openssl rand -base64 32
+JWT_SECRET=your-super-secret-key-change-this-to-something-random-min-32-chars
+
+# Admin User Credentials
+ADMIN_USERNAME=admin
+
+# Admin Password Salt - Use a strong, random string
+# Generate one with: openssl rand -hex 32
+ADMIN_PASSWORD_SALT=your-random-salt-change-this
+
+# Admin Password Hash - SHA256 hash of (password + salt)
+# Generate one with: echo -n "yourPassword$(echo -n 'your-salt' | cat)" | shasum -a 256 | awk '{print $1}'
+# Or in one command (replace YOUR_PASSWORD and YOUR_SALT):
+#   echo -n "YOUR_PASSWORDYOUR_SALT" | shasum -a 256 | awk '{print $1}'
+# Example: If password is "admin123" and salt is "mysalt", run:
+#   echo -n "admin123mysalt" | shasum -a 256 | awk '{print $1}'
+ADMIN_PASSWORD=change-this-to-your-sha256-hash
+
+# =============================================================================
+# Server Configuration (Optional)
+# =============================================================================
+
+# Backend port (default 8080)
 BACKEND_PORT=8080
 
-# =============================================================================
-# Frontend Configuration
-# =============================================================================
-
-# API URL for frontend to connect to backend
-# For native development: http://localhost:8080
-# For Docker development: http://backend:8080 (handled automatically by docker-compose)
-VITE_API_URL=http://localhost:8080
-
-# Port for the frontend dev server (Vite)
+# Frontend port (default: 5173)
 FRONTEND_PORT=5173
 
 # =============================================================================
-# Development Mode
+# Docker Configuration (Optional)
 # =============================================================================
 
-# Set to "development" or "production"
-NODE_ENV=development
-
-# =============================================================================
-# Docker Configuration (only needed for docker-compose)
-# =============================================================================
-
-# Docker socket path (for backend to access Docker daemon)
-# macOS/Linux: /var/run/docker.sock
-DOCKER_SOCKET=/var/run/docker.sock
+# Docker host (uncomment to override default)
+DOCKER_HOST=unix:///var/run/docker.sock


### PR DESCRIPTION
- Updated .env.example to include new environment variables for admin password security, including a SHA256 hash and salt.
- Refactored authentication service to utilize SHA256 for password hashing instead of bcrypt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced admin authentication security with improved password handling
  
* **Chores**
  * Updated environment configuration variables for authentication setup; existing deployments will require configuration updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->