### PR TITLE
fix(server): hide Coolify-injected env vars from user-facing API

### DIFF
--- a/server/internal/coolify/client.go
+++ b/server/internal/coolify/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/config"
@@ -19,11 +20,21 @@ const (
 	ResourceTypeApplication ResourceType = "application"
 	ResourceTypeService     ResourceType = "service"
 	ResourceTypeDatabase    ResourceType = "database"
+
+	// LabelManaged is the Docker label Coolify sets on containers it manages.
+	LabelManaged = "coolify.managed"
 )
 
 type ResourceInfo struct {
 	Type ResourceType
 	UUID string
+}
+
+// IsCoolifyDefaultEnvVar reports whether key is a Coolify-injected environment
+// variable that users should not see or modify. These are set automatically by
+// Coolify at deploy time (see https://coolify.io/docs/knowledge-base/environment-variables).
+func IsCoolifyDefaultEnvVar(key string) bool {
+	return strings.HasPrefix(key, "COOLIFY_") || key == "SOURCE_COMMIT"
 }
 
 type Client struct {
@@ -95,7 +106,7 @@ func NewSingleClient(apiURL, apiToken string) *Client {
 //   - coolify.type={application,service,database}
 //   - com.docker.compose.project={uuid}  (the API-compatible UUID)
 func ExtractResourceInfo(labels map[string]string) *ResourceInfo {
-	if labels["coolify.managed"] != "true" {
+	if labels[LabelManaged] != "true" {
 		return nil
 	}
 
@@ -149,8 +160,11 @@ func (c *Client) SyncEnvVars(ctx context.Context, resource *ResourceInfo, envVar
 		return fmt.Errorf("coolify: failed to fetch existing env vars: %w", err)
 	}
 
-	// 2. Delete env vars that no longer exist
+	// 2. Delete env vars that no longer exist (skip Coolify-injected defaults)
 	for _, ev := range existing {
+		if IsCoolifyDefaultEnvVar(ev.Key) {
+			continue
+		}
 		if _, exists := envVars[ev.Key]; !exists {
 			if delErr := c.deleteEnvVar(ctx, resource, ev.UUID); delErr != nil {
 				log.Printf("Warning: failed to delete Coolify env var %s (%s): %v", ev.Key, ev.UUID, delErr)
@@ -158,9 +172,12 @@ func (c *Client) SyncEnvVars(ctx context.Context, resource *ResourceInfo, envVar
 		}
 	}
 
-	// 3. Bulk upsert the current env vars
+	// 3. Bulk upsert the current env vars, excluding Coolify-injected defaults
 	entries := make([]envVarEntry, 0, len(envVars))
 	for key, value := range envVars {
+		if IsCoolifyDefaultEnvVar(key) {
+			continue
+		}
 		entries = append(entries, envVarEntry{Key: key, Value: value, IsPreview: false})
 	}
 

--- a/server/internal/docker/container.go
+++ b/server/internal/docker/container.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/AmoabaKelvin/logdeck/internal/coolify"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 )
@@ -64,10 +65,15 @@ func (c *MultiHostClient) GetEnvVariables(hostName, id string) (map[string]strin
 		return nil, err
 	}
 
+	isCoolifyManaged := inspect.Config.Labels[coolify.LabelManaged] == "true"
+
 	envMap := make(map[string]string)
 	for _, env := range inspect.Config.Env {
 		parts := strings.SplitN(env, "=", 2)
 		if len(parts) == 2 {
+			if isCoolifyManaged && coolify.IsCoolifyDefaultEnvVar(parts[0]) {
+				continue
+			}
 			envMap[parts[0]] = parts[1]
 		}
 	}
@@ -88,13 +94,21 @@ func (c *MultiHostClient) SetEnvVariables(hostName, id string, envVariables map[
 	}
 
 	labels := inspect.Config.Labels
+	isCoolifyManaged := labels[coolify.LabelManaged] == "true"
 
+	// Split existing env vars into user-defined and Coolify-injected defaults.
+	// Coolify defaults are kept aside so the user cannot accidentally delete or
+	// overwrite them — they get merged back unconditionally before recreation.
 	envMap := make(map[string]string)
-	// First, load all existing env vars from the container config
+	coolifyDefaults := make(map[string]string)
 	for _, env := range inspect.Config.Env {
 		parts := strings.SplitN(env, "=", 2)
 		if len(parts) == 2 {
-			envMap[parts[0]] = parts[1]
+			if isCoolifyManaged && coolify.IsCoolifyDefaultEnvVar(parts[0]) {
+				coolifyDefaults[parts[0]] = parts[1]
+			} else {
+				envMap[parts[0]] = parts[1]
+			}
 		}
 	}
 
@@ -105,8 +119,9 @@ func (c *MultiHostClient) SetEnvVariables(hostName, id string, envVariables map[
 		}
 	}
 
-	// Copy updated/new variables from envVariables into envMap
+	// Apply user-supplied values, then merge Coolify defaults back in
 	maps.Copy(envMap, envVariables)
+	maps.Copy(envMap, coolifyDefaults)
 
 	envs := make([]string, 0, len(envMap))
 	for key, value := range envMap {


### PR DESCRIPTION
## Summary

Coolify injects default environment variables (`COOLIFY_*`, `SOURCE_COMMIT`) into managed containers. Exposing these in the env editor lets users accidentally modify or delete values they shouldn't touch, which can break containers on redeployment.

## Changes

- Add `IsCoolifyDefaultEnvVar` helper and `LabelManaged` constant to the `coolify` package
- `GetEnvVariables` strips Coolify defaults from the response for Coolify-managed containers
- `SetEnvVariables` separates Coolify defaults at load time and merges them back unconditionally, preventing accidental deletion or overwrite
- `SyncEnvVars` skips Coolify defaults in both the delete and upsert loops to avoid pushing Coolify's own injected vars back to its API

## Type of Change

- [x] fix: Bug fix

## Testing

- `go vet` passes on both changed packages