### PR TITLE
feat(frontend): split KEY=value paste in env variable key input

### DIFF
--- a/frontend/src/features/containers/components/environment-variables.tsx
+++ b/frontend/src/features/containers/components/environment-variables.tsx
@@ -94,6 +94,7 @@ export function EnvironmentVariables({
     {}
   );
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const newValueInputRef = useRef<HTMLInputElement>(null);
   const newKeyId = useId();
   const newValueId = useId();
 
@@ -191,6 +192,38 @@ export function EnvironmentVariables({
 
   const handleValueChange = (key: string, value: string) => {
     setEditedEnv((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleNewKeyChange = (rawValue: string) => {
+    const equalIndex = rawValue.indexOf("=");
+    if (equalIndex === -1) {
+      setNewKey(rawValue);
+      return;
+    }
+
+    const key = rawValue.substring(0, equalIndex).trim();
+    let value = rawValue.substring(equalIndex + 1);
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    setNewKey(key);
+    // Only overwrite an existing value when the pasted segment after `=` is
+    // non-empty; otherwise we'd wipe text the user already typed in Value.
+    if (value.length > 0) {
+      setNewValue(value);
+    }
+    // Move focus to the value field so the user can keep editing if needed.
+    requestAnimationFrame(() => {
+      const input = newValueInputRef.current;
+      if (!input) return;
+      input.focus();
+      const caret = input.value.length;
+      input.setSelectionRange(caret, caret);
+    });
   };
 
   const handleAddNew = () => {
@@ -388,8 +421,8 @@ export function EnvironmentVariables({
                   <Input
                     id={newKeyId}
                     value={newKey}
-                    onChange={(e) => setNewKey(e.target.value)}
-                    placeholder="VARIABLE_NAME"
+                    onChange={(e) => handleNewKeyChange(e.target.value)}
+                    placeholder="VARIABLE_NAME or KEY=value"
                     className="font-mono text-xs h-8"
                   />
                 </div>
@@ -399,6 +432,7 @@ export function EnvironmentVariables({
                   </Label>
                   <Input
                     id={newValueId}
+                    ref={newValueInputRef}
                     value={newValue}
                     onChange={(e) => setNewValue(e.target.value)}
                     placeholder="value"


### PR DESCRIPTION
## Summary

Adds Vercel-style paste DX to the "Add environment variable" form: pasting `FOO=bar` into the Key field auto-splits on the first `=`, dropping `FOO` into Key and `bar` into Value, then focuses the Value input.

## Changes

- New `handleNewKeyChange` handler in `environment-variables.tsx` splits on the first `=`, trims the key, and strips matched surrounding quotes from the value
- Splits fire on any `onChange` (paste or typed), matching Vercel's behavior
- Focus jumps to the Value input with the caret at the end of existing content
- Guards against wiping an existing Value when the pasted tail is empty (e.g. editing the key to end in a bare `=`)
- Placeholder updated to hint at the behavior: `VARIABLE_NAME or KEY=value`

## Type of Change

- [x] feat: New feature

## Testing

- `bun run tsc --noEmit` clean
- Manual verification needed in the container logs sheet -> environment variables section:
  - Paste `FOO=bar` into Key -> splits correctly, focus moves to Value
  - Paste `DB_URL=postgres://u:p@h/d?x=1` -> only the first `=` splits
  - Paste `FOO="quoted"` -> quotes stripped
  - Type `FOO` in Key, `existing` in Value, edit Key to `FOO=` -> `existing` is preserved (not wiped)

## Known follow-ups (not in this PR)

- Multi-line paste (pasting a whole `.env` blob into Key) still collapses into a single value; the documented path remains the "Upload .env" button
- Value is not trimmed symmetrically with the key (MEDIUM finding from review); can ship alongside the multi-line paste fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced environment variable input to accept `KEY=value` format directly in the Key field, which automatically parses and populates both the key and value fields for faster data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->