### PR TITLE
fix: prevent logs from disappearing when toggling autoscroll during streaming

### DIFF
--- a/frontend/src/features/containers/components/containers-logs-sheet.tsx
+++ b/frontend/src/features/containers/components/containers-logs-sheet.tsx
@@ -1,5 +1,7 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  ArrowDownIcon,
+  ArrowDownToLineIcon,
   CheckIcon,
   ChevronDownIcon,
   CopyIcon,
@@ -103,14 +105,20 @@ export function ContainersLogsSheet({
   const [showFilters, setShowFilters] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const parentRef = useRef<HTMLDivElement>(null);
+  const autoScrollRef = useRef(autoScroll);
   const logLinesInputId = useId();
 
+  // Keep ref in sync with state
+  useEffect(() => {
+    autoScrollRef.current = autoScroll;
+  }, [autoScroll]);
+
   const scrollToBottom = useCallback(() => {
-    if (autoScroll && parentRef.current) {
+    if (autoScrollRef.current && parentRef.current) {
       // For virtualized list, scroll the parent container to bottom
       parentRef.current.scrollTop = parentRef.current.scrollHeight;
     }
-  }, [autoScroll]);
+  }, []);
 
   const fetchLogs = useCallback(async () => {
     if (!container) return;
@@ -666,12 +674,16 @@ export function ContainersLogsSheet({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
-                      variant={autoScroll ? "default" : "outline"}
+                      variant={autoScroll ? "secondary" : "outline"}
                       size="sm"
                       onClick={() => setAutoScroll(!autoScroll)}
-                      className="h-9"
+                      className={`h-9 ${autoScroll ? "bg-primary/10 hover:bg-primary/20 border-primary/30" : ""}`}
                     >
-                      <ChevronDownIcon className="size-4" />
+                      {autoScroll ? (
+                        <ArrowDownToLineIcon className="size-4" />
+                      ) : (
+                        <ArrowDownIcon className="size-4" />
+                      )}
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>

--- a/frontend/src/routes/containers/$containerId/logs.tsx
+++ b/frontend/src/routes/containers/$containerId/logs.tsx
@@ -2,6 +2,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  ArrowDownIcon,
+  ArrowDownToLineIcon,
   ArrowLeftIcon,
   CheckIcon,
   ChevronDownIcon,
@@ -99,7 +101,13 @@ function ContainerLogsPage() {
   const [showTerminal, setShowTerminal] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const parentRef = useRef<HTMLDivElement>(null);
+  const autoScrollRef = useRef(autoScroll);
   const logLinesInputId = useId();
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    autoScrollRef.current = autoScroll;
+  }, [autoScroll]);
 
   // Decode the URL parameter (could be name or ID)
   const containerIdentifier = decodeURIComponent(encodedContainerId);
@@ -143,11 +151,11 @@ function ContainerLogsPage() {
   };
 
   const scrollToBottom = useCallback(() => {
-    if (autoScroll && parentRef.current) {
+    if (autoScrollRef.current && parentRef.current) {
       // For virtualized list, scroll the parent container to bottom
       parentRef.current.scrollTop = parentRef.current.scrollHeight;
     }
-  }, [autoScroll]);
+  }, []);
 
   const fetchLogs = useCallback(async () => {
     if (!actualContainerId || !container?.host) return;
@@ -730,12 +738,16 @@ function ContainerLogsPage() {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
-                      variant={autoScroll ? "default" : "outline"}
+                      variant={autoScroll ? "secondary" : "outline"}
                       size="sm"
                       onClick={() => setAutoScroll(!autoScroll)}
-                      className="h-9"
+                      className={`h-9 ${autoScroll ? "bg-primary/10 hover:bg-primary/20 border-primary/30" : ""}`}
                     >
-                      <ChevronDownIcon className="size-4" />
+                      {autoScroll ? (
+                        <ArrowDownToLineIcon className="size-4" />
+                      ) : (
+                        <ArrowDownIcon className="size-4" />
+                      )}
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,5 +22,12 @@ export default defineConfig({
   server: {
     host: true, // Listen on all addresses, needed for Docker
     port: 5173,
+    proxy: {
+      // Proxy API requests to the backend during development
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Fix bug where logs would disappear when turning off autoscroll during active streaming
- Update autoscroll button with distinct icons (arrow-down-to-line when on, arrow-down when off)
- Add Vite dev server proxy for easier local development with separate frontend/backend

## Test plan
- [x] Start streaming logs on a container
- [x] Toggle autoscroll off while streaming - logs should remain visible
- [x] New logs should continue arriving but not auto-scroll
- [x] Toggle autoscroll back on - should resume scrolling to bottom
- [x] Verify button icons change appropriately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced auto-scroll reliability and state synchronization in log views.

* **Style**
  * Updated auto-scroll toggle button with new icons and improved visual feedback for active state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->