### PR TITLE
fix: group structured log continuations

### DIFF
--- a/frontend/src/features/containers/api/get-container-logs-parsed.ts
+++ b/frontend/src/features/containers/api/get-container-logs-parsed.ts
@@ -20,6 +20,8 @@ export interface LogEntry {
   message?: string;
   stream?: "stdout" | "stderr";
   raw?: string;
+  fields?: Record<string, string>;
+  continuationCount?: number;
 }
 
 export interface ContainerLogsParsedResponse {
@@ -223,4 +225,83 @@ export function getLogLevelBadgeColor(level: LogLevel | undefined): string {
     default:
       return "bg-muted text-muted-foreground";
   }
+}
+
+const STRUCTURED_FIELD_REGEX = /^([A-Za-z_][A-Za-z0-9_.-]*)\s*[:=]\s*(.+)$/;
+const STACK_TRACE_PREFIXES = [
+  "at ",
+  "File ",
+  "Traceback ",
+  "Caused by:",
+  "... ",
+  "goroutine ",
+];
+
+export function groupRelatedLogEntries<TLogEntry extends LogEntry>(
+  entries: TLogEntry[]
+): TLogEntry[] {
+  const grouped: TLogEntry[] = [];
+
+  for (const entry of entries) {
+    const previous = grouped.at(-1);
+    if (previous && isContinuationLogEntry(entry, previous)) {
+      grouped[grouped.length - 1] = appendContinuationLogEntry(previous, entry);
+      continue;
+    }
+
+    grouped.push(entry);
+  }
+
+  return grouped;
+}
+
+function isContinuationLogEntry(entry: LogEntry, previous: LogEntry): boolean {
+  if (entry.level !== "UNKNOWN") return false;
+
+  const message = (entry.message ?? entry.raw ?? "").trim();
+  const previousMessage = (previous.message ?? previous.raw ?? "").trim();
+  if (!message || !previousMessage) return false;
+
+  if (STRUCTURED_FIELD_REGEX.test(message)) return true;
+
+  return isProblemLevel(previous.level) && isStackTraceContinuation(message);
+}
+
+function appendContinuationLogEntry<TLogEntry extends LogEntry>(
+  entry: TLogEntry,
+  continuation: LogEntry
+): TLogEntry {
+  const message = (continuation.message ?? continuation.raw ?? "").trim();
+  const raw = continuation.raw?.trim();
+  const fields = { ...(entry.fields ?? {}) };
+  const fieldMatch = message.match(STRUCTURED_FIELD_REGEX);
+
+  if (fieldMatch) {
+    fields[fieldMatch[1]] = fieldMatch[2].trim();
+  }
+
+  return {
+    ...entry,
+    message: [entry.message, message].filter(Boolean).join("\n"),
+    raw: [entry.raw, raw].filter(Boolean).join("\n"),
+    fields: Object.keys(fields).length > 0 ? fields : entry.fields,
+    continuationCount: (entry.continuationCount ?? 0) + 1,
+  } as TLogEntry;
+}
+
+function isProblemLevel(level: LogLevel | undefined): boolean {
+  return (
+    level === "WARN" ||
+    level === "WARNING" ||
+    level === "ERROR" ||
+    level === "FATAL" ||
+    level === "PANIC"
+  );
+}
+
+function isStackTraceContinuation(message: string): boolean {
+  return (
+    STACK_TRACE_PREFIXES.some((prefix) => message.startsWith(prefix)) ||
+    (message.startsWith("/") && message.includes(":"))
+  );
 }

--- a/frontend/src/features/containers/components/containers-logs-sheet.tsx
+++ b/frontend/src/features/containers/components/containers-logs-sheet.tsx
@@ -60,6 +60,7 @@ import {
 import {
   getContainerLogsParsed,
   getLogLevelBadgeColor,
+  groupRelatedLogEntries,
   streamContainerLogsParsed
 } from "../api/get-container-logs-parsed";
 import { useContainerLogStream } from "../hooks/use-container-log-stream";
@@ -161,7 +162,7 @@ export function ContainersLogsSheet({
     isLoadingLogs,
     isStreamPaused,
     isStreaming,
-    logs,
+    logs: rawLogs,
     stopStreaming,
     togglePauseStreaming,
     toggleStreaming,
@@ -193,6 +194,7 @@ export function ContainersLogsSheet({
       toast.error(`Failed to start streaming: ${error.message}`);
     },
   });
+  const logs = useMemo(() => groupRelatedLogEntries(rawLogs), [rawLogs]);
 
   const handleRefresh = () => {
     if (!isStreaming) {
@@ -1296,7 +1298,7 @@ export function ContainersLogsSheet({
                                 {entry.level ?? "UNKNOWN"}
                               </Badge>
                               <span
-                                className={`text-foreground flex-1 ${wrapText ? "break-words" : ""}`}
+                                className={`text-foreground flex-1 ${wrapText ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}
                               >
                                 {isJsonString(displayText) ? (
                                   <CollapsibleJson

--- a/server/internal/docker/logs.go
+++ b/server/internal/docker/logs.go
@@ -28,6 +28,7 @@ func parseDockerLogs(reader io.Reader, levelFilter string, searchRegex *regexp.R
 
 	stdout.Flush()
 	stderr.Flush()
+	entries = models.GroupRelatedLogEntries(entries)
 
 	if levelFilter == "" && searchRegex == nil {
 		return entries, nil

--- a/server/internal/docker/logs_test.go
+++ b/server/internal/docker/logs_test.go
@@ -1,0 +1,42 @@
+package docker
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+func TestParseDockerLogsGroupsStructuredContinuationLines(t *testing.T) {
+	var stream bytes.Buffer
+	stdout := stdcopy.NewStdWriter(&stream, stdcopy.Stdout)
+	_, err := stdout.Write([]byte(strings.Join([]string{
+		"2026-05-28T05:00:38.367Z [2026-05-28 05:00:38.367 +0000] INFO: Request received",
+		"2026-05-28T05:00:38.367Z service: \"api\"",
+		"2026-05-28T05:00:38.367Z requestId: \"e675e98a-8c63-42a2-b23b-925a4846b0c4\"",
+		"2026-05-28T05:00:38.368Z [2026-05-28 05:00:38.368 +0000] INFO: Request completed",
+	}, "\n") + "\n"))
+	if err != nil {
+		t.Fatalf("failed to write docker log stream: %v", err)
+	}
+
+	entries, err := parseDockerLogs(&stream, "", nil)
+	if err != nil {
+		t.Fatalf("failed to parse docker logs: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 grouped entries, got %d", len(entries))
+	}
+	if entries[0].Level != models.LogLevelInfo {
+		t.Fatalf("expected first entry to remain INFO, got %s", entries[0].Level)
+	}
+	if entries[0].ContinuationCount != 2 {
+		t.Fatalf("expected first entry to include 2 continuation lines, got %d", entries[0].ContinuationCount)
+	}
+	if !strings.Contains(entries[0].Message, "Request received\nservice: \"api\"\nrequestId:") {
+		t.Fatalf("expected grouped message to include continuation fields, got %q", entries[0].Message)
+	}
+}

--- a/server/internal/models/logs.go
+++ b/server/internal/models/logs.go
@@ -8,11 +8,13 @@ import (
 
 // LogEntry represents a parsed log line with metadata
 type LogEntry struct {
-	Timestamp time.Time `json:"timestamp"`
-	Level     LogLevel  `json:"level"`
-	Message   string    `json:"message"`
-	Stream    string    `json:"stream"` // "stdout" or "stderr"
-	Raw       string    `json:"raw"`    // Original log line
+	Timestamp         time.Time         `json:"timestamp"`
+	Level             LogLevel          `json:"level"`
+	Message           string            `json:"message"`
+	Stream            string            `json:"stream"` // "stdout" or "stderr"
+	Raw               string            `json:"raw"`    // Original log line
+	Fields            map[string]string `json:"fields,omitempty"`
+	ContinuationCount int               `json:"continuationCount,omitempty"`
 }
 
 // LogLevel represents the severity of a log entry
@@ -59,6 +61,7 @@ var timestampFormats = []string{
 
 var tzOffsetNoColon = regexp.MustCompile(`([+-]\d{2})(\d{2})$`)
 var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+var structuredFieldRegex = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_.-]*)\s*[:=]\s*(.+)$`)
 
 // DetectLogLevel analyzes a log message to determine its severity level
 func DetectLogLevel(message string) LogLevel {
@@ -138,6 +141,106 @@ func ParseLogLine(logLine string, stream string) LogEntry {
 		Stream:    stream,
 		Raw:       logLine,
 	}
+}
+
+// GroupRelatedLogEntries folds structured continuation lines into the previous
+// logical log event. Docker adds its own timestamp to every physical line, so
+// multi-line app logs can otherwise appear as separate UNKNOWN rows.
+func GroupRelatedLogEntries(entries []LogEntry) []LogEntry {
+	grouped := make([]LogEntry, 0, len(entries))
+
+	for _, entry := range entries {
+		if len(grouped) > 0 && IsContinuationLogEntry(entry, grouped[len(grouped)-1]) {
+			appendContinuationLine(&grouped[len(grouped)-1], entry)
+			continue
+		}
+
+		grouped = append(grouped, entry)
+	}
+
+	return grouped
+}
+
+func IsContinuationLogEntry(entry LogEntry, previous LogEntry) bool {
+	if entry.Level != LogLevelUnknown {
+		return false
+	}
+
+	message := strings.TrimSpace(entry.Message)
+	if message == "" || strings.TrimSpace(previous.Message) == "" {
+		return false
+	}
+
+	if structuredFieldRegex.MatchString(message) {
+		return true
+	}
+
+	return isStackTraceContinuation(message) && isProblemLevel(previous.Level)
+}
+
+func appendContinuationLine(entry *LogEntry, continuation LogEntry) {
+	message := strings.TrimSpace(continuation.Message)
+	if message != "" {
+		if entry.Message == "" {
+			entry.Message = message
+		} else {
+			entry.Message += "\n" + message
+		}
+	}
+
+	if continuation.Raw != "" {
+		if entry.Raw == "" {
+			entry.Raw = continuation.Raw
+		} else {
+			entry.Raw += "\n" + continuation.Raw
+		}
+	}
+
+	if key, value, ok := parseStructuredField(message); ok {
+		if entry.Fields == nil {
+			entry.Fields = make(map[string]string)
+		}
+		entry.Fields[key] = value
+	}
+
+	entry.ContinuationCount++
+}
+
+func parseStructuredField(message string) (string, string, bool) {
+	matches := structuredFieldRegex.FindStringSubmatch(strings.TrimSpace(message))
+	if len(matches) != 3 {
+		return "", "", false
+	}
+
+	return matches[1], strings.TrimSpace(matches[2]), true
+}
+
+func isProblemLevel(level LogLevel) bool {
+	switch level {
+	case LogLevelWarn, LogLevelWarning, LogLevelError, LogLevelFatal, LogLevelPanic:
+		return true
+	default:
+		return false
+	}
+}
+
+func isStackTraceContinuation(message string) bool {
+	stackPrefixes := []string{
+		"at ",
+		"File ",
+		"Traceback ",
+		"Caused by:",
+		"... ",
+		"goroutine ",
+	}
+
+	for _, prefix := range stackPrefixes {
+		if strings.HasPrefix(message, prefix) {
+			return true
+		}
+	}
+
+	return strings.HasPrefix(message, "/") && strings.Contains(message, ":")
 }
 
 func tryParseTimestampCandidate(candidate string) (time.Time, bool) {

--- a/server/internal/models/logs_test.go
+++ b/server/internal/models/logs_test.go
@@ -1,0 +1,57 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGroupRelatedLogEntriesFoldsStructuredFieldsIntoPreviousEntry(t *testing.T) {
+	entries := []LogEntry{
+		ParseLogLine("2026-05-28T05:00:38.367Z [2026-05-28 05:00:38.367 +0000] INFO: Request received", "stdout"),
+		ParseLogLine("2026-05-28T05:00:38.367Z service: \"api\"", "stdout"),
+		ParseLogLine("2026-05-28T05:00:38.367Z requestId: \"e675e98a-8c63-42a2-b23b-925a4846b0c4\"", "stdout"),
+		ParseLogLine("2026-05-28T05:00:38.367Z method: \"GET\"", "stdout"),
+		ParseLogLine("2026-05-28T05:00:38.367Z path: \"/favicon.ico\"", "stdout"),
+		ParseLogLine("2026-05-28T05:00:38.368Z [2026-05-28 05:00:38.368 +0000] INFO: Request completed", "stdout"),
+	}
+
+	grouped := GroupRelatedLogEntries(entries)
+
+	if len(grouped) != 2 {
+		t.Fatalf("expected 2 grouped entries, got %d", len(grouped))
+	}
+
+	first := grouped[0]
+	if first.Level != LogLevelInfo {
+		t.Fatalf("expected first grouped entry to remain INFO, got %s", first.Level)
+	}
+	if first.ContinuationCount != 4 {
+		t.Fatalf("expected 4 continuation lines, got %d", first.ContinuationCount)
+	}
+	if first.Fields["requestId"] != "\"e675e98a-8c63-42a2-b23b-925a4846b0c4\"" {
+		t.Fatalf("expected requestId field to be captured, got %q", first.Fields["requestId"])
+	}
+	if !strings.Contains(first.Message, "Request received\nservice: \"api\"\nrequestId:") {
+		t.Fatalf("expected continuation fields in message, got %q", first.Message)
+	}
+
+	if grouped[1].Level != LogLevelInfo || !strings.Contains(grouped[1].Message, "Request completed") {
+		t.Fatalf("expected second grouped entry to be request completed INFO, got %#v", grouped[1])
+	}
+}
+
+func TestGroupRelatedLogEntriesDoesNotFoldStandaloneUnknownMessages(t *testing.T) {
+	entries := []LogEntry{
+		ParseLogLine("2026-05-28T05:00:38.367Z INFO starting worker", "stdout"),
+		ParseLogLine("2026-05-28T05:00:38.368Z worker ready on port 3000", "stdout"),
+	}
+
+	grouped := GroupRelatedLogEntries(entries)
+
+	if len(grouped) != 2 {
+		t.Fatalf("expected standalone unknown message to remain separate, got %d entries", len(grouped))
+	}
+	if grouped[1].Level != LogLevelUnknown {
+		t.Fatalf("expected second entry to remain UNKNOWN, got %s", grouped[1].Level)
+	}
+}


### PR DESCRIPTION
## Summary
- Group structured continuation lines like `service:`, `requestId:`, `method:`, and `path:` into the preceding log event instead of rendering them as separate `UNKNOWN` rows.
- Preserve grouped fields and continuation counts in parsed log payloads.
- Apply the same grouping behavior to streamed frontend logs and preserve multi-line display formatting.
- Add regression coverage for parser-level and Docker log stream grouping.

## Validation
- `go test ./internal/models ./internal/docker`
- `bunx tsc --noEmit`
- `bun run build`

## Notes
- `go test ./...` is currently blocked by the existing embed setup because `server/internal/static/dist/*` is not present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-line log entries and continuation lines, such as stack traces and structured output, are now grouped with their parent entries for improved readability and cleaner log display
  * Structured key-value pairs embedded in log messages are automatically extracted and captured

* **Bug Fixes**
  * Enhanced text wrapping behavior in the container logs display for better visual presentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmoabaKelvin/logdeck/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->