### PR TITLE
fix: update Dockerfile for multi-platform support

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 
 WORKDIR /app
 
@@ -7,7 +7,8 @@ ENV GOTOOLCHAIN=auto
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o logdeck-server ./cmd/server
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o logdeck-server ./cmd/server
 
 FROM gcr.io/distroless/static-debian12
 


### PR DESCRIPTION
Modified the Dockerfile to support multi-platform builds by using the BUILDPLATFORM argument. Updated the build command to utilize the TARGETARCH argument for architecture-specific builds, enhancing compatibility across different environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration to support multi-architecture deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->