### PR TITLE
Fix: prevent long image names from overflowing

### DIFF
--- a/frontend/src/features/containers/components/containers-logs-sheet.tsx
+++ b/frontend/src/features/containers/components/containers-logs-sheet.tsx
@@ -461,9 +461,16 @@ export function ContainersLogsSheet({
                     </div>
                     <div className="grid grid-cols-3 gap-4">
                       <span className="text-muted-foreground">Image</span>
-                      <span className="col-span-2 font-medium">
-                        {container.image}
-                      </span>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="col-span-2 font-medium truncate cursor-help">
+                            {container.image}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-md break-all">
+                          {container.image}
+                        </TooltipContent>
+                      </Tooltip>
                     </div>
                     <div className="grid grid-cols-3 gap-4">
                       <span className="text-muted-foreground">State</span>


### PR DESCRIPTION
## Summary
Wrap the image name field in the logs detail card with a Tooltip component and add the `truncate` class to prevent long image names from breaking the layout and overflowing into adjacent columns.

## Changes
- Added Tooltip wrapper around the image name field
- Added `truncate` class to clip long text with ellipsis
- Added cursor-help class for better UX
- Tooltip shows full image name on hover

## Test plan
- Open the logs detail sheet for a container with a long image name
- Verify the image name is truncated and doesn't overflow into the State column
- Hover over the image name to see the full name in a tooltip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Container Logs now displays image names in truncated form with tooltip hover support to reveal the complete image string.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->