### PR TITLE
fix(server): security hardening - terminal teardown, bcrypt verification, CORS, rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ BACKEND_PORT=8080
 # Frontend port (default: 5173)
 FRONTEND_PORT=5173
 
+# Allowed CORS origins (comma-separated). Only needed when the frontend is
+# served from a different origin than the backend (e.g. a dev server).
+# Default: http://localhost:5173,http://127.0.0.1:5173
+# CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
 # =============================================================================
 # Docker Configuration (Optional)
 # =============================================================================

--- a/env.example
+++ b/env.example
@@ -12,7 +12,9 @@ JWT_SECRET=your-super-secret-key-change-this-to-something-random-min-32-chars
 ADMIN_USERNAME=admin
 
 # Admin Password - MUST be a bcrypt hash (plain text is not supported)
-# Generate hash with: cd server/scripts && go run hash-password.go yourPassword
+# Generate hash with: htpasswd -bnBC 10 '' yourPassword | tr -d ':'
+# (htpasswd ships with apache2-utils on Debian/Ubuntu, httpd-tools on RHEL,
+# and is preinstalled on macOS)
 # Example output: $2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 ADMIN_PASSWORD=$2a$10$YourBcryptHashHere
 

--- a/env.example
+++ b/env.example
@@ -26,6 +26,11 @@ BACKEND_PORT=8080
 # Frontend port (default: 5173)
 FRONTEND_PORT=5173
 
+# Allowed CORS origins (comma-separated). Only needed when the frontend is
+# served from a different origin than the backend (e.g. a dev server).
+# Default: http://localhost:5173,http://127.0.0.1:5173
+# CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
 # =============================================================================
 # Docker Configuration (Optional)
 # =============================================================================

--- a/server/internal/api/cors.go
+++ b/server/internal/api/cors.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"os"
+	"strings"
+)
+
+// corsAllowedOrigins returns the allowed CORS origins from the
+// CORS_ALLOWED_ORIGINS env var (comma-separated). When unset, it defaults to
+// the Vite dev server origins — production serves the SPA from the same
+// binary and needs no cross-origin access.
+func corsAllowedOrigins() []string {
+	if raw := os.Getenv("CORS_ALLOWED_ORIGINS"); raw != "" {
+		origins := []string{}
+		for _, o := range strings.Split(raw, ",") {
+			if o = strings.TrimSpace(o); o != "" {
+				origins = append(origins, o)
+			}
+		}
+		if len(origins) > 0 {
+			return origins
+		}
+	}
+	return []string{"http://localhost:5173", "http://127.0.0.1:5173"}
+}

--- a/server/internal/api/ratelimit.go
+++ b/server/internal/api/ratelimit.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// loginRateLimiter throttles /auth/login attempts per client IP.
+var loginRateLimiter = newRateLimiter(10, time.Minute)
+
+// rateLimiter is a fixed-window per-key rate limiter.
+type rateLimiter struct {
+	mu        sync.Mutex
+	limit     int
+	window    time.Duration
+	entries   map[string]*windowEntry
+	lastSweep time.Time
+	now       func() time.Time // swappable for tests
+}
+
+type windowEntry struct {
+	count       int
+	windowStart time.Time
+}
+
+func newRateLimiter(limit int, window time.Duration) *rateLimiter {
+	return &rateLimiter{
+		limit:   limit,
+		window:  window,
+		entries: make(map[string]*windowEntry),
+		now:     time.Now,
+	}
+}
+
+// allow reports whether key may make another request in the current window.
+func (rl *rateLimiter) allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := rl.now()
+	rl.sweep(now)
+
+	e, ok := rl.entries[key]
+	if !ok || now.Sub(e.windowStart) >= rl.window {
+		rl.entries[key] = &windowEntry{count: 1, windowStart: now}
+		return true
+	}
+	e.count++
+	return e.count <= rl.limit
+}
+
+// sweep drops expired entries, at most once per window. Callers must hold rl.mu.
+func (rl *rateLimiter) sweep(now time.Time) {
+	if now.Sub(rl.lastSweep) < rl.window {
+		return
+	}
+	rl.lastSweep = now
+	for key, e := range rl.entries {
+		if now.Sub(e.windowStart) >= rl.window {
+			delete(rl.entries, key)
+		}
+	}
+}
+
+// middleware rejects requests over the per-IP limit with 429 Too Many Requests.
+func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+		if !rl.allow(ip) {
+			http.Error(w, "Too many login attempts, please try again later", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/api/ratelimit_test.go
+++ b/server/internal/api/ratelimit_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRateLimiterAllowsUnderLimit(t *testing.T) {
+	rl := newRateLimiter(3, time.Minute)
+	for i := range 3 {
+		if !rl.allow("1.2.3.4") {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+}
+
+func TestRateLimiterBlocksOverLimit(t *testing.T) {
+	rl := newRateLimiter(3, time.Minute)
+	for range 3 {
+		rl.allow("1.2.3.4")
+	}
+	if rl.allow("1.2.3.4") {
+		t.Error("request over the limit should be blocked")
+	}
+	// A different key is unaffected.
+	if !rl.allow("5.6.7.8") {
+		t.Error("a different key should not be blocked")
+	}
+}
+
+func TestRateLimiterWindowResets(t *testing.T) {
+	rl := newRateLimiter(3, time.Minute)
+	current := time.Unix(1000, 0)
+	rl.now = func() time.Time { return current }
+
+	for range 3 {
+		rl.allow("1.2.3.4")
+	}
+	if rl.allow("1.2.3.4") {
+		t.Fatal("request over the limit should be blocked")
+	}
+
+	current = current.Add(time.Minute)
+	if !rl.allow("1.2.3.4") {
+		t.Error("request should be allowed after the window resets")
+	}
+}
+
+func TestRateLimiterMiddleware(t *testing.T) {
+	rl := newRateLimiter(2, time.Minute)
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := range 2 {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+		r.RemoteAddr = "1.2.3.4:5555"
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, w.Code)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	r.RemoteAddr = "1.2.3.4:5555"
+	handler.ServeHTTP(w, r)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 over the limit, got %d", w.Code)
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -45,7 +45,7 @@ func WriteJsonResponse(w http.ResponseWriter, status int, data interface{}) {
 
 func (ar *APIRouter) Routes() *chi.Mux {
 	ar.router.Use(cors.Handler(cors.Options{
-		AllowedOrigins: []string{"*"},
+		AllowedOrigins: corsAllowedOrigins(),
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders: []string{"*"},
 	}))
@@ -56,7 +56,7 @@ func (ar *APIRouter) Routes() *chi.Mux {
 		r.Get("/system/stats", ar.GetSystemStats)
 
 		// Auth endpoints (always registered, dynamic behavior)
-		r.Post("/auth/login", ar.handleLogin)
+		r.With(loginRateLimiter.middleware).Post("/auth/login", ar.handleLogin)
 
 		// Settings endpoints (follow same auth pattern as other routes)
 		ar.registerSettingsRoutes(r)

--- a/server/internal/api/settings_auth_test.go
+++ b/server/internal/api/settings_auth_test.go
@@ -25,7 +25,7 @@ func newTestRouter(t *testing.T, authSvc *auth.Service) http.Handler {
 
 	manager := config.NewManager()
 	registry := services.NewRegistry(nil, nil, authSvc, manager.Config())
-	return NewRouter(registry, manager)
+	return NewRouter(registry, manager, "test")
 }
 
 func newTestAuthService(t *testing.T) *auth.Service {

--- a/server/internal/api/settings_auth_test.go
+++ b/server/internal/api/settings_auth_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/auth"
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/services"
+)
+
+// newTestRouter builds a router with a clean env-derived config and the given
+// auth service (nil means auth disabled).
+func newTestRouter(t *testing.T, authSvc *auth.Service) http.Handler {
+	t.Helper()
+	for _, key := range []string{
+		"JWT_SECRET", "ADMIN_USERNAME", "ADMIN_PASSWORD", "ADMIN_PASSWORD_SALT",
+		"DOCKER_HOSTS", "COOLIFY_CONFIGS", "READONLY_MODE", "CORS_ALLOWED_ORIGINS",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+
+	manager := config.NewManager()
+	registry := services.NewRegistry(nil, nil, authSvc, manager.Config())
+	return NewRouter(registry, manager)
+}
+
+func newTestAuthService(t *testing.T) *auth.Service {
+	t.Helper()
+	svc := auth.NewServiceFromFileConfig(&config.FileAuthConfig{
+		Enabled:           true,
+		JWTSecret:         "test-secret",
+		AdminUsername:     "admin",
+		AdminPasswordHash: auth.HashPasswordSHA256("password", "salt"),
+		AdminPasswordSalt: "salt",
+	})
+	if svc == nil {
+		t.Fatal("failed to create auth service from file config")
+	}
+	return svc
+}
+
+func TestSettingsRejectUnauthenticatedWhenAuthEnabled(t *testing.T) {
+	router := newTestRouter(t, newTestAuthService(t))
+
+	endpoints := []struct{ method, path string }{
+		{"GET", "/api/v1/settings"},
+		{"PUT", "/api/v1/settings/docker-hosts"},
+		{"PUT", "/api/v1/settings/coolify-hosts"},
+		{"PUT", "/api/v1/settings/read-only"},
+		{"PUT", "/api/v1/settings/auth"},
+		{"POST", "/api/v1/settings/test/docker-host"},
+		{"POST", "/api/v1/settings/test/coolify-host"},
+	}
+	for _, e := range endpoints {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(e.method, e.path, nil)
+		router.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: expected 401 without token, got %d", e.method, e.path, w.Code)
+		}
+	}
+}
+
+func TestSettingsAllowAuthenticatedRequests(t *testing.T) {
+	svc := newTestAuthService(t)
+	router := newTestRouter(t, svc)
+
+	token, err := svc.GenerateToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/settings", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with valid token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSettingsAccessibleWhenAuthDisabled(t *testing.T) {
+	router := newTestRouter(t, nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/settings", nil)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with auth disabled, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/api/settings_handlers.go
+++ b/server/internal/api/settings_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -110,8 +111,8 @@ func (ar *APIRouter) UpdateDockerHosts(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("invalid host name: %q", h.Name), http.StatusBadRequest)
 			return
 		}
-		if !isValidHostScheme(h.Host) {
-			http.Error(w, fmt.Sprintf("invalid host URL: %q (must start with unix://, ssh://, or tcp://)", h.Host), http.StatusBadRequest)
+		if !isValidDockerHostURL(h.Host) {
+			http.Error(w, fmt.Sprintf("invalid host URL: %q (must be a valid unix://, ssh://, or tcp:// URL)", h.Host), http.StatusBadRequest)
 			return
 		}
 		if seen[h.Name] {
@@ -286,8 +287,8 @@ func (ar *APIRouter) TestDockerHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !isValidHostScheme(req.Host) {
-		http.Error(w, "invalid host URL (must start with unix://, ssh://, or tcp://)", http.StatusBadRequest)
+	if !isValidDockerHostURL(req.Host) {
+		http.Error(w, "invalid host URL (must be a valid unix://, ssh://, or tcp:// URL)", http.StatusBadRequest)
 		return
 	}
 
@@ -397,10 +398,19 @@ func settingsErrorStatus(err error) int {
 	return http.StatusInternalServerError
 }
 
-func isValidHostScheme(host string) bool {
-	return strings.HasPrefix(host, "unix://") ||
-		strings.HasPrefix(host, "ssh://") ||
-		strings.HasPrefix(host, "tcp://")
+func isValidDockerHostURL(host string) bool {
+	u, err := url.Parse(host)
+	if err != nil {
+		return false
+	}
+	switch u.Scheme {
+	case "unix":
+		return u.Path != "" || u.Opaque != ""
+	case "ssh", "tcp":
+		return u.Host != ""
+	default:
+		return false
+	}
 }
 
 func isValidCoolifyURL(raw string) bool {

--- a/server/internal/api/terminal.go
+++ b/server/internal/api/terminal.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/go-chi/chi/v5"
@@ -14,9 +16,22 @@ import (
 )
 
 var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool {
-		return true // Allow all origins for now, similar to CORS
-	},
+	CheckOrigin: checkWebSocketOrigin,
+}
+
+// checkWebSocketOrigin allows non-browser clients (no Origin header) and
+// browser requests whose Origin host matches the request Host, preventing
+// cross-site WebSocket hijacking.
+func checkWebSocketOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Host, r.Host)
 }
 
 type ResizeMessage struct {
@@ -55,12 +70,23 @@ func (ar *APIRouter) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Close()
 
-	done := make(chan struct{})
+	outputDone := make(chan struct{})
+	inputDone := make(chan struct{})
 
-	go streamContainerOutput(resp.Reader, ws, done)
-	go ar.forwardClientInput(ctx, host, execID, resp.Conn, io.NopCloser(resp.Conn), ws)
+	go streamContainerOutput(resp.Reader, ws, outputDone)
+	go func() {
+		defer close(inputDone)
+		// resp.Conn doubles as the closer: closing it on client disconnect
+		// tears down the container stream and unblocks resp.Reader.
+		ar.forwardClientInput(ctx, host, execID, resp.Conn, resp.Conn, ws)
+	}()
 
-	<-done
+	// Return when either direction finishes; the deferred ws.Close and
+	// resp.Close tear down the other side.
+	select {
+	case <-outputDone:
+	case <-inputDone:
+	}
 }
 
 func (ar *APIRouter) startExecSession(ctx context.Context, host, containerID string) (string, *types.HijackedResponse, error) {

--- a/server/internal/api/terminal_test.go
+++ b/server/internal/api/terminal_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckWebSocketOrigin(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		origin string
+		want   bool
+	}{
+		{"no origin (non-browser client)", "localhost:8080", "", true},
+		{"matching origin", "localhost:8080", "http://localhost:8080", true},
+		{"matching origin case-insensitive", "localhost:8080", "http://LOCALHOST:8080", true},
+		{"different host", "localhost:8080", "http://evil.example.com", false},
+		{"different port", "localhost:8080", "http://localhost:9999", false},
+		{"origin without host", "localhost:8080", "null", false},
+		{"unparseable origin", "localhost:8080", "http://[::1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/api/v1/containers/abc/exec", nil)
+			r.Host = tt.host
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			if got := checkWebSocketOrigin(r); got != tt.want {
+				t.Errorf("checkWebSocketOrigin(host=%q, origin=%q) = %v, want %v", tt.host, tt.origin, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -21,7 +21,7 @@ var (
 	ErrInvalidToken        = errors.New("invalid token")
 	ErrTokenExpired        = errors.New("token has expired")
 	ErrMissingEnvVars      = errors.New("missing required environment variables")
-	ErrInvalidPasswordHash = errors.New("ADMIN_PASSWORD must be a valid bcrypt hash. Generate one using: cd server/scripts && go run hash-password.go yourPassword")
+	ErrInvalidPasswordHash = errors.New("ADMIN_PASSWORD must be a valid bcrypt hash. Generate one with: htpasswd -bnBC 10 '' yourPassword | tr -d ':'")
 )
 
 type Service struct {
@@ -54,6 +54,14 @@ func NewService() (*Service, error) {
 	// If some but not all are set, return an error
 	if jwtSecret == "" || adminUsername == "" || (adminPasswordHash == "" && sha256Salt == "") {
 		return nil, ErrMissingEnvVars
+	}
+
+	// Without a salt, the password must be a bcrypt hash; validate it up
+	// front so a malformed hash fails at startup instead of on every login.
+	if sha256Salt == "" {
+		if _, err := bcrypt.Cost([]byte(adminPasswordHash)); err != nil {
+			return nil, ErrInvalidPasswordHash
+		}
 	}
 
 	return &Service{

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -3,9 +3,11 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/config"
@@ -63,18 +65,31 @@ func NewService() (*Service, error) {
 	}, nil
 }
 
-// ValidateCredentials checks if the provided credentials are valid
+// ValidateCredentials checks if the provided credentials are valid.
+// Bcrypt hashes (env-configured) and SHA256+salt hashes (file-configured)
+// are both supported.
 func (s *Service) ValidateCredentials(username, password string) error {
-	if username != s.adminUsername {
-		return ErrInvalidCredentials
+	usernameMatch := subtle.ConstantTimeCompare([]byte(username), []byte(s.adminUsername)) == 1
+
+	var passwordMatch bool
+	if isBcryptHash(s.adminPasswordHash) {
+		passwordMatch = bcrypt.CompareHashAndPassword([]byte(s.adminPasswordHash), []byte(password)) == nil
+	} else {
+		hash := HashPasswordSHA256(password, s.sha256Salt)
+		passwordMatch = subtle.ConstantTimeCompare([]byte(hash), []byte(s.adminPasswordHash)) == 1
 	}
 
-	hash := sha256.Sum256([]byte(password + s.sha256Salt))
-	if hex.EncodeToString(hash[:]) != s.adminPasswordHash {
+	if !usernameMatch || !passwordMatch {
 		return ErrInvalidCredentials
 	}
 
 	return nil
+}
+
+func isBcryptHash(hash string) bool {
+	return strings.HasPrefix(hash, "$2a$") ||
+		strings.HasPrefix(hash, "$2b$") ||
+		strings.HasPrefix(hash, "$2y$")
 }
 
 // GenerateToken creates a new JWT token for the user

--- a/server/internal/auth/service_test.go
+++ b/server/internal/auth/service_test.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateCredentialsBcrypt(t *testing.T) {
+	hash, err := HashPassword("correct-password")
+	if err != nil {
+		t.Fatalf("HashPassword failed: %v", err)
+	}
+
+	s := &Service{
+		adminUsername:     "admin",
+		adminPasswordHash: hash,
+	}
+
+	if err := s.ValidateCredentials("admin", "correct-password"); err != nil {
+		t.Errorf("expected valid bcrypt credentials to pass, got: %v", err)
+	}
+
+	if err := s.ValidateCredentials("admin", "wrong-password"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("expected ErrInvalidCredentials for wrong password, got: %v", err)
+	}
+
+	if err := s.ValidateCredentials("intruder", "correct-password"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("expected ErrInvalidCredentials for wrong username, got: %v", err)
+	}
+}
+
+func TestValidateCredentialsSHA256(t *testing.T) {
+	salt := "test-salt"
+	s := &Service{
+		adminUsername:     "admin",
+		adminPasswordHash: HashPasswordSHA256("correct-password", salt),
+		sha256Salt:        salt,
+	}
+
+	if err := s.ValidateCredentials("admin", "correct-password"); err != nil {
+		t.Errorf("expected valid SHA256 credentials to pass, got: %v", err)
+	}
+
+	if err := s.ValidateCredentials("admin", "wrong-password"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("expected ErrInvalidCredentials for wrong password, got: %v", err)
+	}
+
+	if err := s.ValidateCredentials("intruder", "correct-password"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("expected ErrInvalidCredentials for wrong username, got: %v", err)
+	}
+}
+
+func TestIsBcryptHash(t *testing.T) {
+	for _, hash := range []string{"$2a$10$abc", "$2b$10$abc", "$2y$10$abc"} {
+		if !isBcryptHash(hash) {
+			t.Errorf("expected %q to be detected as bcrypt", hash)
+		}
+	}
+	for _, hash := range []string{"", "abc123", "$1$notbcrypt", "e3b0c44298fc1c149afbf4c8996fb924"} {
+		if isBcryptHash(hash) {
+			t.Errorf("expected %q to not be detected as bcrypt", hash)
+		}
+	}
+}

--- a/server/internal/auth/service_test.go
+++ b/server/internal/auth/service_test.go
@@ -50,6 +50,30 @@ func TestValidateCredentialsSHA256(t *testing.T) {
 	}
 }
 
+func TestNewServiceRejectsMalformedBcryptHash(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+	t.Setenv("ADMIN_USERNAME", "admin")
+	t.Setenv("ADMIN_PASSWORD_SALT", "")
+
+	t.Setenv("ADMIN_PASSWORD", "not-a-bcrypt-hash")
+	if _, err := NewService(); !errors.Is(err, ErrInvalidPasswordHash) {
+		t.Errorf("expected ErrInvalidPasswordHash for malformed hash, got: %v", err)
+	}
+
+	hash, err := HashPassword("password")
+	if err != nil {
+		t.Fatalf("HashPassword failed: %v", err)
+	}
+	t.Setenv("ADMIN_PASSWORD", hash)
+	svc, err := NewService()
+	if err != nil {
+		t.Errorf("expected valid bcrypt hash to be accepted, got: %v", err)
+	}
+	if svc == nil {
+		t.Error("expected a service for a valid bcrypt hash")
+	}
+}
+
 func TestIsBcryptHash(t *testing.T) {
 	for _, hash := range []string{"$2a$10$abc", "$2b$10$abc", "$2y$10$abc"} {
 		if !isBcryptHash(hash) {

--- a/server/internal/docker/exec.go
+++ b/server/internal/docker/exec.go
@@ -66,6 +66,3 @@ func (c *MultiHostClient) ResizeExec(ctx context.Context, host, execID string, h
 	})
 }
 
-// GetClientExport exposes GetClient for use in other packages if needed
-// although it is already exported in client.go, this is just a comment reminder
-


### PR DESCRIPTION
## Summary

Security batch for the Go server. Stacked on #63 (base branch is server-robustness); merge that PR first, then this one retargets to main automatically.

- Terminal WebSocket: a browser disconnect now tears down the hijacked Docker exec connection (the closer was an io.NopCloser, leaking a goroutine, the TCP connection, and the exec session per abandoned terminal). The handler also returns when either direction finishes, and the upgrader now validates the Origin header (same-host browsers and non-browser clients allowed) instead of accepting any origin.
- Authentication: ValidateCredentials now verifies bcrypt hashes ($2a$/$2b$/$2y$) with bcrypt.CompareHashAndPassword - previously env.example instructed users to supply a bcrypt hash that could never validate because only SHA256 was checked. The SHA256+salt path is kept for UI-driven file config. Username and hash comparisons use constant-time comparison.
- CORS: allowed origins come from CORS_ALLOWED_ORIGINS (comma-separated), defaulting to the Vite dev server origins instead of *. Documented in env.example.
- Login rate limiting: self-contained per-IP fixed-window limiter (10/minute, 429 on excess) on /auth/login.
- Docker host validation: settings updates now parse host URLs with url.Parse, requiring a host for ssh/tcp schemes and a socket path for unix, in both UpdateDockerHosts and TestDockerHost.
- Settings routes were verified to already be auth-gated; added httptest coverage (401 without a token on all seven settings endpoints, 200 with a valid token, 200 when auth is disabled).

## Tests

12 new test functions across auth service (bcrypt/SHA256 paths), origin checking, the rate limiter (window reset via injected clock), and settings auth. go build, go vet, and go test ./... pass on the combined tree with server-robustness merged in.

https://claude.ai/code/session_01Ksbg2abvq4FA4DrsYjnDoi