### PR TITLE
fix: tear down and auto-recover log streams when the Docker daemon dies

### DIFF
--- a/frontend/src/features/containers/api/get-container-logs-parsed.ts
+++ b/frontend/src/features/containers/api/get-container-logs-parsed.ts
@@ -30,6 +30,22 @@ export interface ContainerLogsParsedResponse {
   count: number;
 }
 
+// Liveness line the server writes on quiet follow streams. Never displayed;
+// consumers use it to tell a quiet stream from a dead one.
+export interface LogStreamHeartbeat {
+  type: "heartbeat";
+}
+
+export function isLogStreamHeartbeat(
+  value: unknown
+): value is LogStreamHeartbeat {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "heartbeat"
+  );
+}
+
 export interface ContainerLogsOptions {
   since?: string;
   until?: string;
@@ -114,7 +130,7 @@ export async function* streamContainerLogsParsed(
   host: string,
   options?: ContainerLogsOptions,
   signal?: AbortSignal
-): AsyncGenerator<LogEntry, void, unknown> {
+): AsyncGenerator<LogEntry | LogStreamHeartbeat, void, unknown> {
   const streamOptions = { ...options, follow: true };
   const response = await authenticatedFetch(buildLogsUrl(id, host, streamOptions), {
     headers: {
@@ -134,7 +150,7 @@ export async function* streamContainerLogsParsed(
     throw new Error("Streaming is not supported in this environment.");
   }
 
-  for await (const entry of iterateNDJSONStream<LogEntry>(
+  for await (const entry of iterateNDJSONStream<LogEntry | LogStreamHeartbeat>(
     response.body,
     signal
   )) {

--- a/frontend/src/features/containers/components/log-viewer/log-viewer.tsx
+++ b/frontend/src/features/containers/components/log-viewer/log-viewer.tsx
@@ -190,6 +190,7 @@ export function LogViewer({
 		droppedCount,
 		fetchLogs,
 		isLoadingLogs,
+		isReconnecting,
 		isStreamPaused,
 		isStreaming,
 		logs: rawLogs,
@@ -883,6 +884,11 @@ export function LogViewer({
 						className="h-8 w-20 text-xs"
 					/>
 				</div>
+				{isReconnecting && (
+					<span className="shrink-0 text-xs text-muted-foreground animate-pulse">
+						Reconnecting…
+					</span>
+				)}
 				<Button
 					variant="outline"
 					size="sm"
@@ -1070,6 +1076,11 @@ export function LogViewer({
 
 				{/* Controls: log level, time range, stream, auto-scroll, overflow */}
 				<div className="flex items-center gap-1 shrink-0">
+					{isReconnecting && (
+						<span className="shrink-0 text-xs text-muted-foreground animate-pulse">
+							Reconnecting…
+						</span>
+					)}
 					{levelFilterPopover}
 
 					<TimeRangeControl

--- a/frontend/src/features/containers/hooks/use-container-log-stream.test.ts
+++ b/frontend/src/features/containers/hooks/use-container-log-stream.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { LogStreamHeartbeat } from "@/features/containers/api/get-container-logs-parsed";
+
 import { useContainerLogStream } from "./use-container-log-stream";
 
 interface TestEntry {
@@ -9,14 +11,16 @@ interface TestEntry {
 }
 
 const entry = (id: number): TestEntry => ({ id, message: `line ${id}` });
+const heartbeat = (): LogStreamHeartbeat => ({ type: "heartbeat" });
 
-// A push-controlled async generator standing in for the NDJSON stream.
+// A push-controlled async generator standing in for the NDJSON stream. Like a
+// real fetch stream, a pending read ends when the signal aborts.
 function createControlledStream() {
-	const queue: TestEntry[] = [];
+	const queue: (TestEntry | LogStreamHeartbeat)[] = [];
 	let notify: (() => void) | null = null;
 	let ended = false;
 
-	const push = (...entries: TestEntry[]) => {
+	const push = (...entries: (TestEntry | LogStreamHeartbeat)[]) => {
 		queue.push(...entries);
 		notify?.();
 		notify = null;
@@ -28,16 +32,20 @@ function createControlledStream() {
 		notify = null;
 	};
 
-	async function* stream(): AsyncGenerator<TestEntry, void, unknown> {
+	async function* stream(
+		signal?: AbortSignal
+	): AsyncGenerator<TestEntry | LogStreamHeartbeat, void, unknown> {
 		while (true) {
 			while (queue.length > 0) {
 				const next = queue.shift();
 				if (next) yield next;
 			}
-			if (ended) return;
+			if (ended || signal?.aborted) return;
 			await new Promise<void>((resolve) => {
 				notify = resolve;
+				signal?.addEventListener("abort", () => resolve(), { once: true });
 			});
+			if (signal?.aborted) return;
 		}
 	}
 
@@ -56,6 +64,14 @@ function setup(options?: { maxLogLines?: number }) {
 	const controlled = createControlledStream();
 	const scrollToBottom = vi.fn();
 	const renderCount = { current: 0 };
+	const streamLogs = vi.fn(
+		(
+			_id: string,
+			_host: string,
+			_options: unknown,
+			signal: AbortSignal
+		) => controlled.stream(signal)
+	);
 
 	const hook = renderHook(() => {
 		renderCount.current += 1;
@@ -65,12 +81,12 @@ function setup(options?: { maxLogLines?: number }) {
 			tail: 100,
 			maxLogLines: options?.maxLogLines,
 			getLogs: vi.fn().mockResolvedValue([]),
-			streamLogs: () => controlled.stream(),
+			streamLogs,
 			scrollToBottom,
 		});
 	});
 
-	return { ...hook, controlled, scrollToBottom, renderCount };
+	return { ...hook, controlled, scrollToBottom, renderCount, streamLogs };
 }
 
 describe("useContainerLogStream", () => {
@@ -236,5 +252,85 @@ describe("useContainerLogStream", () => {
 		expect(result.current.isStreamPaused).toBe(false);
 		expect(result.current.bufferedCount).toBe(0);
 		expect(result.current.logs.map((e) => e.id)).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it("aborts a silent stream after the idle timeout and reconnects with backoff", async () => {
+		const { result, controlled, streamLogs } = setup();
+
+		await act(async () => {
+			void result.current.startStreaming();
+			controlled.push(entry(1));
+			await drainMicrotasks();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(100);
+		});
+		expect(result.current.logs.map((e) => e.id)).toEqual([1]);
+		expect(streamLogs).toHaveBeenCalledTimes(1);
+
+		// Silence past the 45s idle timeout: the watchdog aborts the session
+		// and schedules a reconnect.
+		await act(async () => {
+			vi.advanceTimersByTime(45_100);
+			await drainMicrotasks();
+		});
+		expect(result.current.isReconnecting).toBe(true);
+		expect(result.current.isStreaming).toBe(true);
+		expect(streamLogs).toHaveBeenCalledTimes(1); // still in the 1s backoff
+
+		await act(async () => {
+			vi.advanceTimersByTime(1_000);
+			await drainMicrotasks();
+		});
+		expect(streamLogs).toHaveBeenCalledTimes(2);
+
+		// Data on the new session clears the reconnecting state and appends
+		// without wiping what was already displayed.
+		await act(async () => {
+			controlled.push(entry(2));
+			await drainMicrotasks();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(100);
+		});
+		expect(result.current.isReconnecting).toBe(false);
+		expect(result.current.logs.map((e) => e.id)).toEqual([1, 2]);
+
+		act(() => {
+			result.current.stopStreaming();
+		});
+		expect(result.current.isStreaming).toBe(false);
+	});
+
+	it("skips heartbeats as log rows while they reset the idle timer", async () => {
+		const { result, controlled, streamLogs } = setup();
+
+		await act(async () => {
+			void result.current.startStreaming();
+			controlled.push(entry(1));
+			await drainMicrotasks();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(100);
+		});
+		expect(result.current.logs.map((e) => e.id)).toEqual([1]);
+
+		// 30s of silence, then a heartbeat, then 30s more: 60s total without
+		// entries, but the heartbeat keeps the stream alive.
+		await act(async () => {
+			vi.advanceTimersByTime(30_000);
+			controlled.push(heartbeat());
+			await drainMicrotasks();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(30_000);
+			await drainMicrotasks();
+		});
+
+		expect(streamLogs).toHaveBeenCalledTimes(1); // no reconnect happened
+		expect(result.current.isReconnecting).toBe(false);
+		expect(result.current.isStreaming).toBe(true);
+		// The heartbeat never shows up as a rendered row.
+		expect(result.current.logs.map((e) => e.id)).toEqual([1]);
 	});
 });

--- a/frontend/src/features/containers/hooks/use-container-log-stream.ts
+++ b/frontend/src/features/containers/hooks/use-container-log-stream.ts
@@ -1,9 +1,32 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { ContainerLogsOptions } from "@/features/containers/api/get-container-logs-parsed";
+import {
+  type ContainerLogsOptions,
+  isLogStreamHeartbeat,
+  type LogStreamHeartbeat,
+} from "@/features/containers/api/get-container-logs-parsed";
 
 export const DEFAULT_MAX_LOG_LINES = 10000;
 const STREAM_FLUSH_INTERVAL_MS = 100;
+// A live stream silent past this (no entries, no server heartbeats) is
+// presumed dead and gets aborted so the stream loop reconnects. The server
+// heartbeats every ~15s, so a healthy-but-quiet stream never trips this.
+const STREAM_IDLE_TIMEOUT_MS = 45_000;
+const RECONNECT_MIN_DELAY_MS = 1_000;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+
+// Resolves after ms, or immediately when the signal aborts.
+function waitWithSignal(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(onDone, ms);
+    function onDone() {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onDone);
+      resolve();
+    }
+    signal.addEventListener("abort", onDone);
+  });
+}
 
 interface UseContainerLogStreamOptions<TLogEntry> {
   containerId?: string;
@@ -25,7 +48,7 @@ interface UseContainerLogStreamOptions<TLogEntry> {
     host: string,
     options: ContainerLogsOptions,
     signal: AbortSignal
-  ) => AsyncGenerator<TLogEntry, void, unknown>;
+  ) => AsyncGenerator<TLogEntry | LogStreamHeartbeat, void, unknown>;
   scrollToBottom: (behavior?: ScrollBehavior) => void;
   onResetState?: () => void;
   onFetchError?: (error: Error) => void;
@@ -50,6 +73,7 @@ export function useContainerLogStream<TLogEntry>({
   const [logs, setLogs] = useState<TLogEntry[]>([]);
   const [isLoadingLogs, setIsLoadingLogs] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const [isStreamPaused, setIsStreamPaused] = useState(false);
   const [bufferedCount, setBufferedCount] = useState(0);
   const [droppedCount, setDroppedCount] = useState(0);
@@ -60,6 +84,8 @@ export function useContainerLogStream<TLogEntry>({
   } | null>(null);
 
   const abortControllerRef = useRef<AbortController | null>(null);
+  const stopRequestedRef = useRef(false);
+  const lastActivityRef = useRef(0);
   const isStreamPausedRef = useRef(false);
   const bufferedLogsRef = useRef<TLogEntry[]>([]);
   const pendingLogsRef = useRef<TLogEntry[]>([]);
@@ -212,6 +238,15 @@ export function useContainerLogStream<TLogEntry>({
   }, [recordBufferedDroppedLines]);
 
   const handleFlushTick = useCallback(() => {
+    // Idle watchdog: abort a stream that has gone silent past the timeout so
+    // the loop in startStreaming reconnects. Aborting an already-aborted
+    // controller is a no-op.
+    if (
+      abortControllerRef.current &&
+      Date.now() - lastActivityRef.current > STREAM_IDLE_TIMEOUT_MS
+    ) {
+      abortControllerRef.current.abort();
+    }
     if (isStreamPausedRef.current) {
       syncBufferedLogs();
       return;
@@ -284,12 +319,14 @@ export function useContainerLogStream<TLogEntry>({
   ]);
 
   const stopStreaming = useCallback(() => {
+    stopRequestedRef.current = true;
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
       abortControllerRef.current = null;
     }
     resetPauseAndBuffer();
     setIsStreaming(false);
+    setIsReconnecting(false);
   }, [resetPauseAndBuffer]);
 
   const startStreaming = useCallback(async () => {
@@ -304,45 +341,86 @@ export function useContainerLogStream<TLogEntry>({
     logsLengthRef.current = 0;
     pendingLogsRef.current = [];
 
+    stopRequestedRef.current = false;
+    let abortController: AbortController | null = null;
+    let hasReceivedFirstEntry = false;
+
+    stopFlushInterval();
+    flushIntervalRef.current = setInterval(handleFlushTick, STREAM_FLUSH_INTERVAL_MS);
+
     try {
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
+      // One iteration per connection. A session that ends or errors without
+      // the user stopping it is retried with capped exponential backoff;
+      // receiving anything (entry or heartbeat) resets the backoff.
+      for (let attempt = 0; ; attempt++) {
+        abortController = new AbortController();
+        abortControllerRef.current = abortController;
+        lastActivityRef.current = Date.now();
 
-      const stream = streamLogsRef.current(
-        containerId,
-        host,
-        { tail, search },
-        abortController.signal
-      );
-      let hasReceivedFirstEntry = false;
+        if (attempt > 0) {
+          setIsReconnecting(true);
+          await waitWithSignal(
+            Math.min(RECONNECT_MIN_DELAY_MS * 2 ** (attempt - 1), RECONNECT_MAX_DELAY_MS),
+            abortController.signal
+          );
+          if (stopRequestedRef.current || abortController.signal.aborted) {
+            break;
+          }
+        }
 
-      stopFlushInterval();
-      flushIntervalRef.current = setInterval(handleFlushTick, STREAM_FLUSH_INTERVAL_MS);
+        try {
+          const stream = streamLogsRef.current(
+            containerId,
+            host,
+            // Reconnects follow from "now" so lines already on screen are
+            // not re-fetched and duplicated.
+            { tail: attempt === 0 ? tail : 0, search },
+            abortController.signal
+          );
 
-      for await (const entry of stream) {
-        if (abortController.signal.aborted) {
+          for await (const item of stream) {
+            if (abortController.signal.aborted) {
+              break;
+            }
+
+            lastActivityRef.current = Date.now();
+            attempt = 0;
+            setIsReconnecting(false);
+
+            if (!hasReceivedFirstEntry) {
+              hasReceivedFirstEntry = true;
+              setIsLoadingLogs(false);
+            }
+
+            if (isLogStreamHeartbeat(item)) {
+              continue;
+            }
+            const entry = item as TLogEntry;
+
+            if (isStreamPausedRef.current) {
+              bufferedLogsRef.current.push(entry);
+              continue;
+            }
+
+            pendingLogsRef.current.push(entry);
+          }
+        } catch (error) {
+          if (error instanceof Error) {
+            const message = error.message.toLowerCase();
+            const isAbort =
+              error.name === "AbortError" || message.includes("aborted");
+            // Reconnect attempts fail quietly; isReconnecting is the signal.
+            if (!isAbort && attempt === 0) {
+              onStreamErrorRef.current?.(error);
+            }
+          }
+        }
+
+        if (
+          stopRequestedRef.current ||
+          abortControllerRef.current !== abortController
+        ) {
           break;
-        }
-
-        if (!hasReceivedFirstEntry) {
-          hasReceivedFirstEntry = true;
-          setIsLoadingLogs(false);
-        }
-
-        if (isStreamPausedRef.current) {
-          bufferedLogsRef.current.push(entry);
-          continue;
-        }
-
-        pendingLogsRef.current.push(entry);
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        const message = error.message.toLowerCase();
-        const isAbort =
-          error.name === "AbortError" || message.includes("aborted");
-        if (!isAbort) {
-          onStreamErrorRef.current?.(error);
         }
       }
     } finally {
@@ -350,7 +428,10 @@ export function useContainerLogStream<TLogEntry>({
       flushPendingLogs();
       setIsLoadingLogs(false);
       setIsStreaming(false);
-      abortControllerRef.current = null;
+      setIsReconnecting(false);
+      if (abortControllerRef.current === abortController) {
+        abortControllerRef.current = null;
+      }
     }
   }, [
     containerId,
@@ -410,6 +491,7 @@ export function useContainerLogStream<TLogEntry>({
     droppedCount,
     fetchLogs,
     isLoadingLogs,
+    isReconnecting,
     isStreamPaused,
     isStreaming,
     logs,

--- a/server/internal/docker/logs.go
+++ b/server/internal/docker/logs.go
@@ -3,14 +3,28 @@ package docker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
+)
+
+// Follow-mode liveness monitor knobs. A daemon that dies without closing the
+// socket leaves StdCopy blocked forever (issue #53); each monitor tick emits a
+// heartbeat if nothing was written since the previous tick (so the client can
+// tell a quiet stream from a dead one) and pings the daemon so a dead socket
+// tears the stream down instead of hanging.
+const (
+	monitorInterval = 15 * time.Second
+	pingTimeout     = 3 * time.Second
+	maxPingFailures = 2
 )
 
 // parseDockerLogs parses the Docker log stream into structured entries,
@@ -112,6 +126,7 @@ type streamingLogWriter struct {
 	pipeWriter  *io.PipeWriter
 	levelFilter string
 	searchRegex *regexp.Regexp
+	wroteEntry  *atomic.Bool // set on each encoded entry; monitor clears it per tick
 }
 
 func (w *streamingLogWriter) Write(p []byte) (n int, err error) {
@@ -175,6 +190,9 @@ func (w *streamingLogWriter) emit(line string) error {
 	}
 
 	w.encoderMu.Lock()
+	// Set before Encode (which blocks on the pipe) so a monitor tick during
+	// the write already counts it as activity.
+	w.wroteEntry.Store(true)
 	err := w.encoder.Encode(entry)
 	w.encoderMu.Unlock()
 
@@ -232,6 +250,19 @@ func (c *MultiHostClient) StreamContainerLogsParsed(ctx context.Context, hostNam
 		return nil, err
 	}
 
+	ping := func(ctx context.Context) error {
+		_, err := apiClient.Ping(ctx)
+		return err
+	}
+	return newParsedLogStream(ctx, logs, options, ping, nil), nil
+}
+
+// newParsedLogStream parses the raw Docker log stream into NDJSON on a pipe.
+// When following, a monitor goroutine keeps the stream honest: heartbeats on
+// quiet intervals and teardown when the daemon stops answering pings. tick
+// overrides the monitor cadence in tests; nil means a real time.Ticker at
+// monitorInterval.
+func newParsedLogStream(ctx context.Context, logs io.ReadCloser, options models.LogOptions, ping func(context.Context) error, tick <-chan time.Time) io.ReadCloser {
 	pipeReader, pipeWriter := io.Pipe()
 
 	var searchRegex *regexp.Regexp
@@ -239,31 +270,81 @@ func (c *MultiHostClient) StreamContainerLogsParsed(ctx context.Context, hostNam
 		searchRegex, _ = regexp.Compile(options.Search) // already validated by handler
 	}
 
+	encoder := json.NewEncoder(pipeWriter)
+	var mu sync.Mutex
+	var wroteEntry atomic.Bool
+
+	stdout := &streamingLogWriter{
+		stream:      "stdout",
+		encoder:     encoder,
+		encoderMu:   &mu,
+		pipeWriter:  pipeWriter,
+		levelFilter: options.Level,
+		searchRegex: searchRegex,
+		wroteEntry:  &wroteEntry,
+	}
+	stderr := &streamingLogWriter{
+		stream:      "stderr",
+		encoder:     encoder,
+		encoderMu:   &mu,
+		pipeWriter:  pipeWriter,
+		levelFilter: options.Level,
+		searchRegex: searchRegex,
+		wroteEntry:  &wroteEntry,
+	}
+
+	done := make(chan struct{})
+
+	if options.Follow {
+		go func() {
+			if tick == nil {
+				ticker := time.NewTicker(monitorInterval)
+				defer ticker.Stop()
+				tick = ticker.C
+			}
+
+			pingFailures := 0
+			for {
+				select {
+				case <-done:
+					return
+				case <-ctx.Done():
+					return
+				case <-tick:
+				}
+
+				if !wroteEntry.Swap(false) {
+					mu.Lock()
+					err := encoder.Encode(map[string]string{"type": "heartbeat"})
+					mu.Unlock()
+					if err != nil {
+						return
+					}
+				}
+
+				pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+				err := ping(pingCtx)
+				cancel()
+				if err == nil {
+					pingFailures = 0
+					continue
+				}
+				pingFailures++
+				if pingFailures >= maxPingFailures {
+					pipeWriter.CloseWithError(fmt.Errorf("docker daemon unreachable while streaming logs: %w", err))
+					logs.Close() // unblock StdCopy, which is stuck reading the dead socket
+					return
+				}
+			}
+		}()
+	}
+
 	go func() {
+		defer close(done)
 		defer logs.Close()
 		defer pipeWriter.Close()
 
-		encoder := json.NewEncoder(pipeWriter)
-		var mu sync.Mutex
-
-		stdout := &streamingLogWriter{
-			stream:      "stdout",
-			encoder:     encoder,
-			encoderMu:   &mu,
-			pipeWriter:  pipeWriter,
-			levelFilter: options.Level,
-			searchRegex: searchRegex,
-		}
-		stderr := &streamingLogWriter{
-			stream:      "stderr",
-			encoder:     encoder,
-			encoderMu:   &mu,
-			pipeWriter:  pipeWriter,
-			levelFilter: options.Level,
-			searchRegex: searchRegex,
-		}
-
-		_, err = stdcopy.StdCopy(stdout, stderr, logs)
+		_, err := stdcopy.StdCopy(stdout, stderr, logs)
 		stdout.Flush()
 		stderr.Flush()
 
@@ -272,5 +353,5 @@ func (c *MultiHostClient) StreamContainerLogsParsed(ctx context.Context, hostNam
 		}
 	}()
 
-	return pipeReader, nil
+	return pipeReader
 }

--- a/server/internal/docker/logs_test.go
+++ b/server/internal/docker/logs_test.go
@@ -1,12 +1,17 @@
 package docker
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -114,6 +119,7 @@ func TestStreamingLogWriterLineBufferCap(t *testing.T) {
 				encoder:    json.NewEncoder(&out),
 				encoderMu:  &mu,
 				pipeWriter: pipeWriter,
+				wroteEntry: new(atomic.Bool),
 			}
 			for _, chunk := range tt.writes {
 				if _, err := w.Write([]byte(chunk)); err != nil {
@@ -131,5 +137,98 @@ func TestStreamingLogWriterLineBufferCap(t *testing.T) {
 				t.Fatalf("buffer exceeds cap: %d bytes", len(w.buffer))
 			}
 		})
+	}
+}
+
+// sendTick delivers a monitor tick, failing fast instead of deadlocking if the
+// monitor stopped consuming.
+func sendTick(t *testing.T, tick chan<- time.Time) {
+	t.Helper()
+	select {
+	case tick <- time.Time{}:
+	case <-time.After(5 * time.Second):
+		t.Fatal("follow monitor did not consume tick")
+	}
+}
+
+func TestFollowMonitorTearsDownStreamWhenDaemonDies(t *testing.T) {
+	// A raw stream that never delivers data and never closes, like the socket
+	// to a daemon that died mid-restart.
+	rawReader, _ := io.Pipe()
+	tick := make(chan time.Time)
+
+	stream := newParsedLogStream(context.Background(), rawReader, models.LogOptions{Follow: true},
+		func(context.Context) error { return errors.New("daemon down") }, tick)
+
+	type result struct {
+		out string
+		err error
+	}
+	results := make(chan result, 1)
+	go func() {
+		out, err := io.ReadAll(stream)
+		results <- result{string(out), err}
+	}()
+
+	sendTick(t, tick) // heartbeat + first failed ping
+	sendTick(t, tick) // heartbeat + second failed ping: daemon declared dead
+
+	select {
+	case res := <-results:
+		if res.err == nil || !strings.Contains(res.err.Error(), "docker daemon unreachable") {
+			t.Fatalf("expected daemon-unreachable error, got %v", res.err)
+		}
+		if got := strings.Count(res.out, `"type":"heartbeat"`); got != 2 {
+			t.Fatalf("expected 2 heartbeats before teardown, got %d in %q", got, res.out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream did not terminate after the daemon died")
+	}
+}
+
+func TestFollowMonitorHeartbeatsOnlyWhenIdleAndStopsAfterClose(t *testing.T) {
+	rawReader, rawWriter := io.Pipe()
+	tick := make(chan time.Time)
+
+	stream := newParsedLogStream(context.Background(), rawReader, models.LogOptions{Follow: true},
+		func(context.Context) error { return nil }, tick)
+	reader := bufio.NewReader(stream)
+
+	go func() {
+		stdw := stdcopy.NewStdWriter(rawWriter, stdcopy.Stdout)
+		stdw.Write([]byte("hello world\n"))
+	}()
+	line, err := reader.ReadString('\n')
+	if err != nil || !strings.Contains(line, "hello world") {
+		t.Fatalf("expected log entry, got %q (err %v)", line, err)
+	}
+
+	sendTick(t, tick) // an entry was written this interval: no heartbeat
+	sendTick(t, tick) // idle interval: heartbeat
+	line, err = reader.ReadString('\n')
+	if err != nil || !strings.Contains(line, `"type":"heartbeat"`) {
+		t.Fatalf("expected heartbeat after idle tick, got %q (err %v)", line, err)
+	}
+
+	// The stream ends normally. If the first tick had wrongly produced a
+	// heartbeat, an extra heartbeat line would be read here instead of EOF.
+	rawWriter.Close()
+	if line, err = reader.ReadString('\n'); err != io.EOF {
+		t.Fatalf("expected EOF after the log stream ended, got %q (err %v)", line, err)
+	}
+
+	// The monitor exits once the stream ends: it either sees the done channel
+	// or consumes one final tick whose heartbeat write fails on the closed
+	// pipe. Two more ticks can therefore never both be consumed.
+	consumed := 0
+	for i := 0; i < 2; i++ {
+		select {
+		case tick <- time.Time{}:
+			consumed++
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	if consumed == 2 {
+		t.Fatal("follow monitor kept running after the stream ended")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #53 - log streams hung indefinitely when the Docker daemon restarted.

Root cause: when the daemon dies without closing its socket (OrbStack restarts do this), the server's follow-mode goroutine blocks forever in stdcopy.StdCopy, the pipe never closes, and the client waits on a silent open connection with no liveness signal at any layer.

Server (one new goroutine per follow stream, plain 15s ticker):
- Emits a {"type":"heartbeat"} NDJSON line on any interval that carried no log data, so clients can tell a quiet stream from a dead one.
- Pings the daemon each tick (3s timeout); two consecutive failures close the Docker read side (unblocking StdCopy) and end the client stream with a descriptive error instead of hanging.

Frontend:
- Heartbeats reset a 45s idle timer and are filtered before rendering; a live stream silent past the timeout is aborted.
- Any stream end not caused by the user pressing Stop reconnects with capped exponential backoff (1s to 30s); reconnects follow from now (tail 0) so displayed lines are not duplicated. A small "Reconnecting..." indicator shows in the toolbar.

## Verification

- Server: go build, go vet, go test (including -race -count=5 on the docker package). New deterministic tests use a blocking pipe as the dead-daemon socket and an injected tick channel.
- Frontend: tsc, biome lint, 40/40 vitest tests, production build. New hook tests cover the idle timeout triggering reconnect and heartbeats preventing it without rendering.
- End to end: streamed a live container via curl, restarted the Docker engine mid-stream - the stream ended immediately with a clean error instead of hanging, and a fresh stream worked right after. Heartbeats observed during quiet periods.

## Notes

Stacked on #68 (base branch is logviewer-unification) because the reconnect logic lives in the stream hook that PR restructures. Merge order: #67, #68, then this - it retargets to main automatically.

https://claude.ai/code/session_01Ksbg2abvq4FA4DrsYjnDoi