### PR TITLE
fix: render Docker host names in filter

### DIFF
--- a/frontend/src/features/containers/components/containers-toolbar.tsx
+++ b/frontend/src/features/containers/components/containers-toolbar.tsx
@@ -134,8 +134,8 @@ export function ContainersToolbar({
 								All hosts
 							</DropdownMenuRadioItem>
 							{availableHosts.map((host) => (
-								<DropdownMenuRadioItem key={host.Name} value={host.Name}>
-									{host.Name}
+								<DropdownMenuRadioItem key={host.name} value={host.name}>
+									{host.name}
 								</DropdownMenuRadioItem>
 							))}
 						</DropdownMenuRadioGroup>
@@ -256,12 +256,7 @@ export function ContainersToolbar({
 
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="sm"
-							className="h-9 shrink-0"
-							asChild
-						>
+						<Button variant="ghost" size="sm" className="h-9 shrink-0" asChild>
 							<Link to="/settings" aria-label="Settings">
 								<SettingsIcon className="size-4" />
 							</Link>

--- a/frontend/src/features/containers/types.ts
+++ b/frontend/src/features/containers/types.ts
@@ -1,41 +1,41 @@
 export interface DockerHost {
-  Name: string
-  Host: string
+	name: string;
+	host: string;
 }
 
 export interface ContainerInfo {
-  id: string
-  names: string[]
-  image: string
-  image_id: string
-  command: string
-  created: number
-  state: string
-  status: string
-  labels?: Record<string, string>
-  host: string
+	id: string;
+	names: string[];
+	image: string;
+	image_id: string;
+	command: string;
+	created: number;
+	state: string;
+	status: string;
+	labels?: Record<string, string>;
+	host: string;
 }
 
 export interface HostError {
-  host: string
-  message: string
+	host: string;
+	message: string;
 }
 
 export interface ContainersQueryParams {
-  search?: string
-  state?: string
-  sortCreated?: "asc" | "desc"
-  groupBy?: "none" | "compose"
-  host?: string
+	search?: string;
+	state?: string;
+	sortCreated?: "asc" | "desc";
+	groupBy?: "none" | "compose";
+	host?: string;
 }
 
 export interface ContainerStats {
-  id: string
-  host: string
-  cpu_percent: number
-  memory_percent: number
-  memory_used: number
-  memory_limit: number
+	id: string;
+	host: string;
+	cpu_percent: number;
+	memory_percent: number;
+	memory_used: number;
+	memory_limit: number;
 }
 
-export type ContainerStatsMap = Record<string, ContainerStats>
+export type ContainerStatsMap = Record<string, ContainerStats>;


### PR DESCRIPTION
## Summary
- Align the containers Docker host type with the backend JSON shape (`name` / `host`).
- Render host filter options from `host.name` so configured hosts appear under "All hosts".

## Validation
- `bunx biome check src/features/containers/types.ts src/features/containers/components/containers-toolbar.tsx`
- `bun run build`
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed property references in the containers interface for proper functionality.

* **Refactor**
  * Simplified containers toolbar code structure.
  * Standardized container type definitions for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmoabaKelvin/logdeck/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->