### PR TITLE
fix(frontend): handle explicit empty quoted values in env var paste split

### DIFF
--- a/frontend/src/features/containers/components/environment-variables.tsx
+++ b/frontend/src/features/containers/components/environment-variables.tsx
@@ -202,7 +202,8 @@ export function EnvironmentVariables({
     }
 
     const key = rawValue.substring(0, equalIndex).trim();
-    let value = rawValue.substring(equalIndex + 1);
+    const rawTail = rawValue.substring(equalIndex + 1);
+    let value = rawTail;
     if (
       (value.startsWith('"') && value.endsWith('"')) ||
       (value.startsWith("'") && value.endsWith("'"))
@@ -213,7 +214,9 @@ export function EnvironmentVariables({
     setNewKey(key);
     // Only overwrite an existing value when the pasted segment after `=` is
     // non-empty; otherwise we'd wipe text the user already typed in Value.
-    if (value.length > 0) {
+    // Check rawTail (pre-strip) so explicit empty quotes like KEY="" still
+    // clear the value field.
+    if (rawTail.length > 0) {
       setNewValue(value);
     }
     // Move focus to the value field so the user can keep editing if needed.


### PR DESCRIPTION
## Summary

Fixes a bug where pasting `KEY=""` or `KEY=''` into the env var Key field would not clear the Value field, leaving stale content behind.

## Changes

- Check `rawTail.length` (pre-quote-strip) instead of `value.length` (post-strip) when deciding whether to call `setNewValue`
- Explicit empty quoted values now correctly set Value to empty string

## Type of Change

- [x] fix: Bug fix

## Testing

- `bun run tsc --noEmit` clean
- Manual: paste `FOO=""` into Key field with `existing` already in Value -> Value should become empty
- Manual: paste `FOO=` (bare equals, no quotes) -> Value should remain unchanged (existing guard still works since `rawTail` is empty)