### PR TITLE
fix(docker): handle unreachable hosts without stalling container listing

### DIFF
--- a/frontend/src/features/containers/api/get-containers.ts
+++ b/frontend/src/features/containers/api/get-containers.ts
@@ -1,7 +1,7 @@
 import { authenticatedFetch } from "@/lib/api-client";
 import { API_BASE_URL } from "@/types/api";
 
-import type { ContainerInfo, DockerHost } from "../types";
+import type { ContainerInfo, DockerHost, HostError } from "../types";
 
 const CONTAINERS_ENDPOINT = `${API_BASE_URL}/api/v1/containers`;
 
@@ -9,6 +9,7 @@ export interface GetContainersResponse {
   containers: ContainerInfo[];
   readOnly: boolean;
   hosts: DockerHost[];
+  hostErrors: HostError[];
 }
 
 export async function getContainers(): Promise<GetContainersResponse> {
@@ -28,6 +29,7 @@ export async function getContainers(): Promise<GetContainersResponse> {
   const containers = (data as { containers?: unknown }).containers;
   const readOnly = (data as { readOnly?: boolean }).readOnly ?? false;
   const hosts = (data as { hosts?: unknown }).hosts;
+  const hostErrors = (data as { hostErrors?: unknown }).hostErrors;
 
   if (!Array.isArray(containers)) {
     throw new Error("Unexpected response format");
@@ -41,5 +43,6 @@ export async function getContainers(): Promise<GetContainersResponse> {
     containers: containers as ContainerInfo[],
     readOnly,
     hosts: hosts as DockerHost[],
+    hostErrors: Array.isArray(hostErrors) ? (hostErrors as HostError[]) : [],
   };
 }

--- a/frontend/src/features/containers/components/containers-dashboard.tsx
+++ b/frontend/src/features/containers/components/containers-dashboard.tsx
@@ -54,6 +54,20 @@ export function ContainersDashboard() {
   const containers = data?.containers ?? [];
   const isReadOnly = data?.readOnly ?? false;
   const hosts = data?.hosts ?? [];
+  const hostErrors = data?.hostErrors ?? [];
+
+  const hostErrorKeys = hostErrors.map((he) => he.host).sort().join(",");
+  useEffect(() => {
+    if (hostErrors.length > 0) {
+      for (const he of hostErrors) {
+        toast.warning(`Could not reach host "${he.host}"`, {
+          id: `host-error-${he.host}`,
+          description: "Containers from this host could not be loaded.",
+          duration: 8000,
+        });
+      }
+    }
+  }, [hostErrorKeys, hostErrors]);
 
   const hostInfo = useMemo(
     () => ({

--- a/frontend/src/features/containers/components/containers-dashboard.tsx
+++ b/frontend/src/features/containers/components/containers-dashboard.tsx
@@ -56,18 +56,15 @@ export function ContainersDashboard() {
   const hosts = data?.hosts ?? [];
   const hostErrors = data?.hostErrors ?? [];
 
-  const hostErrorKeys = hostErrors.map((he) => he.host).sort().join(",");
   useEffect(() => {
-    if (hostErrors.length > 0) {
-      for (const he of hostErrors) {
-        toast.warning(`Could not reach host "${he.host}"`, {
-          id: `host-error-${he.host}`,
-          description: "Containers from this host could not be loaded.",
-          duration: 8000,
-        });
-      }
+    for (const he of hostErrors) {
+      toast.warning(`Could not reach host "${he.host}"`, {
+        id: `host-error-${he.host}`,
+        description: "Containers from this host could not be loaded.",
+        duration: 8000,
+      });
     }
-  }, [hostErrorKeys, hostErrors]);
+  }, [hostErrors]);
 
   const hostInfo = useMemo(
     () => ({

--- a/frontend/src/features/containers/types.ts
+++ b/frontend/src/features/containers/types.ts
@@ -16,6 +16,11 @@ export interface ContainerInfo {
   host: string
 }
 
+export interface HostError {
+  host: string
+  message: string
+}
+
 export interface ContainersQueryParams {
   search?: string
   state?: string

--- a/server/internal/docker/client.go
+++ b/server/internal/docker/client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/config"
 	"github.com/AmoabaKelvin/logdeck/internal/models"
@@ -37,6 +39,7 @@ func NewMultiHostClient(hosts []config.DockerHost) (*MultiHostClient, error) {
 				Transport: &http.Transport{
 					DialContext: helper.Dialer,
 				},
+				Timeout: 10 * time.Second,
 			}
 
 			apiClient, err = client.NewClientWithOpts(
@@ -73,32 +76,43 @@ type HostError struct {
 func (c *MultiHostClient) ListContainersAllHosts(ctx context.Context) (map[string][]models.ContainerInfo, []HostError, error) {
 	result := make(map[string][]models.ContainerInfo)
 	var hostErrors []HostError
+	var mu sync.Mutex
+	var wg sync.WaitGroup
 
 	for hostName, apiClient := range c.clients {
-		containers, err := apiClient.ContainerList(ctx, container.ListOptions{All: true})
-		if err != nil {
-			hostErrors = append(hostErrors, HostError{HostName: hostName, Err: err})
-			continue
-		}
+		wg.Add(1)
+		go func(name string, cl *client.Client) {
+			defer wg.Done()
 
-		hostContainers := make([]models.ContainerInfo, 0, len(containers))
-		for _, ctr := range containers {
-			hostContainers = append(hostContainers, models.ContainerInfo{
-				ID:      ctr.ID,
-				Names:   ctr.Names,
-				Image:   ctr.Image,
-				ImageID: ctr.ImageID,
-				Command: ctr.Command,
-				Created: ctr.Created,
-				State:   ctr.State,
-				Status:  ctr.Status,
-				Labels:  ctr.Labels,
-				Host:    hostName,
-			})
-		}
-		result[hostName] = hostContainers
+			containers, err := cl.ContainerList(ctx, container.ListOptions{All: true})
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				hostErrors = append(hostErrors, HostError{HostName: name, Err: err})
+				return
+			}
+
+			hostContainers := make([]models.ContainerInfo, 0, len(containers))
+			for _, ctr := range containers {
+				hostContainers = append(hostContainers, models.ContainerInfo{
+					ID:      ctr.ID,
+					Names:   ctr.Names,
+					Image:   ctr.Image,
+					ImageID: ctr.ImageID,
+					Command: ctr.Command,
+					Created: ctr.Created,
+					State:   ctr.State,
+					Status:  ctr.Status,
+					Labels:  ctr.Labels,
+					Host:    name,
+				})
+			}
+			result[name] = hostContainers
+		}(hostName, apiClient)
 	}
 
+	wg.Wait()
 	return result, hostErrors, nil
 }
 


### PR DESCRIPTION
## Summary

When one Docker host is unreachable, the entire container listing request hangs indefinitely. This fix fetches from all hosts concurrently and returns partial results with error info for failed hosts.

## Changes

- Fetch containers from all Docker hosts concurrently using goroutines instead of sequentially
- Add HTTP client timeout (10s) for SSH connections to prevent indefinite hangs
- Use request context instead of background context so goroutines cancel on client disconnect
- Return partial results (200) with a `hostErrors` field instead of failing the entire request (500)
- Surface per-host errors as toast warnings in the frontend dashboard

## Type of Change

- [x] fix: Bug fix

## Testing

- Configure two Docker hosts, make one unreachable
- Verify containers from the reachable host load within the timeout
- Verify a toast warning appears for the unreachable host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added warning notifications for unreachable hosts to alert users when hosts cannot be reached.

* **Bug Fixes**
  * Dashboard now gracefully handles host connection failures, displaying containers from available hosts instead of failing completely.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->