### PR TITLE
feat(frontend): add SVG favicon with LogDeck "L" branding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#111827"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#ffffff">L</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds an SVG favicon displaying a bold "L" on a dark rounded rectangle, replacing the default favicon as the primary icon.

## Changes

- Add `frontend/public/favicon.svg` with a white "L" on a dark (`#111827`) rounded background
- Update `frontend/index.html` to use SVG favicon as primary, with `.ico` fallback for older browsers

## Type of Change

- [x] feat: New feature

## Testing

Verified the SVG renders correctly in browser tab. The `.ico` fallback remains for browsers without SVG favicon support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced favicon declarations with support for multiple formats for improved cross-browser and device compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->