### PR TITLE
feat: add Docker Hub publishing workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: amoabakelvin
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: amoabakelvin/logdeck
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 services:
   logdeck:
-    build:
-      context: .
-      dockerfile: ./server/Dockerfile
+    image: amoabakelvin/logdeck:latest
+    # To build locally instead, comment out 'image' and uncomment below:
+    # build:
+    #   context: .
+    #   dockerfile: ./server/Dockerfile
     ports:
       - "8123:8080"
     environment:
@@ -14,3 +16,4 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.ssh:/root/.ssh:ro
+      - /proc:/host/proc:ro


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated Docker Hub publishing
- Build multi-arch images (amd64/arm64) on push to main or version tags
- Update docker-compose.yml to pull from `amoabakelvin/logdeck` instead of building locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated Docker image publishing to a container registry on main branch pushes and release tags.
  * Updated deployment configuration to use prebuilt container images instead of building locally.
  * Added read-only access to system proc filesystem for the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->