### PR TITLE
fix(server): panic recovery, graceful shutdown, context propagation, and safe env edits

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -33,7 +33,8 @@ COPY --from=frontend-builder /frontend/dist ./internal/static/dist
 
 # Build Go binary with embedded frontend
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o logdeck-server ./cmd/server
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -ldflags "-X main.version=${VERSION}" -o logdeck-server ./cmd/server
 
 # Stage 3: Final runtime image with SSH client for remote Docker hosts
 FROM debian:bookworm-slim

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -17,6 +17,10 @@ import (
 	"github.com/AmoabaKelvin/logdeck/internal/system"
 )
 
+// version is injected at build time via
+// -ldflags "-X main.version=<version>". Defaults to "dev".
+var version = "dev"
+
 func main() {
 	system.Init()
 
@@ -90,7 +94,7 @@ func main() {
 		log.Println("Configuration reloaded successfully")
 	})
 
-	apiRouter := api.NewRouter(registry, manager)
+	apiRouter := api.NewRouter(registry, manager, version)
 
 	// No WriteTimeout/IdleTimeout: log streaming and terminal WebSockets are
 	// long-lived connections and would be killed by them.

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/api"
@@ -89,8 +92,30 @@ func main() {
 
 	apiRouter := api.NewRouter(registry, manager)
 
-	log.Println("Server starting on :8080")
-	if err := http.ListenAndServe(":8080", apiRouter); err != nil {
-		log.Fatalf("Server failed to start: %v", err)
+	// No WriteTimeout/IdleTimeout: log streaming and terminal WebSockets are
+	// long-lived connections and would be killed by them.
+	server := &http.Server{
+		Addr:              ":8080",
+		Handler:           apiRouter,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		log.Println("Server starting on :8080")
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server failed to start: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Println("Shutting down server...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Graceful shutdown failed: %v", err)
 	}
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -97,11 +97,14 @@ func main() {
 	apiRouter := api.NewRouter(registry, manager, version)
 
 	// No WriteTimeout/IdleTimeout: log streaming and terminal WebSockets are
-	// long-lived connections and would be killed by them.
+	// long-lived connections and would be killed by them. ReadTimeout only
+	// bounds reading the request (headers + body), so hijacked WebSockets
+	// (unaffected after upgrade) and streaming responses (write-side) are safe.
 	server := &http.Server{
 		Addr:              ":8080",
 		Handler:           apiRouter,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -85,7 +85,7 @@ func (ar *APIRouter) GetContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	container, err := ar.registry.Docker().GetContainer(host, id)
+	container, err := ar.registry.Docker().GetContainer(r.Context(), host, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -104,7 +104,7 @@ func (ar *APIRouter) StartContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := ar.registry.Docker().StartContainer(host, id)
+	err := ar.registry.Docker().StartContainer(r.Context(), host, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -123,7 +123,7 @@ func (ar *APIRouter) StopContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := ar.registry.Docker().StopContainer(host, id)
+	err := ar.registry.Docker().StopContainer(r.Context(), host, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -142,7 +142,7 @@ func (ar *APIRouter) RestartContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := ar.registry.Docker().RestartContainer(host, id)
+	err := ar.registry.Docker().RestartContainer(r.Context(), host, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -161,7 +161,7 @@ func (ar *APIRouter) RemoveContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := ar.registry.Docker().RemoveContainer(host, id)
+	err := ar.registry.Docker().RemoveContainer(r.Context(), host, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -192,11 +192,11 @@ func (ar *APIRouter) GetContainerLogsParsed(w http.ResponseWriter, r *http.Reque
 	}
 
 	if options.Follow {
-		ar.streamParsedLogs(w, host, id, options)
+		ar.streamParsedLogs(w, r, host, id, options)
 		return
 	}
 
-	logs, err := ar.registry.Docker().GetContainerLogsParsed(host, id, options)
+	logs, err := ar.registry.Docker().GetContainerLogsParsed(r.Context(), host, id, options)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -208,8 +208,8 @@ func (ar *APIRouter) GetContainerLogsParsed(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-func (ar *APIRouter) streamParsedLogs(w http.ResponseWriter, host, id string, options models.LogOptions) {
-	stream, err := ar.registry.Docker().StreamContainerLogsParsed(host, id, options)
+func (ar *APIRouter) streamParsedLogs(w http.ResponseWriter, r *http.Request, host, id string, options models.LogOptions) {
+	stream, err := ar.registry.Docker().StreamContainerLogsParsed(r.Context(), host, id, options)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -294,7 +294,7 @@ func (ar *APIRouter) GetEnvVariables(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	envVariables, err := ar.registry.Docker().GetEnvVariables(host, id)
+	envVariables, err := ar.registry.Docker().GetEnvVariables(r.Context(), host, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -329,7 +329,7 @@ func (ar *APIRouter) UpdateEnvVariables(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	newContainerID, labels, err := ar.registry.Docker().SetEnvVariables(host, id, envVariables.Env)
+	newContainerID, labels, err := ar.registry.Docker().SetEnvVariables(r.Context(), host, id, envVariables.Env)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -263,7 +263,7 @@ func parseLogOptions(r *http.Request) models.LogOptions {
 	}
 
 	if tail := query.Get("tail"); tail != "" {
-		options.Tail = tail
+		options.Tail = clampTail(tail)
 	}
 
 	if details := query.Get("details"); details != "" {
@@ -283,6 +283,18 @@ func parseLogOptions(r *http.Request) models.LogOptions {
 	}
 
 	return options
+}
+
+// maxTailLines bounds how many log lines a single request can pull into
+// memory. "all" (and any other non-numeric value) is treated as the max.
+const maxTailLines = 10000
+
+func clampTail(tail string) string {
+	n, err := strconv.Atoi(tail)
+	if err != nil || n < 0 || n > maxTailLines {
+		return strconv.Itoa(maxTailLines)
+	}
+	return tail
 }
 
 func (ar *APIRouter) GetEnvVariables(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/api/handlers_test.go
+++ b/server/internal/api/handlers_test.go
@@ -1,0 +1,26 @@
+package api
+
+import "testing"
+
+func TestClampTail(t *testing.T) {
+	tests := []struct {
+		name string
+		tail string
+		want string
+	}{
+		{name: "small value passes through", tail: "100", want: "100"},
+		{name: "max value passes through", tail: "10000", want: "10000"},
+		{name: "over max is clamped", tail: "50000", want: "10000"},
+		{name: "all is treated as max", tail: "all", want: "10000"},
+		{name: "non-numeric is treated as max", tail: "banana", want: "10000"},
+		{name: "negative is treated as max", tail: "-5", want: "10000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampTail(tt.tail); got != tt.want {
+				t.Fatalf("clampTail(%q) = %q, want %q", tt.tail, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/api/health.go
+++ b/server/internal/api/health.go
@@ -1,0 +1,13 @@
+package api
+
+import "net/http"
+
+// handleHealthz reports server liveness. Public, no auth.
+func (ar *APIRouter) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	WriteJsonResponse(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleVersion returns the server version. Public, no auth.
+func (ar *APIRouter) handleVersion(w http.ResponseWriter, r *http.Request) {
+	WriteJsonResponse(w, http.StatusOK, map[string]string{"version": ar.version})
+}

--- a/server/internal/api/health_test.go
+++ b/server/internal/api/health_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleHealthz(t *testing.T) {
+	ar := &APIRouter{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/healthz", nil)
+	rec := httptest.NewRecorder()
+	ar.handleHealthz(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("expected status \"ok\", got %q", body["status"])
+	}
+}
+
+func TestHandleVersion(t *testing.T) {
+	ar := &APIRouter{version: "1.2.3"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	rec := httptest.NewRecorder()
+	ar.handleVersion(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["version"] != "1.2.3" {
+		t.Fatalf("expected version \"1.2.3\", got %q", body["version"])
+	}
+}

--- a/server/internal/api/middleware/accesslog.go
+++ b/server/internal/api/middleware/accesslog.go
@@ -14,13 +14,17 @@ func AccessLog(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
-		next.ServeHTTP(ww, r)
+		// Deferred so panicked requests are still logged (their status reads
+		// 0 here; Recoverer above writes the actual 500 response).
+		defer func() {
+			slog.Info("request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", ww.Status(),
+				"duration", time.Since(start),
+			)
+		}()
 
-		slog.Info("request",
-			"method", r.Method,
-			"path", r.URL.Path,
-			"status", ww.Status(),
-			"duration", time.Since(start),
-		)
+		next.ServeHTTP(ww, r)
 	})
 }

--- a/server/internal/api/middleware/accesslog.go
+++ b/server/internal/api/middleware/accesslog.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// AccessLog logs each request (method, path, status, duration) using slog.
+func AccessLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		next.ServeHTTP(ww, r)
+
+		slog.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", ww.Status(),
+			"duration", time.Since(start),
+		)
+	})
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AmoabaKelvin/logdeck/internal/services"
 	"github.com/AmoabaKelvin/logdeck/internal/static"
 	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 )
 
@@ -44,6 +45,8 @@ func WriteJsonResponse(w http.ResponseWriter, status int, data interface{}) {
 }
 
 func (ar *APIRouter) Routes() *chi.Mux {
+	ar.router.Use(chimiddleware.RequestID)
+	ar.router.Use(chimiddleware.Recoverer)
 	ar.router.Use(cors.Handler(cors.Options{
 		AllowedOrigins: []string{"*"},
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
@@ -52,6 +55,9 @@ func (ar *APIRouter) Routes() *chi.Mux {
 
 	// API routes
 	ar.router.Route("/api/v1", func(r chi.Router) {
+		// Access logging only for API routes (static SPA routes stay quiet)
+		r.Use(middleware.AccessLog)
+
 		// System stats - publicly available
 		r.Get("/system/stats", ar.GetSystemStats)
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -19,13 +19,15 @@ type APIRouter struct {
 	router   *chi.Mux
 	registry *services.Registry
 	manager  *config.Manager
+	version  string
 }
 
-func NewRouter(registry *services.Registry, manager *config.Manager) *chi.Mux {
+func NewRouter(registry *services.Registry, manager *config.Manager, version string) *chi.Mux {
 	r := &APIRouter{
 		router:   chi.NewRouter(),
 		registry: registry,
 		manager:  manager,
+		version:  version,
 	}
 
 	return r.Routes()
@@ -57,6 +59,10 @@ func (ar *APIRouter) Routes() *chi.Mux {
 	ar.router.Route("/api/v1", func(r chi.Router) {
 		// Access logging only for API routes (static SPA routes stay quiet)
 		r.Use(middleware.AccessLog)
+
+		// Health and version - publicly available
+		r.Get("/healthz", ar.handleHealthz)
+		r.Get("/version", ar.handleVersion)
 
 		// System stats - publicly available
 		r.Get("/system/stats", ar.GetSystemStats)

--- a/server/internal/docker/container.go
+++ b/server/internal/docker/container.go
@@ -10,57 +10,57 @@ import (
 	"github.com/docker/docker/api/types/network"
 )
 
-func (c *MultiHostClient) GetContainer(hostName, id string) (container.InspectResponse, error) {
+func (c *MultiHostClient) GetContainer(ctx context.Context, hostName, id string) (container.InspectResponse, error) {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return container.InspectResponse{}, err
 	}
-	result, err := apiClient.ContainerInspect(context.Background(), id)
+	result, err := apiClient.ContainerInspect(ctx, id)
 	if err != nil {
 		return container.InspectResponse{}, err
 	}
 	return result, nil
 }
 
-func (c *MultiHostClient) StartContainer(hostName, id string) error {
+func (c *MultiHostClient) StartContainer(ctx context.Context, hostName, id string) error {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return err
 	}
-	return apiClient.ContainerStart(context.Background(), id, container.StartOptions{})
+	return apiClient.ContainerStart(ctx, id, container.StartOptions{})
 }
 
-func (c *MultiHostClient) StopContainer(hostName, id string) error {
+func (c *MultiHostClient) StopContainer(ctx context.Context, hostName, id string) error {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return err
 	}
-	return apiClient.ContainerStop(context.Background(), id, container.StopOptions{})
+	return apiClient.ContainerStop(ctx, id, container.StopOptions{})
 }
 
-func (c *MultiHostClient) RestartContainer(hostName, id string) error {
+func (c *MultiHostClient) RestartContainer(ctx context.Context, hostName, id string) error {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return err
 	}
-	return apiClient.ContainerRestart(context.Background(), id, container.StopOptions{})
+	return apiClient.ContainerRestart(ctx, id, container.StopOptions{})
 }
 
-func (c *MultiHostClient) RemoveContainer(hostName, id string) error {
+func (c *MultiHostClient) RemoveContainer(ctx context.Context, hostName, id string) error {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return err
 	}
-	return apiClient.ContainerRemove(context.Background(), id, container.RemoveOptions{})
+	return apiClient.ContainerRemove(ctx, id, container.RemoveOptions{})
 }
 
-func (c *MultiHostClient) GetEnvVariables(hostName, id string) (map[string]string, error) {
+func (c *MultiHostClient) GetEnvVariables(ctx context.Context, hostName, id string) (map[string]string, error) {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return nil, err
 	}
 
-	inspect, err := apiClient.ContainerInspect(context.Background(), id)
+	inspect, err := apiClient.ContainerInspect(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -82,13 +82,13 @@ func (c *MultiHostClient) GetEnvVariables(hostName, id string) (map[string]strin
 
 // SetEnvVariables recreates a container with updated environment variables.
 // Returns the new container ID and the original container's labels.
-func (c *MultiHostClient) SetEnvVariables(hostName, id string, envVariables map[string]string) (string, map[string]string, error) {
+func (c *MultiHostClient) SetEnvVariables(ctx context.Context, hostName, id string, envVariables map[string]string) (string, map[string]string, error) {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return "", nil, err
 	}
 
-	inspect, err := apiClient.ContainerInspect(context.Background(), id)
+	inspect, err := apiClient.ContainerInspect(ctx, id)
 	if err != nil {
 		return "", nil, err
 	}
@@ -130,12 +130,12 @@ func (c *MultiHostClient) SetEnvVariables(hostName, id string, envVariables map[
 
 	containerName := strings.TrimPrefix(inspect.Name, "/")
 
-	err = apiClient.ContainerStop(context.Background(), id, container.StopOptions{})
+	err = apiClient.ContainerStop(ctx, id, container.StopOptions{})
 	if err != nil {
 		return "", nil, err
 	}
 
-	err = apiClient.ContainerRemove(context.Background(), id, container.RemoveOptions{})
+	err = apiClient.ContainerRemove(ctx, id, container.RemoveOptions{})
 	if err != nil {
 		return "", nil, err
 	}
@@ -144,7 +144,7 @@ func (c *MultiHostClient) SetEnvVariables(hostName, id string, envVariables map[
 	newConfig.Env = envs
 
 	resp, err := apiClient.ContainerCreate(
-		context.Background(),
+		ctx,
 		newConfig,
 		inspect.HostConfig,
 		&network.NetworkingConfig{
@@ -157,7 +157,7 @@ func (c *MultiHostClient) SetEnvVariables(hostName, id string, envVariables map[
 		return "", nil, err
 	}
 
-	err = apiClient.ContainerStart(context.Background(), resp.ID, container.StartOptions{})
+	err = apiClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
 	if err != nil {
 		return "", nil, err
 	}

--- a/server/internal/docker/container.go
+++ b/server/internal/docker/container.go
@@ -225,9 +225,13 @@ func recreateContainerWithEnv(ctx context.Context, apiClient containerRecreateAP
 		return "", err
 	}
 
-	if err := apiClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
-		rollback(resp.ID)
-		return "", err
+	// Only start the replacement if the original was running, so editing
+	// env vars on a stopped container leaves it stopped.
+	if wasRunning {
+		if err := apiClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+			rollback(resp.ID)
+			return "", err
+		}
 	}
 
 	// Replacement is running; removing the renamed original is best-effort.

--- a/server/internal/docker/container.go
+++ b/server/internal/docker/container.go
@@ -202,7 +202,8 @@ func recreateContainerWithEnv(ctx context.Context, apiClient containerRecreateAP
 		return "", err
 	}
 
-	newConfig := inspect.Config
+	// Copy the config so we don't mutate the shared InspectResponse in place.
+	newConfig := *inspect.Config
 	newConfig.Env = envs
 
 	var networking *network.NetworkingConfig
@@ -214,7 +215,7 @@ func recreateContainerWithEnv(ctx context.Context, apiClient containerRecreateAP
 
 	resp, err := apiClient.ContainerCreate(
 		ctx,
-		newConfig,
+		&newConfig,
 		inspect.HostConfig,
 		networking,
 		nil,

--- a/server/internal/docker/container.go
+++ b/server/internal/docker/container.go
@@ -2,12 +2,15 @@ package docker
 
 import (
 	"context"
+	"log"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/AmoabaKelvin/logdeck/internal/coolify"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func (c *MultiHostClient) GetContainer(ctx context.Context, hostName, id string) (container.InspectResponse, error) {
@@ -80,6 +83,25 @@ func (c *MultiHostClient) GetEnvVariables(ctx context.Context, hostName, id stri
 	return envMap, nil
 }
 
+// containerRecreateAPI is the subset of the Docker client used by the
+// env-edit recreate flow, extracted so the rollback logic can be tested.
+type containerRecreateAPI interface {
+	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
+	ContainerRename(ctx context.Context, containerID, newContainerName string) error
+	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
+	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
+	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
+}
+
+// envEditLocks serializes concurrent env edits on the same container,
+// keyed by host+containerID. Package-level so locks survive client hot-swaps.
+var envEditLocks sync.Map
+
+func envEditLock(hostName, id string) *sync.Mutex {
+	lock, _ := envEditLocks.LoadOrStore(hostName+"/"+id, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
 // SetEnvVariables recreates a container with updated environment variables.
 // Returns the new container ID and the original container's labels.
 func (c *MultiHostClient) SetEnvVariables(ctx context.Context, hostName, id string, envVariables map[string]string) (string, map[string]string, error) {
@@ -87,6 +109,10 @@ func (c *MultiHostClient) SetEnvVariables(ctx context.Context, hostName, id stri
 	if err != nil {
 		return "", nil, err
 	}
+
+	lock := envEditLock(hostName, id)
+	lock.Lock()
+	defer lock.Unlock()
 
 	inspect, err := apiClient.ContainerInspect(ctx, id)
 	if err != nil {
@@ -128,39 +154,86 @@ func (c *MultiHostClient) SetEnvVariables(ctx context.Context, hostName, id stri
 		envs = append(envs, key+"="+value)
 	}
 
-	containerName := strings.TrimPrefix(inspect.Name, "/")
-
-	err = apiClient.ContainerStop(ctx, id, container.StopOptions{})
+	newID, err := recreateContainerWithEnv(ctx, apiClient, inspect, envs)
 	if err != nil {
 		return "", nil, err
 	}
 
-	err = apiClient.ContainerRemove(ctx, id, container.RemoveOptions{})
-	if err != nil {
-		return "", nil, err
+	return newID, labels, nil
+}
+
+// recreateContainerWithEnv replaces a container with an identical one whose
+// env is envs. The original is renamed aside (not removed) until the
+// replacement is running, so any failure rolls back to the original.
+func recreateContainerWithEnv(ctx context.Context, apiClient containerRecreateAPI, inspect container.InspectResponse, envs []string) (string, error) {
+	containerName := strings.TrimPrefix(inspect.Name, "/")
+	wasRunning := inspect.State != nil && inspect.State.Running
+
+	shortID := inspect.ID
+	if len(shortID) > 12 {
+		shortID = shortID[:12]
+	}
+	tempName := containerName + "-logdeck-old-" + shortID
+
+	// Rollback and cleanup must proceed even if the request was canceled.
+	cleanupCtx := context.WithoutCancel(ctx)
+
+	// rollback removes the partially-created replacement (if any), renames
+	// the original back, and restarts it if it was running.
+	rollback := func(newID string) {
+		if newID != "" {
+			_ = apiClient.ContainerRemove(cleanupCtx, newID, container.RemoveOptions{Force: true})
+		}
+		_ = apiClient.ContainerRename(cleanupCtx, inspect.ID, containerName)
+		if wasRunning {
+			_ = apiClient.ContainerStart(cleanupCtx, inspect.ID, container.StartOptions{})
+		}
+	}
+
+	if err := apiClient.ContainerStop(ctx, inspect.ID, container.StopOptions{}); err != nil {
+		return "", err
+	}
+
+	if err := apiClient.ContainerRename(ctx, inspect.ID, tempName); err != nil {
+		// Name unchanged; just restart the original if it was running.
+		if wasRunning {
+			_ = apiClient.ContainerStart(cleanupCtx, inspect.ID, container.StartOptions{})
+		}
+		return "", err
 	}
 
 	newConfig := inspect.Config
 	newConfig.Env = envs
 
+	var networking *network.NetworkingConfig
+	if inspect.NetworkSettings != nil {
+		networking = &network.NetworkingConfig{
+			EndpointsConfig: inspect.NetworkSettings.Networks,
+		}
+	}
+
 	resp, err := apiClient.ContainerCreate(
 		ctx,
 		newConfig,
 		inspect.HostConfig,
-		&network.NetworkingConfig{
-			EndpointsConfig: inspect.NetworkSettings.Networks,
-		},
+		networking,
 		nil,
 		containerName,
 	)
 	if err != nil {
-		return "", nil, err
+		rollback("")
+		return "", err
 	}
 
-	err = apiClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
-	if err != nil {
-		return "", nil, err
+	if err := apiClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		rollback(resp.ID)
+		return "", err
 	}
 
-	return resp.ID, labels, nil
+	// Replacement is running; removing the renamed original is best-effort.
+	if err := apiClient.ContainerRemove(cleanupCtx, inspect.ID, container.RemoveOptions{}); err != nil {
+		log.Printf("Warning: failed to remove old container %s after env update: %v", tempName, err)
+	}
+
+	return resp.ID, nil
 }

--- a/server/internal/docker/container_test.go
+++ b/server/internal/docker/container_test.go
@@ -13,23 +13,27 @@ import (
 )
 
 type fakeRecreateAPI struct {
-	calls      []string
-	createErr  error
-	startErrOn string // container ID whose start should fail
+	calls         []string
+	stopErr       error
+	renameErr     error
+	createErr     error
+	startErrOn    string   // container ID whose start should fail
+	lastCreateEnv []string // env passed to the last ContainerCreate call
 }
 
 func (f *fakeRecreateAPI) ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error {
 	f.calls = append(f.calls, "stop "+containerID)
-	return nil
+	return f.stopErr
 }
 
 func (f *fakeRecreateAPI) ContainerRename(ctx context.Context, containerID, newContainerName string) error {
 	f.calls = append(f.calls, "rename "+containerID+" "+newContainerName)
-	return nil
+	return f.renameErr
 }
 
 func (f *fakeRecreateAPI) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
 	f.calls = append(f.calls, "create "+containerName)
+	f.lastCreateEnv = config.Env
 	if f.createErr != nil {
 		return container.CreateResponse{}, f.createErr
 	}
@@ -86,6 +90,38 @@ func TestRecreateContainerWithEnv(t *testing.T) {
 			},
 		},
 		{
+			name:    "success on stopped container leaves replacement stopped",
+			api:     &fakeRecreateAPI{},
+			running: false,
+			wantID:  "new-container-id",
+			wantCalls: []string{
+				"stop abcdef1234567890",
+				"rename abcdef1234567890 " + tempName,
+				"create web",
+				"remove abcdef1234567890 force=false",
+			},
+		},
+		{
+			name:    "stop failure returns immediately with no rollback",
+			api:     &fakeRecreateAPI{stopErr: errors.New("stop failed")},
+			running: true,
+			wantErr: true,
+			wantCalls: []string{
+				"stop abcdef1234567890",
+			},
+		},
+		{
+			name:    "rename failure restarts the running original",
+			api:     &fakeRecreateAPI{renameErr: errors.New("rename failed")},
+			running: true,
+			wantErr: true,
+			wantCalls: []string{
+				"stop abcdef1234567890",
+				"rename abcdef1234567890 " + tempName,
+				"start abcdef1234567890",
+			},
+		},
+		{
 			name:    "create failure renames original back and restarts it",
 			api:     &fakeRecreateAPI{createErr: errors.New("create failed")},
 			running: true,
@@ -138,6 +174,9 @@ func TestRecreateContainerWithEnv(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tt.api.calls, tt.wantCalls) {
 				t.Fatalf("call sequence mismatch:\ngot:  %v\nwant: %v", tt.api.calls, tt.wantCalls)
+			}
+			if tt.wantID != "" && !reflect.DeepEqual(tt.api.lastCreateEnv, []string{"A=2"}) {
+				t.Fatalf("expected replacement created with env [A=2], got %v", tt.api.lastCreateEnv)
 			}
 		})
 	}

--- a/server/internal/docker/container_test.go
+++ b/server/internal/docker/container_test.go
@@ -1,0 +1,144 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type fakeRecreateAPI struct {
+	calls      []string
+	createErr  error
+	startErrOn string // container ID whose start should fail
+}
+
+func (f *fakeRecreateAPI) ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error {
+	f.calls = append(f.calls, "stop "+containerID)
+	return nil
+}
+
+func (f *fakeRecreateAPI) ContainerRename(ctx context.Context, containerID, newContainerName string) error {
+	f.calls = append(f.calls, "rename "+containerID+" "+newContainerName)
+	return nil
+}
+
+func (f *fakeRecreateAPI) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+	f.calls = append(f.calls, "create "+containerName)
+	if f.createErr != nil {
+		return container.CreateResponse{}, f.createErr
+	}
+	return container.CreateResponse{ID: "new-container-id"}, nil
+}
+
+func (f *fakeRecreateAPI) ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error {
+	f.calls = append(f.calls, "start "+containerID)
+	if containerID == f.startErrOn {
+		return errors.New("start failed")
+	}
+	return nil
+}
+
+func (f *fakeRecreateAPI) ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error {
+	f.calls = append(f.calls, fmt.Sprintf("remove %s force=%t", containerID, options.Force))
+	return nil
+}
+
+func testInspectResponse(running bool) container.InspectResponse {
+	return container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:         "abcdef1234567890",
+			Name:       "/web",
+			State:      &container.State{Running: running},
+			HostConfig: &container.HostConfig{},
+		},
+		Config: &container.Config{Env: []string{"A=1"}},
+	}
+}
+
+func TestRecreateContainerWithEnv(t *testing.T) {
+	const tempName = "web-logdeck-old-abcdef123456"
+
+	tests := []struct {
+		name      string
+		api       *fakeRecreateAPI
+		running   bool
+		wantErr   bool
+		wantID    string
+		wantCalls []string
+	}{
+		{
+			name:    "success removes renamed original only after new container starts",
+			api:     &fakeRecreateAPI{},
+			running: true,
+			wantID:  "new-container-id",
+			wantCalls: []string{
+				"stop abcdef1234567890",
+				"rename abcdef1234567890 " + tempName,
+				"create web",
+				"start new-container-id",
+				"remove abcdef1234567890 force=false",
+			},
+		},
+		{
+			name:    "create failure renames original back and restarts it",
+			api:     &fakeRecreateAPI{createErr: errors.New("create failed")},
+			running: true,
+			wantErr: true,
+			wantCalls: []string{
+				"stop abcdef1234567890",
+				"rename abcdef1234567890 " + tempName,
+				"create web",
+				"rename abcdef1234567890 web",
+				"start abcdef1234567890",
+			},
+		},
+		{
+			name:    "start failure removes new container and restores original",
+			api:     &fakeRecreateAPI{startErrOn: "new-container-id"},
+			running: true,
+			wantErr: true,
+			wantCalls: []string{
+				"stop abcdef1234567890",
+				"rename abcdef1234567890 " + tempName,
+				"create web",
+				"start new-container-id",
+				"remove new-container-id force=true",
+				"rename abcdef1234567890 web",
+				"start abcdef1234567890",
+			},
+		},
+		{
+			name:    "create failure on stopped container does not restart it",
+			api:     &fakeRecreateAPI{createErr: errors.New("create failed")},
+			running: false,
+			wantErr: true,
+			wantCalls: []string{
+				"stop abcdef1234567890",
+				"rename abcdef1234567890 " + tempName,
+				"create web",
+				"rename abcdef1234567890 web",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := recreateContainerWithEnv(context.Background(), tt.api, testInspectResponse(tt.running), []string{"A=2"})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("recreateContainerWithEnv() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if id != tt.wantID {
+				t.Fatalf("recreateContainerWithEnv() id = %q, want %q", id, tt.wantID)
+			}
+			if !reflect.DeepEqual(tt.api.calls, tt.wantCalls) {
+				t.Fatalf("call sequence mismatch:\ngot:  %v\nwant: %v", tt.api.calls, tt.wantCalls)
+			}
+		})
+	}
+}

--- a/server/internal/docker/logs.go
+++ b/server/internal/docker/logs.go
@@ -182,13 +182,13 @@ func buildLogsOptions(options models.LogOptions, follow, timestamps bool) contai
 }
 
 // multi host client methods
-func (c *MultiHostClient) GetContainerLogsParsed(hostName, id string, options models.LogOptions) ([]models.LogEntry, error) {
+func (c *MultiHostClient) GetContainerLogsParsed(ctx context.Context, hostName, id string, options models.LogOptions) ([]models.LogEntry, error) {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return nil, err
 	}
 
-	logs, err := apiClient.ContainerLogs(context.Background(), id, buildLogsOptions(options, false, true))
+	logs, err := apiClient.ContainerLogs(ctx, id, buildLogsOptions(options, false, true))
 	if err != nil {
 		return nil, err
 	}
@@ -202,13 +202,15 @@ func (c *MultiHostClient) GetContainerLogsParsed(hostName, id string, options mo
 	return parseDockerLogs(logs, options.Level, searchRegex)
 }
 
-func (c *MultiHostClient) StreamContainerLogsParsed(hostName, id string, options models.LogOptions) (io.ReadCloser, error) {
+// StreamContainerLogsParsed streams parsed logs. The Docker log stream is tied
+// to ctx, so a disconnected client cancels the follow-mode stream.
+func (c *MultiHostClient) StreamContainerLogsParsed(ctx context.Context, hostName, id string, options models.LogOptions) (io.ReadCloser, error) {
 	apiClient, err := c.GetClient(hostName)
 	if err != nil {
 		return nil, err
 	}
 
-	logs, err := apiClient.ContainerLogs(context.Background(), id, buildLogsOptions(options, options.Follow, true))
+	logs, err := apiClient.ContainerLogs(ctx, id, buildLogsOptions(options, options.Follow, true))
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/docker/logs.go
+++ b/server/internal/docker/logs.go
@@ -47,6 +47,11 @@ func parseDockerLogs(reader io.Reader, levelFilter string, searchRegex *regexp.R
 	return filtered, nil
 }
 
+// maxLineBufferSize caps the pending (newline-less) line buffer in the log
+// writers. An oversized chunk is flushed as its own log entry so a single
+// line without a newline cannot grow without bound.
+const maxLineBufferSize = 1 << 20 // 1 MiB
+
 // logWriter implements io.Writer and parses log lines
 type logWriter struct {
 	stream  string
@@ -78,6 +83,10 @@ func (w *logWriter) Write(p []byte) (n int, err error) {
 			entry := models.ParseLogLine(line, w.stream)
 			*w.entries = append(*w.entries, entry)
 		}
+	}
+
+	if len(w.buffer) > maxLineBufferSize {
+		w.Flush()
 	}
 
 	return len(p), nil
@@ -129,6 +138,14 @@ func (w *streamingLogWriter) Write(p []byte) (n int, err error) {
 			if encodeErr := w.emit(line); encodeErr != nil {
 				return 0, encodeErr
 			}
+		}
+	}
+
+	if len(w.buffer) > maxLineBufferSize {
+		line := strings.TrimSuffix(string(w.buffer), "\r")
+		w.buffer = nil
+		if encodeErr := w.emit(line); encodeErr != nil {
+			return 0, encodeErr
 		}
 	}
 

--- a/server/internal/docker/logs_test.go
+++ b/server/internal/docker/logs_test.go
@@ -2,7 +2,10 @@ package docker
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
@@ -38,5 +41,95 @@ func TestParseDockerLogsGroupsStructuredContinuationLines(t *testing.T) {
 	}
 	if !strings.Contains(entries[0].Message, "Request received\nservice: \"api\"\nrequestId:") {
 		t.Fatalf("expected grouped message to include continuation fields, got %q", entries[0].Message)
+	}
+}
+
+func TestLogWriterLineBufferCap(t *testing.T) {
+	tests := []struct {
+		name        string
+		writes      []string
+		wantEntries int
+	}{
+		{
+			name:        "line under cap stays buffered until flush",
+			writes:      []string{strings.Repeat("a", 1024)},
+			wantEntries: 0,
+		},
+		{
+			name:        "oversized line flushed as its own entry",
+			writes:      []string{strings.Repeat("a", maxLineBufferSize+1)},
+			wantEntries: 1,
+		},
+		{
+			name:        "oversized line accumulated across writes",
+			writes:      []string{strings.Repeat("a", maxLineBufferSize), strings.Repeat("b", 10)},
+			wantEntries: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var entries []models.LogEntry
+			w := &logWriter{stream: "stdout", entries: &entries}
+			for _, chunk := range tt.writes {
+				if _, err := w.Write([]byte(chunk)); err != nil {
+					t.Fatalf("write failed: %v", err)
+				}
+			}
+			if len(entries) != tt.wantEntries {
+				t.Fatalf("expected %d entries, got %d", tt.wantEntries, len(entries))
+			}
+			if len(w.buffer) > maxLineBufferSize {
+				t.Fatalf("buffer exceeds cap: %d bytes", len(w.buffer))
+			}
+		})
+	}
+}
+
+func TestStreamingLogWriterLineBufferCap(t *testing.T) {
+	tests := []struct {
+		name        string
+		writes      []string
+		wantEntries int
+	}{
+		{
+			name:        "line under cap stays buffered until flush",
+			writes:      []string{strings.Repeat("a", 1024)},
+			wantEntries: 0,
+		},
+		{
+			name:        "oversized line emitted as its own entry",
+			writes:      []string{strings.Repeat("a", maxLineBufferSize+1)},
+			wantEntries: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			var mu sync.Mutex
+			_, pipeWriter := io.Pipe()
+			w := &streamingLogWriter{
+				stream:     "stdout",
+				encoder:    json.NewEncoder(&out),
+				encoderMu:  &mu,
+				pipeWriter: pipeWriter,
+			}
+			for _, chunk := range tt.writes {
+				if _, err := w.Write([]byte(chunk)); err != nil {
+					t.Fatalf("write failed: %v", err)
+				}
+			}
+			got := 0
+			if out.Len() > 0 {
+				got = strings.Count(strings.TrimRight(out.String(), "\n"), "\n") + 1
+			}
+			if got != tt.wantEntries {
+				t.Fatalf("expected %d emitted entries, got %d", tt.wantEntries, got)
+			}
+			if len(w.buffer) > maxLineBufferSize {
+				t.Fatalf("buffer exceeds cap: %d bytes", len(w.buffer))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Robustness batch for the Go server:

- Add chi RequestID and Recoverer middleware plus a slog-based access log scoped to /api/v1 routes, so a panicking handler no longer kills the process.
- Replace bare http.ListenAndServe with an http.Server using ReadHeaderTimeout (10s) and graceful shutdown on SIGINT/SIGTERM with a 10s grace period. WriteTimeout/IdleTimeout are deliberately not set because log streams and terminal WebSockets are long-lived.
- Propagate the request context through the Docker layer (previously context.Background() everywhere), so client disconnects cancel Docker operations and follow-mode log streams.
- Make env-var edits recoverable: rename old container -> create -> start -> remove, with rollback (restore name, restart if it was running) on any failure, using context.WithoutCancel so a client disconnect cannot strand a container mid-edit. Concurrent edits on the same container are serialized with a per-container mutex.
- Cap unbounded buffers: tail clamped to 10000 lines (all/invalid values become the max), 1 MiB cap on pending newline-less line buffers.
- Add public GET /api/v1/healthz and /api/v1/version endpoints; version is injected via ldflags (wired into server/Dockerfile).

## Tests

New unit tests for the env-edit rollback call sequences (against a fake client), the tail clamp, both log writer buffer caps, and healthz/version handlers. go build, go vet, and go test ./... pass.

## Notes

Merge this before the security-hardening PR: that branch is stacked on this one because its settings auth tests use the new three-argument NewRouter signature introduced here.

https://claude.ai/code/session_01Ksbg2abvq4FA4DrsYjnDoi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public health and version endpoints to check service status and display the running build version.
  * Added request access logging to improve visibility into API calls.

* **Bug Fixes**
  * Improved request handling so container and log operations respect cancellation and shut down more cleanly.
  * Limited log tailing and in-memory log buffering to reduce resource spikes.
  * Made container environment updates more reliable and safer during concurrent changes.

* **Tests**
  * Added/extended unit tests for tail clamping, log buffering limits, and container recreation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->