### PR TITLE
feat(server): per-host Coolify configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,7 @@ DOCKER_HOST=unix:///var/run/docker.sock
 # Coolify Integration (Optional)
 # =============================================================================
 # Enable this to persist env var changes across Coolify redeployments.
-# Both values must be set together.
+# Format: hostName|apiURL|apiToken,hostName|apiURL|apiToken,...
+# Host names must match names defined in DOCKER_HOSTS.
 
-# COOLIFY_API_URL=https://your-coolify-instance.com
-# COOLIFY_API_TOKEN=your-coolify-api-token
+# COOLIFY_CONFIGS=prod|https://coolify-prod.example.com|token-abc,staging|https://coolify-staging.example.com|token-xyz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - ADMIN_PASSWORD_SALT=${ADMIN_PASSWORD_SALT}
       - DOCKER_HOST=${DOCKER_HOST:-unix:///var/run/docker.sock}
+      - DOCKER_HOSTS=${DOCKER_HOSTS:-}
       - COOLIFY_CONFIGS=${COOLIFY_CONFIGS:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - ADMIN_PASSWORD_SALT=${ADMIN_PASSWORD_SALT}
       - DOCKER_HOST=${DOCKER_HOST:-unix:///var/run/docker.sock}
-      - COOLIFY_API_URL=${COOLIFY_API_URL:-}
-      - COOLIFY_API_TOKEN=${COOLIFY_API_TOKEN:-}
+      - COOLIFY_CONFIGS=${COOLIFY_CONFIGS:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.ssh:/root/.ssh:ro

--- a/docs/app/docs/configuration/page.tsx
+++ b/docs/app/docs/configuration/page.tsx
@@ -201,30 +201,21 @@ DOCKER_HOSTS=local=unix:///var/run/docker.sock,prod=ssh://deploy@prod.example.co
 
             <div>
               <div className="flex items-baseline gap-2 mb-1">
-                <code className="text-sm font-mono bg-muted px-2 py-1 rounded">COOLIFY_API_URL</code>
+                <code className="text-sm font-mono bg-muted px-2 py-1 rounded">COOLIFY_CONFIGS</code>
                 <span className="text-xs text-amber-600 dark:text-amber-500 font-medium">Required for Coolify</span>
               </div>
               <p className="text-sm text-muted-foreground">
-                The base URL of your Coolify instance API.
-              </p>
-              <div className="mt-2">
-                <CodeBlock code='COOLIFY_API_URL=https://your-coolify-instance.com' language="bash" />
-              </div>
-            </div>
-
-            <Separator />
-
-            <div>
-              <div className="flex items-baseline gap-2 mb-1">
-                <code className="text-sm font-mono bg-muted px-2 py-1 rounded">COOLIFY_API_TOKEN</code>
-                <span className="text-xs text-amber-600 dark:text-amber-500 font-medium">Required for Coolify</span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                API token for authenticating with the Coolify API. Generate one from your Coolify dashboard
+                Per-host Coolify configuration. Each entry maps a Docker host name (from <code>DOCKER_HOSTS</code>)
+                to a Coolify instance URL and API token. Generate API tokens from your Coolify dashboard
                 under <strong>Settings &rarr; API Tokens</strong>.
               </p>
               <div className="mt-2">
-                <CodeBlock code='COOLIFY_API_TOKEN=your-coolify-api-token' language="bash" />
+                <CodeBlock code={`# Format: hostName|apiURL|apiToken,hostName|apiURL|apiToken
+# Single host
+COOLIFY_CONFIGS=local|https://your-coolify-instance.com|your-api-token
+
+# Multiple hosts with different Coolify instances
+COOLIFY_CONFIGS=prod|https://coolify-prod.example.com|token-abc,staging|https://coolify-staging.example.com|token-xyz`} language="bash" />
               </div>
             </div>
 
@@ -377,9 +368,8 @@ console.log(hash);`}
       ADMIN_PASSWORD_SALT: "your-random-salt-change-this"
       ADMIN_PASSWORD: "your-sha256-hash"
 
-      # Coolify integration (optional - remove if not using Coolify)
-      # COOLIFY_API_URL: "https://your-coolify-instance.com"
-      # COOLIFY_API_TOKEN: "your-coolify-api-token"
+      # Coolify integration (optional - host names must match DOCKER_HOSTS)
+      # COOLIFY_CONFIGS: "local|https://your-coolify-instance.com|your-api-token"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080"]

--- a/docs/app/docs/installation/page.tsx
+++ b/docs/app/docs/installation/page.tsx
@@ -66,8 +66,8 @@ export default function InstallationPage() {
       # ADMIN_PASSWORD: your-sha256-hash
 
       # Optional: Coolify integration (persists env var changes across redeployments)
-      # COOLIFY_API_URL: https://your-coolify-instance.com
-      # COOLIFY_API_TOKEN: your-coolify-api-token
+      # Host names must match DOCKER_HOSTS
+      # COOLIFY_CONFIGS: local|https://your-coolify-instance.com|your-api-token
     volumes:
       # Mount the Docker socket for container management
       - /var/run/docker.sock:/var/run/docker.sock
@@ -246,24 +246,20 @@ export DOCKER_HOSTS="local=unix:///var/run/docker.sock,prod=ssh://deploy@prod.ex
                 Coolify Integration (Optional)
               </CardTitle>
               <CardDescription>
-                Both must be set together. Leave unset if not using Coolify.
+                Leave unset if not using Coolify.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               <div>
                 <code className="text-sm bg-muted px-2 py-1 rounded">
-                  COOLIFY_API_URL
+                  COOLIFY_CONFIGS
                 </code>
                 <p className="text-sm text-muted-foreground mt-1">
-                  Base URL of your Coolify instance (e.g., <code>https://coolify.example.com</code>).
+                  Per-host Coolify configuration. Format: <code>hostName|apiURL|apiToken,...</code>
                 </p>
-              </div>
-              <div>
-                <code className="text-sm bg-muted px-2 py-1 rounded">
-                  COOLIFY_API_TOKEN
-                </code>
                 <p className="text-sm text-muted-foreground mt-1">
-                  API token from Coolify. Generate one under Settings &rarr; API Tokens.
+                  Host names must match those in <code>DOCKER_HOSTS</code>. Generate API tokens from
+                  your Coolify dashboard under Settings &rarr; API Tokens.
                 </p>
               </div>
             </CardContent>

--- a/env.example
+++ b/env.example
@@ -37,8 +37,8 @@ FRONTEND_PORT=5173
 # Coolify Integration (Optional)
 # =============================================================================
 # Enable this to persist env var changes across Coolify redeployments.
-# Both values must be set together.
+# Format: hostName|apiURL|apiToken,hostName|apiURL|apiToken,...
+# Host names must match names defined in DOCKER_HOSTS.
 
-# COOLIFY_API_URL=https://your-coolify-instance.com
-# COOLIFY_API_TOKEN=your-coolify-api-token
+# COOLIFY_CONFIGS=local|https://your-coolify-instance.com|your-api-token
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -43,12 +43,12 @@ func main() {
 		log.Println("Read-only mode is DISABLED - all operations are allowed")
 	}
 
-	coolifyClient := coolify.NewClient(config.Coolify)
+	coolifyClient := coolify.NewMultiClient(config.CoolifyHosts)
 	if coolifyClient != nil {
-		log.Println("Coolify integration is ENABLED")
+		log.Printf("Coolify integration is ENABLED (%d host configs)", len(config.CoolifyHosts))
 	} else {
-		log.Println("Coolify integration is DISABLED - no Coolify environment variables detected")
-		log.Println("   To enable Coolify integration, set: COOLIFY_API_URL, COOLIFY_API_TOKEN")
+		log.Println("Coolify integration is DISABLED - COOLIFY_CONFIGS is not set")
+		log.Println("   To enable, set: COOLIFY_CONFIGS=hostName|apiURL|apiToken,...")
 	}
 
 	apiRouter := api.NewRouter(multiHostClient, authService, config, coolifyClient)

--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/coolify"
@@ -270,6 +271,10 @@ func parseLogOptions(r *http.Request) models.LogOptions {
 		options.ShowStderr, _ = strconv.ParseBool(stderr)
 	}
 
+	if level := query.Get("level"); level != "" {
+		options.Level = strings.ToUpper(level)
+	}
+
 	return options
 }
 
@@ -330,13 +335,14 @@ func (ar *APIRouter) UpdateEnvVariables(w http.ResponseWriter, r *http.Request) 
 
 	// Best-effort sync to Coolify API
 	if ar.coolify != nil {
+		coolifyClient := ar.coolify.GetClient(host)
 		coolifyResource := coolify.ExtractResourceInfo(labels)
-		if coolifyResource != nil {
+		if coolifyClient != nil && coolifyResource != nil {
 			syncCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 			defer cancel()
 
-			if syncErr := ar.coolify.SyncEnvVars(syncCtx, coolifyResource, envVariables.Env); syncErr != nil {
-				log.Printf("Warning: failed to sync env vars to Coolify: %v", syncErr)
+			if syncErr := coolifyClient.SyncEnvVars(syncCtx, coolifyResource, envVariables.Env); syncErr != nil {
+				log.Printf("Warning: failed to sync env vars to Coolify for host %s: %v", host, syncErr)
 				response["coolify_synced"] = false
 				response["coolify_error"] = syncErr.Error()
 			} else {

--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/coolify"
@@ -269,10 +268,6 @@ func parseLogOptions(r *http.Request) models.LogOptions {
 
 	if stderr := query.Get("stderr"); stderr != "" {
 		options.ShowStderr, _ = strconv.ParseBool(stderr)
-	}
-
-	if level := query.Get("level"); level != "" {
-		options.Level = strings.ToUpper(level)
 	}
 
 	return options

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -20,10 +20,10 @@ type APIRouter struct {
 	docker      *docker.MultiHostClient
 	authService *auth.Service
 	config      *config.Config
-	coolify     *coolify.Client
+	coolify     *coolify.MultiClient
 }
 
-func NewRouter(docker *docker.MultiHostClient, authService *auth.Service, config *config.Config, coolifyClient *coolify.Client) *chi.Mux {
+func NewRouter(docker *docker.MultiHostClient, authService *auth.Service, config *config.Config, coolifyClient *coolify.MultiClient) *chi.Mux {
 	r := &APIRouter{
 		router:      chi.NewRouter(),
 		docker:      docker,

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -11,15 +11,16 @@ type DockerHost struct {
 	Host string
 }
 
-type CoolifyConfig struct {
+type CoolifyHostConfig struct {
+	HostName string
 	APIURL   string
 	APIToken string
 }
 
 type Config struct {
-	ReadOnly    bool
-	DockerHosts []DockerHost
-	Coolify     *CoolifyConfig
+	ReadOnly     bool
+	DockerHosts  []DockerHost
+	CoolifyHosts []CoolifyHostConfig
 }
 
 func NewConfig() *Config {
@@ -32,27 +33,22 @@ func NewConfig() *Config {
 		dockerHosts = []DockerHost{{Name: "local", Host: "unix:///var/run/docker.sock"}}
 	}
 
-	coolify := parseCoolifyConfig()
+	coolifyHosts := parseCoolifyHostConfigs()
 
-	return &Config{ReadOnly: isReadOnlyMode, DockerHosts: dockerHosts, Coolify: coolify}
-}
-
-func parseCoolifyConfig() *CoolifyConfig {
-	apiURL := strings.TrimSpace(os.Getenv("COOLIFY_API_URL"))
-	apiToken := strings.TrimSpace(os.Getenv("COOLIFY_API_TOKEN"))
-
-	if apiURL == "" && apiToken == "" {
-		return nil
+	// Warn if COOLIFY_CONFIGS references host names not in DOCKER_HOSTS
+	if len(coolifyHosts) > 0 {
+		hostSet := make(map[string]bool, len(dockerHosts))
+		for _, dh := range dockerHosts {
+			hostSet[dh.Name] = true
+		}
+		for _, ch := range coolifyHosts {
+			if !hostSet[ch.HostName] {
+				log.Printf("Warning: COOLIFY_CONFIGS references unknown Docker host %q (not found in DOCKER_HOSTS)", ch.HostName)
+			}
+		}
 	}
 
-	if apiURL == "" || apiToken == "" {
-		log.Fatalf("Partial Coolify configuration detected. Both COOLIFY_API_URL and COOLIFY_API_TOKEN must be set together.")
-	}
-
-	// Remove trailing slash from API URL
-	apiURL = strings.TrimRight(apiURL, "/")
-
-	return &CoolifyConfig{APIURL: apiURL, APIToken: apiToken}
+	return &Config{ReadOnly: isReadOnlyMode, DockerHosts: dockerHosts, CoolifyHosts: coolifyHosts}
 }
 
 func parseDockerHosts() []DockerHost {
@@ -81,4 +77,42 @@ func parseDockerHosts() []DockerHost {
 	}
 
 	return dockerHostsList
+}
+
+func parseCoolifyHostConfigs() []CoolifyHostConfig {
+	// Format: COOLIFY_CONFIGS=hostA|https://coolify-a.com|tokenA,hostB|https://coolify-b.com|tokenB
+	raw := os.Getenv("COOLIFY_CONFIGS")
+	if raw == "" {
+		return []CoolifyHostConfig{}
+	}
+
+	var configs []CoolifyHostConfig
+	seen := make(map[string]bool)
+
+	entries := strings.SplitSeq(raw, ",")
+	for entry := range entries {
+		entry = strings.TrimSpace(entry)
+		parts := strings.SplitN(entry, "|", 3)
+		if len(parts) != 3 {
+			log.Fatalf("Invalid COOLIFY_CONFIGS format: %s (expected format: hostName|apiURL|apiToken)", entry)
+		}
+
+		hostName := strings.TrimSpace(parts[0])
+		apiURL := strings.TrimSpace(parts[1])
+		apiToken := strings.TrimSpace(parts[2])
+
+		if hostName == "" || apiURL == "" || apiToken == "" {
+			log.Fatalf("Invalid COOLIFY_CONFIGS format: %s (hostName, apiURL, and apiToken cannot be empty)", entry)
+		}
+
+		if seen[hostName] {
+			log.Fatalf("Duplicate host name in COOLIFY_CONFIGS: %s", hostName)
+		}
+		seen[hostName] = true
+
+		apiURL = strings.TrimRight(apiURL, "/")
+		configs = append(configs, CoolifyHostConfig{HostName: hostName, APIURL: apiURL, APIToken: apiToken})
+	}
+
+	return configs
 }

--- a/server/internal/coolify/client.go
+++ b/server/internal/coolify/client.go
@@ -32,18 +32,41 @@ type Client struct {
 	httpClient *http.Client
 }
 
-func NewClient(cfg *config.CoolifyConfig) *Client {
-	if cfg == nil {
+func newClient(apiURL, apiToken string) *Client {
+	return &Client{
+		apiURL:     apiURL,
+		apiToken:   apiToken,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// MultiClient routes Coolify API calls to the correct per-host client.
+type MultiClient struct {
+	clients map[string]*Client
+}
+
+// NewMultiClient creates a MultiClient from per-host configs.
+// Returns nil if no configs are provided.
+func NewMultiClient(hostConfigs []config.CoolifyHostConfig) *MultiClient {
+	if len(hostConfigs) == 0 {
 		return nil
 	}
 
-	return &Client{
-		apiURL:   cfg.APIURL,
-		apiToken: cfg.APIToken,
-		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
-		},
+	clients := make(map[string]*Client, len(hostConfigs))
+	for _, hc := range hostConfigs {
+		clients[hc.HostName] = newClient(hc.APIURL, hc.APIToken)
 	}
+
+	return &MultiClient{clients: clients}
+}
+
+// GetClient returns the Coolify client for the given Docker host name.
+// Returns nil if no config exists for that host.
+func (mc *MultiClient) GetClient(hostName string) *Client {
+	if mc == nil {
+		return nil
+	}
+	return mc.clients[hostName]
 }
 
 // ExtractResourceInfo checks container labels for Coolify management info.


### PR DESCRIPTION
## Summary

Replace the global `COOLIFY_API_URL`/`COOLIFY_API_TOKEN` env vars with a single `COOLIFY_CONFIGS` that maps each Docker host to its own Coolify instance. Fixes env var sync going to the wrong Coolify instance when multiple Docker hosts are managed by different Coolify instances.

## Changes

- Add `COOLIFY_CONFIGS` env var with format `hostName|apiURL|apiToken,...`
- Add `MultiClient` in the coolify package that routes sync calls to the correct per-host client
- Remove global `COOLIFY_API_URL`/`COOLIFY_API_TOKEN` config (breaking change)
- Warn at startup if `COOLIFY_CONFIGS` references host names not in `DOCKER_HOSTS`
- Update docs site, `.env.example`, and `docker-compose.yml`

## Type of Change

- [x] feat: New feature

## Breaking Change

Users with existing `COOLIFY_API_URL` and `COOLIFY_API_TOKEN` must migrate to:
`COOLIFY_CONFIGS=hostName|https://your-coolify-instance.com|your-api-token`

## Test plan

- [ ] Set `COOLIFY_CONFIGS` with valid entries and verify Coolify sync works per-host
- [ ] Leave `COOLIFY_CONFIGS` unset and verify no sync is attempted
- [ ] Set `COOLIFY_CONFIGS` with a bad format and verify fatal error on startup
- [ ] Set `COOLIFY_CONFIGS` with a host name not in `DOCKER_HOSTS` and verify warning log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-host Coolify integration with per-host clients and enabled-host counting

* **Configuration Updates**
  * Replaced COOLIFY_API_URL/COOLIFY_API_TOKEN with COOLIFY_CONFIGS
  * New format: hostName|apiURL|apiToken,hostName|apiURL|apiToken,...
  * Host names must match entries in DOCKER_HOSTS

* **Documentation**
  * Updated configuration and installation docs and examples

* **Bug Fixes**
  * Improved Coolify sync reporting to include target host on failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->