### PR TITLE
fix(frontend): keep container states live on dashboard and detail pages

### DIFF
--- a/frontend/src/features/containers/components/containers-dashboard.tsx
+++ b/frontend/src/features/containers/components/containers-dashboard.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -20,9 +20,8 @@ import {
   startContainer,
   stopContainer,
 } from "../api/container-actions";
-import { useContainerEvents } from "../hooks/use-container-events";
 import { useContainersDashboardUrlState } from "../hooks/use-containers-dashboard-url-state";
-import { useContainersQuery } from "../hooks/use-containers-query";
+import { useLiveContainersQuery } from "../hooks/use-live-containers-query";
 import { useContainerStats } from "../hooks/use-container-stats";
 import { useSystemStats } from "../hooks/use-system-stats";
 
@@ -47,40 +46,10 @@ import type {
   SortDirection,
 } from "./container-utils";
 
-const EVENT_INVALIDATE_DEBOUNCE_MS = 300;
-
 export function ContainersDashboard() {
   const queryClient = useQueryClient();
-
-  // Invalidate the containers query on lifecycle events, debounced so an
-  // event burst doesn't stampede refetches.
-  const invalidateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
-  const handleContainerEvent = useCallback(() => {
-    if (invalidateTimeoutRef.current !== null) return;
-    invalidateTimeoutRef.current = setTimeout(() => {
-      invalidateTimeoutRef.current = null;
-      void queryClient.invalidateQueries({
-        queryKey: ["containers"],
-        exact: true,
-      });
-    }, EVENT_INVALIDATE_DEBOUNCE_MS);
-  }, [queryClient]);
-
-  useEffect(() => {
-    return () => {
-      if (invalidateTimeoutRef.current !== null) {
-        clearTimeout(invalidateTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const { isConnected: isEventStreamConnected } =
-    useContainerEvents(handleContainerEvent);
-
   const { data, error, isError, isFetching, isLoading, refetch } =
-    useContainersQuery({ eventsConnected: isEventStreamConnected });
+    useLiveContainersQuery();
   const { data: systemStats } = useSystemStats();
   const { statsMap } = useContainerStats();
 

--- a/frontend/src/features/containers/hooks/use-containers-query.ts
+++ b/frontend/src/features/containers/hooks/use-containers-query.ts
@@ -13,8 +13,8 @@ export function useContainersQuery({
     queryKey: ["containers"],
     queryFn: getContainers,
     staleTime: 30_000,
-    // With the event stream connected, updates are pushed; polling is only a
-    // slow safety net.
-    refetchInterval: eventsConnected ? 60_000 : undefined,
+    // With the event stream connected, updates are pushed and polling is only
+    // a slow safety net; when disconnected, polling carries the updates.
+    refetchInterval: eventsConnected ? 60_000 : 30_000,
   });
 }

--- a/frontend/src/features/containers/hooks/use-live-containers-query.ts
+++ b/frontend/src/features/containers/hooks/use-live-containers-query.ts
@@ -1,0 +1,42 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef } from "react";
+
+import { useContainerEvents } from "./use-container-events";
+import { useContainersQuery } from "./use-containers-query";
+
+const EVENT_INVALIDATE_DEBOUNCE_MS = 300;
+
+/**
+ * Containers query kept fresh by the container event stream: lifecycle
+ * events invalidate the query (debounced so an event burst doesn't stampede
+ * refetches), with polling as fallback while the stream is disconnected.
+ */
+export function useLiveContainersQuery() {
+  const queryClient = useQueryClient();
+  const invalidateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  const handleContainerEvent = useCallback(() => {
+    if (invalidateTimeoutRef.current !== null) return;
+    invalidateTimeoutRef.current = setTimeout(() => {
+      invalidateTimeoutRef.current = null;
+      void queryClient.invalidateQueries({
+        queryKey: ["containers"],
+        exact: true,
+      });
+    }, EVENT_INVALIDATE_DEBOUNCE_MS);
+  }, [queryClient]);
+
+  useEffect(() => {
+    return () => {
+      if (invalidateTimeoutRef.current !== null) {
+        clearTimeout(invalidateTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const { isConnected } = useContainerEvents(handleContainerEvent);
+
+  return useContainersQuery({ eventsConnected: isConnected });
+}

--- a/frontend/src/routes/containers/$containerId/logs.tsx
+++ b/frontend/src/routes/containers/$containerId/logs.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
@@ -66,7 +66,6 @@ import {
 	getLogLevelBadgeColor,
 	streamContainerLogsParsed,
 } from "@/features/containers/api/get-container-logs-parsed";
-import { getContainers } from "@/features/containers/api/get-containers";
 import { CollapsibleJson } from "@/features/containers/components/collapsible-json";
 import {
 	formatContainerName,
@@ -83,6 +82,7 @@ import { SelectionActionBar } from "@/features/containers/components/selection-a
 import { Terminal } from "@/features/containers/components/terminal";
 import { useContainerLogStream } from "@/features/containers/hooks/use-container-log-stream";
 import { useContainerStats } from "@/features/containers/hooks/use-container-stats";
+import { useLiveContainersQuery } from "@/features/containers/hooks/use-live-containers-query";
 import { requireAuthIfEnabled } from "@/lib/auth-guard";
 import { isJsonString } from "@/lib/json-format";
 import { escapeRegExp } from "@/lib/utils";
@@ -155,10 +155,7 @@ function ContainerLogsPage() {
 	const containerIdentifier = decodeURIComponent(encodedContainerId);
 
 	// Fetch container info
-	const { data: containersData } = useQuery({
-		queryKey: ["containers"],
-		queryFn: getContainers,
-	});
+	const { data: containersData } = useLiveContainersQuery();
 	const { statsMap } = useContainerStats();
 
 	const containers = containersData?.containers ?? [];


### PR DESCRIPTION
## Summary

Fixes #61. Follow-up to #65 completing the fix for it (container states only changed on page refresh):

- The fallback polling was inverted: the containers query polled every 60s only while the event stream was connected, and not at all when disconnected - which is exactly when polling matters. It now polls every 30s while the event stream is down and keeps the 60s safety net while connected.
- The container detail page had its own containers query with no event-driven invalidation, so it stayed stale even after #65. The event wiring (stream subscription, debounced invalidation, fallback poll) is extracted into a shared useLiveContainersQuery hook used by both the dashboard and the detail page.

## Verification

tsc --noEmit, biome lint, and production build all pass.

https://claude.ai/code/session_01Ksbg2abvq4FA4DrsYjnDoi
