### PR TITLE
fix: resolve indefinite stream hang when Docker engine restarts

### DIFF
--- a/frontend/src/features/containers/api/get-container-logs-parsed.ts
+++ b/frontend/src/features/containers/api/get-container-logs-parsed.ts
@@ -187,6 +187,26 @@ export async function* streamContainerLogsParsed(
   }
 }
 
+export async function* streamContainerEvents(
+  id: string,
+  host: string,
+  signal?: AbortSignal
+): AsyncGenerator<{ action: string }, void, unknown> {
+  const url = `${BASE_URL}/${encodeURIComponent(id)}/events?host=${encodeURIComponent(host)}`;
+  const response = await authenticatedFetch(url, {
+    headers: { Accept: "application/x-ndjson" },
+    signal,
+  });
+
+  if (!response.ok || !response.body) return;
+
+  for await (const entry of iterateNDJSONStream(response.body, signal)) {
+    if (entry && typeof (entry as { action?: string }).action === "string") {
+      yield entry as { action: string };
+    }
+  }
+}
+
 export function getLogLevelColor(level: LogLevel | undefined): string {
   switch (level ?? "UNKNOWN") {
     case "TRACE":

--- a/frontend/src/features/containers/hooks/use-container-log-stream.ts
+++ b/frontend/src/features/containers/hooks/use-container-log-stream.ts
@@ -18,6 +18,7 @@ interface UseContainerLogStreamOptions<TLogEntry> {
     options: ContainerLogsOptions,
     signal: AbortSignal
   ) => AsyncGenerator<TLogEntry, void, unknown>;
+  streamEvents?: (containerId: string, host: string, signal: AbortSignal) => AsyncGenerator<{ action: string }, void, unknown>;
   scrollToBottom: (behavior?: ScrollBehavior) => void;
   onResetState?: () => void;
   onFetchError?: (error: Error) => void;
@@ -31,6 +32,7 @@ export function useContainerLogStream<TLogEntry>({
   search,
   getLogs,
   streamLogs,
+  streamEvents,
   scrollToBottom,
   onResetState,
   onFetchError,
@@ -47,44 +49,33 @@ export function useContainerLogStream<TLogEntry>({
   } | null>(null);
 
   const abortControllerRef = useRef<AbortController | null>(null);
+  const reconnectAbortRef = useRef<AbortController | null>(null);
   const isStreamPausedRef = useRef(false);
   const bufferedLogsRef = useRef<TLogEntry[]>([]);
   const logsLengthRef = useRef(0);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const getLogsRef = useRef(getLogs);
   const streamLogsRef = useRef(streamLogs);
+  const streamEventsRef = useRef(streamEvents);
   const scrollToBottomRef = useRef(scrollToBottom);
   const onResetStateRef = useRef(onResetState);
   const onFetchErrorRef = useRef(onFetchError);
   const onStreamErrorRef = useRef(onStreamError);
 
-  useEffect(() => {
-    isStreamPausedRef.current = isStreamPaused;
-  }, [isStreamPaused]);
+  useEffect(() => { isStreamPausedRef.current = isStreamPaused; }, [isStreamPaused]);
+  useEffect(() => { getLogsRef.current = getLogs; }, [getLogs]);
+  useEffect(() => { streamLogsRef.current = streamLogs; }, [streamLogs]);
+  useEffect(() => { streamEventsRef.current = streamEvents; }, [streamEvents]);
+  useEffect(() => { scrollToBottomRef.current = scrollToBottom; }, [scrollToBottom]);
+  useEffect(() => { onResetStateRef.current = onResetState; }, [onResetState]);
+  useEffect(() => { onFetchErrorRef.current = onFetchError; }, [onFetchError]);
+  useEffect(() => { onStreamErrorRef.current = onStreamError; }, [onStreamError]);
 
   useEffect(() => {
-    getLogsRef.current = getLogs;
-  }, [getLogs]);
-
-  useEffect(() => {
-    streamLogsRef.current = streamLogs;
-  }, [streamLogs]);
-
-  useEffect(() => {
-    scrollToBottomRef.current = scrollToBottom;
-  }, [scrollToBottom]);
-
-  useEffect(() => {
-    onResetStateRef.current = onResetState;
-  }, [onResetState]);
-
-  useEffect(() => {
-    onFetchErrorRef.current = onFetchError;
-  }, [onFetchError]);
-
-  useEffect(() => {
-    onStreamErrorRef.current = onStreamError;
-  }, [onStreamError]);
+    return () => {
+      if (animationTimeoutRef.current) clearTimeout(animationTimeoutRef.current);
+    };
+  }, []);
 
   const resetPauseAndBuffer = useCallback(() => {
     setIsStreamPaused(false);
@@ -94,21 +85,9 @@ export function useContainerLogStream<TLogEntry>({
   }, []);
 
   const triggerRowAnimation = useCallback((start: number, end: number) => {
-    if (animationTimeoutRef.current) {
-      clearTimeout(animationTimeoutRef.current);
-    }
+    if (animationTimeoutRef.current) clearTimeout(animationTimeoutRef.current);
     setAnimatedRange({ start, end });
-    animationTimeoutRef.current = setTimeout(() => {
-      setAnimatedRange(null);
-    }, 260);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (animationTimeoutRef.current) {
-        clearTimeout(animationTimeoutRef.current);
-      }
-    };
+    animationTimeoutRef.current = setTimeout(() => setAnimatedRange(null), 260);
   }, []);
 
   const fetchLogs = useCallback(async () => {
@@ -123,9 +102,7 @@ export function useContainerLogStream<TLogEntry>({
       logsLengthRef.current = logEntries.length;
       setTimeout(() => scrollToBottomRef.current(), 100);
     } catch (error) {
-      if (error instanceof Error) {
-        onFetchErrorRef.current?.(error);
-      }
+      if (error instanceof Error) onFetchErrorRef.current?.(error);
       setLogs([]);
       logsLengthRef.current = 0;
     } finally {
@@ -134,6 +111,10 @@ export function useContainerLogStream<TLogEntry>({
   }, [containerId, host, resetPauseAndBuffer, tail, search]);
 
   const stopStreaming = useCallback(() => {
+    if (reconnectAbortRef.current) {
+      reconnectAbortRef.current.abort();
+      reconnectAbortRef.current = null;
+    }
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
       abortControllerRef.current = null;
@@ -152,54 +133,95 @@ export function useContainerLogStream<TLogEntry>({
     setLogs([]);
     logsLengthRef.current = 0;
 
-    try {
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
+    const reconnectAbort = new AbortController();
+    reconnectAbortRef.current = reconnectAbort;
 
-      const stream = streamLogsRef.current(
-        containerId,
-        host,
-        { tail, search },
-        abortController.signal
-      );
-      let hasReceivedFirstEntry = false;
+    while (!reconnectAbort.signal.aborted) {
+      try {
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
 
-      for await (const entry of stream) {
-        if (abortController.signal.aborted) {
-          break;
+        const onReconnectAbort = () => abortController.abort();
+        reconnectAbort.signal.addEventListener("abort", onReconnectAbort, { once: true });
+
+        const stream = streamLogsRef.current(
+          containerId,
+          host,
+          { tail, search },
+          abortController.signal
+        );
+        let hasReceivedFirstEntry = false;
+
+        for await (const entry of stream) {
+          if (abortController.signal.aborted) break;
+
+          if (!hasReceivedFirstEntry) {
+            hasReceivedFirstEntry = true;
+            setIsLoadingLogs(false);
+          }
+
+          if (isStreamPausedRef.current) {
+            bufferedLogsRef.current.push(entry);
+            setBufferedCount((prev) => prev + 1);
+            continue;
+          }
+
+          const nextIndex = logsLengthRef.current;
+          setLogs((prev) => [...prev, entry]);
+          logsLengthRef.current += 1;
+          triggerRowAnimation(nextIndex, nextIndex);
+          setTimeout(() => scrollToBottomRef.current(), 100);
         }
 
-        if (!hasReceivedFirstEntry) {
-          hasReceivedFirstEntry = true;
-          setIsLoadingLogs(false);
+        reconnectAbort.signal.removeEventListener("abort", onReconnectAbort);
+      } catch (error) {
+        if (error instanceof Error) {
+          const isAbort = error.name === "AbortError" || error.message.toLowerCase().includes("aborted");
+          if (!isAbort) onStreamErrorRef.current?.(error);
         }
-
-        if (isStreamPausedRef.current) {
-          bufferedLogsRef.current.push(entry);
-          setBufferedCount((prev) => prev + 1);
-          continue;
-        }
-
-        const nextIndex = logsLengthRef.current;
-        setLogs((prev) => [...prev, entry]);
-        logsLengthRef.current += 1;
-        triggerRowAnimation(nextIndex, nextIndex);
-        setTimeout(() => scrollToBottomRef.current(), 100);
       }
-    } catch (error) {
-      if (error instanceof Error) {
-        const message = error.message.toLowerCase();
-        const isAbort =
-          error.name === "AbortError" || message.includes("aborted");
-        if (!isAbort) {
-          onStreamErrorRef.current?.(error);
+
+      if (reconnectAbort.signal.aborted) break;
+
+      const streamEventsFn = streamEventsRef.current;
+      if (!streamEventsFn) break;
+
+      let reconnected = false;
+      const eventsAbort = new AbortController();
+      const onStop = () => eventsAbort.abort();
+      reconnectAbort.signal.addEventListener("abort", onStop, { once: true });
+
+      while (!reconnectAbort.signal.aborted && !reconnected) {
+        try {
+          for await (const event of streamEventsFn(containerId, host, eventsAbort.signal)) {
+            if (event.action === "start") {
+              reconnected = true;
+              break;
+            }
+          }
+        } catch {
+          // ignore — engine still coming up
+        }
+        if (!reconnected && !reconnectAbort.signal.aborted) {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
         }
       }
-    } finally {
-      setIsLoadingLogs(false);
-      setIsStreaming(false);
-      abortControllerRef.current = null;
+
+      reconnectAbort.signal.removeEventListener("abort", onStop);
+
+      if (!reconnected || reconnectAbort.signal.aborted) break;
+
+      setIsLoadingLogs(true);
+      setLogs([]);
+      logsLengthRef.current = 0;
+      resetPauseAndBuffer();
+      onResetStateRef.current?.();
     }
+
+    setIsLoadingLogs(false);
+    setIsStreaming(false);
+    abortControllerRef.current = null;
+    reconnectAbortRef.current = null;
   }, [containerId, host, resetPauseAndBuffer, tail, search, triggerRowAnimation]);
 
   const toggleStreaming = useCallback(() => {

--- a/frontend/src/routes/containers/$containerId/logs.tsx
+++ b/frontend/src/routes/containers/$containerId/logs.tsx
@@ -64,6 +64,7 @@ import type {
 import {
 	getContainerLogsParsed,
 	getLogLevelBadgeColor,
+	streamContainerEvents,
 	streamContainerLogsParsed,
 } from "@/features/containers/api/get-container-logs-parsed";
 import { getContainers } from "@/features/containers/api/get-containers";
@@ -158,6 +159,7 @@ function ContainerLogsPage() {
 	const { data: containersData } = useQuery({
 		queryKey: ["containers"],
 		queryFn: getContainers,
+		refetchInterval: 5000,
 	});
 	const { statsMap } = useContainerStats();
 
@@ -224,6 +226,7 @@ function ContainerLogsPage() {
 		tail: logLines,
 		getLogs: getContainerLogsParsed,
 		streamLogs: streamContainerLogsParsed,
+		streamEvents: (id, h, signal) => streamContainerEvents(id, h, signal),
 		scrollToBottom,
 		onResetState: () => {
 			setPinnedLogIndices(new Set());
@@ -247,10 +250,13 @@ function ContainerLogsPage() {
 		if (!isStreaming) {
 			fetchLogs();
 		}
+	}, [isStreaming, fetchLogs]);
+
+	useEffect(() => {
 		return () => {
 			stopStreaming();
 		};
-	}, [isStreaming, fetchLogs, stopStreaming]);
+	}, [stopStreaming]);
 
 	const handleLogLinesChange = (value: string) => {
 		const num = parseInt(value, 10);
@@ -896,9 +902,9 @@ function ContainerLogsPage() {
 												State
 											</span>
 											<Badge
-												className={`${getStateBadgeClass(container.state)} border-0`}
+												className={`${container ? getStateBadgeClass(container.state) : "bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500"} border-0`}
 											>
-												{toTitleCase(container.state)}
+												{container ? toTitleCase(container.state) : "—"}
 											</Badge>
 										</div>
 										<div>
@@ -1400,7 +1406,12 @@ function ContainerLogsPage() {
 								ref={parentRef}
 								className="h-[calc(100vh-400px)] min-h-[400px] w-full overflow-auto"
 							>
-								{isLoadingLogs && logs.length === 0 ? (
+								{isStreaming && !isLoadingLogs && logs.length === 0 ? (
+									<div className="flex items-center justify-center py-8 text-muted-foreground">
+										<Spinner className="mr-2 size-4" />
+										Waiting to reconnect…
+									</div>
+								) : isLoadingLogs && logs.length === 0 ? (
 									<div className="flex items-center justify-center py-8 text-muted-foreground">
 										<Spinner className="mr-2 size-4" />
 										Loading logs...

--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -192,7 +192,7 @@ func (ar *APIRouter) GetContainerLogsParsed(w http.ResponseWriter, r *http.Reque
 	}
 
 	if options.Follow {
-		ar.streamParsedLogs(w, host, id, options)
+		ar.streamParsedLogs(w, r, host, id, options)
 		return
 	}
 
@@ -208,8 +208,49 @@ func (ar *APIRouter) GetContainerLogsParsed(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-func (ar *APIRouter) streamParsedLogs(w http.ResponseWriter, host, id string, options models.LogOptions) {
-	stream, err := ar.registry.Docker().StreamContainerLogsParsed(host, id, options)
+func (ar *APIRouter) StreamContainerEvents(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host := r.URL.Query().Get("host")
+	if host == "" {
+		host = "local"
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	msgCh, errCh, err := ar.registry.Docker().StreamContainerEvents(r.Context(), host, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	enc := json.NewEncoder(w)
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case err := <-errCh:
+			if err != nil && err != context.Canceled {
+				_ = enc.Encode(map[string]string{"error": err.Error()})
+				flusher.Flush()
+			}
+			return
+		case msg := <-msgCh:
+			_ = enc.Encode(map[string]string{"action": string(msg.Action)})
+			flusher.Flush()
+		}
+	}
+}
+
+func (ar *APIRouter) streamParsedLogs(w http.ResponseWriter, r *http.Request, host, id string, options models.LogOptions) {
+	stream, err := ar.registry.Docker().StreamContainerLogsParsed(r.Context(), host, id, options)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -90,6 +90,7 @@ func (ar *APIRouter) registerContainerRoutes(r chi.Router) {
 		// Read-only routes (always available)
 		r.Get("/", ar.GetContainer)
 		r.Get("/logs/parsed", ar.GetContainerLogsParsed)
+		r.Get("/events", ar.StreamContainerEvents)
 		r.Get("/env", ar.GetEnvVariables)
 
 		// Mutating routes (blocked in read-only mode)

--- a/server/internal/docker/logs.go
+++ b/server/internal/docker/logs.go
@@ -7,9 +7,12 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
@@ -101,6 +104,7 @@ type streamingLogWriter struct {
 	encoder     *json.Encoder
 	encoderMu   *sync.Mutex
 	pipeWriter  *io.PipeWriter
+	activityCh  chan<- struct{}
 	levelFilter string
 	searchRegex *regexp.Regexp
 }
@@ -163,9 +167,16 @@ func (w *streamingLogWriter) emit(line string) error {
 
 	if err != nil {
 		w.pipeWriter.CloseWithError(err)
+		return err
 	}
 
-	return err
+	// Non-blocking ping so the watcher resets its idle timer.
+	select {
+	case w.activityCh <- struct{}{}:
+	default:
+	}
+
+	return nil
 }
 
 func buildLogsOptions(options models.LogOptions, follow, timestamps bool) container.LogsOptions {
@@ -179,6 +190,25 @@ func buildLogsOptions(options models.LogOptions, follow, timestamps bool) contai
 		ShowStdout: options.ShowStdout,
 		ShowStderr: options.ShowStderr,
 	}
+}
+
+func (c *MultiHostClient) StreamContainerEvents(ctx context.Context, hostName, id string) (<-chan events.Message, <-chan error, error) {
+	apiClient, err := c.GetClient(hostName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	eventFilters := filters.NewArgs(
+		filters.Arg("type", "container"),
+		filters.Arg("container", id),
+		filters.Arg("event", string(events.ActionStart)),
+		filters.Arg("event", string(events.ActionDie)),
+		filters.Arg("event", string(events.ActionKill)),
+		filters.Arg("event", string(events.ActionStop)),
+		filters.Arg("event", string(events.ActionRestart)),
+	)
+	msgCh, errCh := apiClient.Events(ctx, events.ListOptions{Filters: eventFilters})
+	return msgCh, errCh, nil
 }
 
 // multi host client methods
@@ -202,16 +232,57 @@ func (c *MultiHostClient) GetContainerLogsParsed(hostName, id string, options mo
 	return parseDockerLogs(logs, options.Level, searchRegex)
 }
 
-func (c *MultiHostClient) StreamContainerLogsParsed(hostName, id string, options models.LogOptions) (io.ReadCloser, error) {
+func (c *MultiHostClient) StreamContainerLogsParsed(ctx context.Context, hostName, id string, options models.LogOptions) (io.ReadCloser, error) {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return nil, err
 	}
 
-	logs, err := apiClient.ContainerLogs(context.Background(), id, buildLogsOptions(options, options.Follow, true))
+	streamCtx, cancelStream := context.WithCancel(ctx)
+
+	logStream, err := apiClient.ContainerLogs(streamCtx, id, buildLogsOptions(options, options.Follow, true))
 	if err != nil {
+		cancelStream()
 		return nil, err
 	}
+
+	activityCh := make(chan struct{}, 1)
+
+	go func() {
+		defer cancelStream()
+		eventFilters := filters.NewArgs(
+			filters.Arg("type", "container"),
+			filters.Arg("container", id),
+			filters.Arg("event", string(events.ActionDie)),
+			filters.Arg("event", string(events.ActionKill)),
+			filters.Arg("event", string(events.ActionStop)),
+		)
+		eventCh, errCh := apiClient.Events(streamCtx, events.ListOptions{Filters: eventFilters})
+
+		idleTimer := time.NewTimer(30 * time.Second)
+		defer idleTimer.Stop()
+
+		for {
+			select {
+			case <-streamCtx.Done():
+				return
+			case <-eventCh:
+				return
+			case <-errCh:
+				return
+			case <-activityCh:
+				if !idleTimer.Stop() {
+					select {
+					case <-idleTimer.C:
+					default:
+					}
+				}
+				idleTimer.Reset(30 * time.Second)
+			case <-idleTimer.C:
+				return
+			}
+		}
+	}()
 
 	pipeReader, pipeWriter := io.Pipe()
 
@@ -221,8 +292,14 @@ func (c *MultiHostClient) StreamContainerLogsParsed(hostName, id string, options
 	}
 
 	go func() {
-		defer logs.Close()
+		defer cancelStream()
+		defer logStream.Close()
 		defer pipeWriter.Close()
+
+		go func() {
+			<-streamCtx.Done()
+			logStream.Close()
+		}()
 
 		encoder := json.NewEncoder(pipeWriter)
 		var mu sync.Mutex
@@ -232,6 +309,7 @@ func (c *MultiHostClient) StreamContainerLogsParsed(hostName, id string, options
 			encoder:     encoder,
 			encoderMu:   &mu,
 			pipeWriter:  pipeWriter,
+			activityCh:  activityCh,
 			levelFilter: options.Level,
 			searchRegex: searchRegex,
 		}
@@ -240,11 +318,12 @@ func (c *MultiHostClient) StreamContainerLogsParsed(hostName, id string, options
 			encoder:     encoder,
 			encoderMu:   &mu,
 			pipeWriter:  pipeWriter,
+			activityCh:  activityCh,
 			levelFilter: options.Level,
 			searchRegex: searchRegex,
 		}
 
-		_, err = stdcopy.StdCopy(stdout, stderr, logs)
+		_, err = stdcopy.StdCopy(stdout, stderr, logStream)
 		stdout.Flush()
 		stderr.Flush()
 


### PR DESCRIPTION
addreses #53 

watches for container die/kill/stop events on the server-side and cancel the log stream context(with EOF) when any of it is triggered.

i also exposed a GET /containers/{id}/events endpoint streaming container lifecycle events.
added an auto-reconnect loop on the client(frontend) on stream end which subscribes to the events endpoint and resume streaming on start event