### PR TITLE
feat: add Podman support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,17 @@ Manage containers across multiple Docker hosts from a single interface:
 
 For detailed configuration, see the [Multi-Host Setup Guide](./multi-host.md).
 
+### Podman Support
+
+LogDeck works with Podman as well as Docker, using Podman's Docker-compatible API:
+
+- Automatic detection of local Docker and Podman sockets (rootless and rootful)
+- All features work unchanged: logs, stats, lifecycle actions, events, and the terminal
+- Compose grouping recognizes both Docker Compose and podman-compose projects
+- Mix Docker and Podman hosts in a single multi-host setup
+
+For setup instructions, see the [Podman Setup Guide](./podman.md).
+
 ### Container Lifecycle Management
 
 - Start, stop, restart, and remove containers

--- a/env.example
+++ b/env.example
@@ -40,6 +40,11 @@ FRONTEND_PORT=5173
 # Docker host (uncomment to override default)
 # DOCKER_HOST=unix:///var/run/docker.sock
 
+# Podman works too, via its Docker-compatible API socket (see podman.md).
+# Rootless: unix:///run/user/1000/podman/podman.sock
+# Rootful:  unix:///run/podman/podman.sock
+# DOCKER_HOSTS=local=unix:///run/podman/podman.sock
+
 # =============================================================================
 # Coolify Integration (Optional)
 # =============================================================================

--- a/frontend/src/features/containers/components/container-utils.ts
+++ b/frontend/src/features/containers/components/container-utils.ts
@@ -18,7 +18,22 @@ export interface StateCounts {
   other: number;
 }
 
-const COMPOSE_PROJECT_LABEL = "com.docker.compose.project";
+// Docker Compose and recent podman-compose both set the com.docker label;
+// older podman-compose releases only set the io.podman one.
+const COMPOSE_PROJECT_LABELS = [
+  "com.docker.compose.project",
+  "io.podman.compose.project",
+];
+
+function getComposeProject(labels?: Record<string, string>) {
+  for (const label of COMPOSE_PROJECT_LABELS) {
+    const project = labels?.[label]?.trim();
+    if (project) {
+      return project;
+    }
+  }
+  return undefined;
+}
 
 export function formatContainerName(names: string[]) {
   if (!names.length) {
@@ -86,8 +101,7 @@ export function groupByCompose(
   const groups = new Map<string, ContainerInfo[]>();
 
   containers.forEach((container) => {
-    const key =
-      container.labels?.[COMPOSE_PROJECT_LABEL]?.trim() || "Standalone";
+    const key = getComposeProject(container.labels) || "Standalone";
     if (!groups.has(key)) {
       groups.set(key, []);
     }

--- a/frontend/src/features/settings/components/docker-hosts-section.tsx
+++ b/frontend/src/features/settings/components/docker-hosts-section.tsx
@@ -143,12 +143,16 @@ export function DockerHostsSection({ config }: DockerHostsSectionProps) {
       { name: key, host: hostUrl },
       {
         onSuccess: (result) => {
+          const engineLabel =
+            result.engine && result.engineVersion
+              ? `${result.engine} ${result.engineVersion}`
+              : `Docker ${result.dockerVersion ?? ""}`;
           setTestResults((prev) => ({
             ...prev,
             [key]: {
               success: result.success,
               message: result.success
-                ? `Connected (Docker ${result.dockerVersion ?? ""})`
+                ? `Connected (${engineLabel})`
                 : result.message,
             },
           }));
@@ -277,7 +281,8 @@ export function DockerHostsSection({ config }: DockerHostsSectionProps) {
       <CardHeader>
         <CardTitle>Docker Hosts</CardTitle>
         <CardDescription>
-          Configure which Docker daemon sockets or remote hosts to connect to.
+          Configure which Docker or Podman sockets and remote hosts to connect
+          to.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -45,4 +45,7 @@ export interface TestConnectionResult {
   success: boolean;
   message: string;
   dockerVersion?: string;
+  /** "Docker" or "Podman", when the server could identify the engine. */
+  engine?: string;
+  engineVersion?: string;
 }

--- a/multi-host.md
+++ b/multi-host.md
@@ -4,6 +4,8 @@
 
 LogDeck supports managing Docker containers across multiple Docker hosts simultaneously. This feature enables monitoring and controlling containers on local, remote, and SSH-connected Docker daemons from a single interface.
 
+Hosts can also be Podman endpoints (Podman serves a Docker-compatible API) and can be mixed freely with Docker hosts. See the [Podman Setup Guide](./podman.md) for socket paths and Podman-specific setup.
+
 ## Prerequisites
 
 ### Server Requirements

--- a/podman.md
+++ b/podman.md
@@ -1,0 +1,181 @@
+# Podman Setup Guide
+
+## Overview
+
+LogDeck supports Podman through Podman's Docker-compatible REST API. Every
+feature — container listing, log streaming, stats, lifecycle actions, events,
+the interactive terminal, and environment variable editing — goes through this
+API, so no LogDeck-specific configuration is needed beyond pointing it at a
+Podman socket.
+
+Podman hosts are configured exactly like Docker hosts (via `DOCKER_HOSTS` or
+the Settings UI) and can be freely mixed with Docker hosts in a multi-host
+setup. The host connection test in Settings reports which engine it reached,
+for example `Connected (Podman 5.3.1)`.
+
+## Prerequisites
+
+- Podman 4.0 or later (earlier versions have incomplete Docker API support)
+- The Podman API socket enabled (see below) — unlike Docker, Podman is
+  daemonless and does not listen on a socket by default
+
+## Enabling the Podman API Socket
+
+### Rootless (recommended)
+
+Enable the per-user socket:
+
+```bash
+systemctl --user enable --now podman.socket
+```
+
+The socket is created at `$XDG_RUNTIME_DIR/podman/podman.sock`, typically:
+
+```
+/run/user/1000/podman/podman.sock
+```
+
+To keep the socket available when you are not logged in, enable lingering for
+the user:
+
+```bash
+sudo loginctl enable-linger $USER
+```
+
+### Rootful
+
+```bash
+sudo systemctl enable --now podman.socket
+```
+
+The socket is created at `/run/podman/podman.sock`.
+
+### Verify the socket
+
+```bash
+curl --unix-socket /run/user/1000/podman/podman.sock http://d/v1.40/_ping
+# OK
+```
+
+## Local Socket Auto-Detection
+
+When no hosts are configured, LogDeck probes for a local socket in this order
+and uses the first one it finds:
+
+1. `/var/run/docker.sock` (Docker)
+2. `$XDG_RUNTIME_DIR/podman/podman.sock` (rootless Podman)
+3. `/run/podman/podman.sock` (rootful Podman)
+
+On a Podman-only machine with the socket enabled, LogDeck therefore works with
+no configuration at all.
+
+## Configuration Examples
+
+Podman sockets use the same `DOCKER_HOSTS` format as Docker (see the
+[Multi-Host Setup Guide](./multi-host.md)):
+
+```bash
+# Rootless Podman
+DOCKER_HOSTS=local=unix:///run/user/1000/podman/podman.sock
+
+# Rootful Podman
+DOCKER_HOSTS=local=unix:///run/podman/podman.sock
+
+# Mixed Docker and Podman hosts
+DOCKER_HOSTS=docker=unix:///var/run/docker.sock,podman=unix:///run/podman/podman.sock,prod=ssh://deploy@prod.example.com
+```
+
+## Running LogDeck as a Container Under Podman
+
+Mount the Podman socket where LogDeck expects the default Docker socket:
+
+```bash
+# Rootless
+podman run -d \
+  --name logdeck \
+  -p 8123:8080 \
+  -v $XDG_RUNTIME_DIR/podman/podman.sock:/var/run/docker.sock \
+  --security-opt label=disable \
+  docker.io/amoabakelvin/logdeck:latest
+
+# Rootful
+sudo podman run -d \
+  --name logdeck \
+  -p 8123:8080 \
+  -v /run/podman/podman.sock:/var/run/docker.sock \
+  --security-opt label=disable \
+  docker.io/amoabakelvin/logdeck:latest
+```
+
+Notes:
+
+- `--security-opt label=disable` is needed on SELinux systems (Fedora, RHEL,
+  CentOS) so the container may use the mounted socket. Alternatively, keep
+  labeling enabled and run with `podman run --privileged`, or manage the
+  policy explicitly.
+- The socket must belong to the same user namespace: mount the rootless
+  socket into rootless containers and the rootful socket into rootful ones.
+
+## Remote Podman Hosts over SSH
+
+LogDeck's SSH transport runs `docker system dial-stdio` on the remote host to
+reach its socket. For a Podman-only remote host, install the `podman-docker`
+package, which provides a `docker` command that transparently invokes Podman:
+
+```bash
+# On the remote host
+sudo dnf install podman-docker   # Fedora/RHEL
+sudo apt install podman-docker   # Debian/Ubuntu
+
+# Enable the socket for the user you SSH in as
+systemctl --user enable --now podman.socket
+```
+
+Then configure the host as usual:
+
+```bash
+DOCKER_HOSTS=remote=ssh://deploy@podman-host.example.com
+```
+
+## TCP Connections
+
+Podman can serve its API over TCP, but the endpoint is unauthenticated and
+unencrypted — restrict it to trusted networks:
+
+```bash
+podman system service --time=0 tcp://0.0.0.0:2375
+```
+
+```bash
+DOCKER_HOSTS=remote=tcp://podman-host.example.com:2375
+```
+
+## macOS (podman machine)
+
+On macOS, Podman runs inside a virtual machine that forwards its API socket to
+the host. Find the host-side socket path with:
+
+```bash
+podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
+```
+
+Use that path in your configuration:
+
+```bash
+DOCKER_HOSTS=local=unix:///Users/you/.local/share/containers/podman/machine/podman.sock
+```
+
+## Compose Project Grouping
+
+Grouping containers by compose project works with both label conventions:
+
+- `com.docker.compose.project` — set by Docker Compose and recent
+  podman-compose releases
+- `io.podman.compose.project` — set by podman-compose
+
+## Limitations
+
+- The Coolify integration is Docker-specific and does not apply to Podman
+  hosts.
+- Podman 3.x and earlier are not supported; several endpoints LogDeck relies
+  on (stats, events filtering) behave differently there.

--- a/server/internal/api/settings_handlers.go
+++ b/server/internal/api/settings_handlers.go
@@ -325,11 +325,19 @@ func (ar *APIRouter) TestDockerHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	WriteJsonResponse(w, http.StatusOK, map[string]any{
+	response := map[string]any{
 		"success":       true,
 		"message":       "Connection successful",
 		"dockerVersion": ping.APIVersion,
-	})
+	}
+	// Identify the engine (Docker or Podman) so the UI can say what it
+	// actually connected to. Best-effort: the connection test already passed.
+	if engine, version, err := tempClient.EngineInfo(ctx, "test"); err == nil {
+		response["engine"] = engine
+		response["engineVersion"] = version
+	}
+
+	WriteJsonResponse(w, http.StatusOK, response)
 }
 
 // TestCoolifyHost handles POST /api/v1/settings/test/coolify-host.

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -28,9 +28,9 @@ func NewConfig() *Config {
 	dockerHosts := parseDockerHosts()
 
 	// if we don't have any docker hosts, we should default back to
-	// the unix socket on the machine running logdeck.
+	// the local Docker or Podman socket on the machine running logdeck.
 	if len(dockerHosts) == 0 {
-		dockerHosts = []DockerHost{{Name: "local", Host: "unix:///var/run/docker.sock"}}
+		dockerHosts = []DockerHost{DefaultLocalHost()}
 	}
 
 	coolifyHosts := parseCoolifyHostConfigs()

--- a/server/internal/config/local_socket.go
+++ b/server/internal/config/local_socket.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// dockerSocketPath is the conventional Docker daemon socket. It is probed
+// first and is also the fallback when no local socket exists, so connection
+// errors point at the location most users expect.
+const dockerSocketPath = "/var/run/docker.sock"
+
+// DefaultLocalHost returns the host used when no Docker hosts are configured.
+// It probes for a local Docker socket first, then Podman's API sockets
+// (rootless, then rootful), so LogDeck works out of the box on Podman-only
+// machines. Podman's socket speaks the Docker-compatible API, so no other
+// changes are needed to talk to it.
+func DefaultLocalHost() DockerHost {
+	return DockerHost{Name: "local", Host: "unix://" + firstExistingSocket(localSocketCandidates())}
+}
+
+// localSocketCandidates lists local engine sockets in preference order:
+// Docker, rootless Podman, rootful Podman.
+func localSocketCandidates() []string {
+	candidates := []string{dockerSocketPath}
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		candidates = append(candidates, filepath.Join(runtimeDir, "podman", "podman.sock"))
+	}
+	return append(candidates, "/run/podman/podman.sock")
+}
+
+// firstExistingSocket returns the first candidate that exists and is a unix
+// socket, or dockerSocketPath when none match.
+func firstExistingSocket(candidates []string) string {
+	for _, path := range candidates {
+		if info, err := os.Stat(path); err == nil && info.Mode()&os.ModeSocket != 0 {
+			return path
+		}
+	}
+	return dockerSocketPath
+}

--- a/server/internal/config/local_socket_test.go
+++ b/server/internal/config/local_socket_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// shortTempDir returns a temp dir with a short path; unix socket paths are
+// limited to ~104 chars on macOS, which t.TempDir() subtest paths can exceed.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+// listenUnix creates a real unix socket at path and cleans it up with the test.
+func listenUnix(t *testing.T, path string) {
+	t.Helper()
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("failed to create unix socket %s: %v", path, err)
+	}
+	t.Cleanup(func() { l.Close() })
+}
+
+func TestFirstExistingSocket(t *testing.T) {
+	t.Run("returns first candidate that is a socket", func(t *testing.T) {
+		dir := shortTempDir(t)
+		missing := filepath.Join(dir, "docker.sock")
+		podmanSock := filepath.Join(dir, "podman.sock")
+		listenUnix(t, podmanSock)
+
+		if got := firstExistingSocket([]string{missing, podmanSock}); got != podmanSock {
+			t.Errorf("expected %s, got %s", podmanSock, got)
+		}
+	})
+
+	t.Run("prefers earlier candidates", func(t *testing.T) {
+		dir := shortTempDir(t)
+		first := filepath.Join(dir, "first.sock")
+		second := filepath.Join(dir, "second.sock")
+		listenUnix(t, first)
+		listenUnix(t, second)
+
+		if got := firstExistingSocket([]string{first, second}); got != first {
+			t.Errorf("expected %s, got %s", first, got)
+		}
+	})
+
+	t.Run("skips regular files", func(t *testing.T) {
+		dir := shortTempDir(t)
+		notASocket := filepath.Join(dir, "not-a-socket")
+		if err := os.WriteFile(notASocket, []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		sock := filepath.Join(dir, "real.sock")
+		listenUnix(t, sock)
+
+		if got := firstExistingSocket([]string{notASocket, sock}); got != sock {
+			t.Errorf("expected %s, got %s", sock, got)
+		}
+	})
+
+	t.Run("falls back to docker socket path when nothing exists", func(t *testing.T) {
+		missing := filepath.Join(shortTempDir(t), "missing.sock")
+		if got := firstExistingSocket([]string{missing}); got != dockerSocketPath {
+			t.Errorf("expected %s, got %s", dockerSocketPath, got)
+		}
+	})
+}
+
+func TestLocalSocketCandidatesIncludesRootlessPodman(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+
+	candidates := localSocketCandidates()
+	want := []string{
+		"/var/run/docker.sock",
+		"/run/user/1000/podman/podman.sock",
+		"/run/podman/podman.sock",
+	}
+	if len(candidates) != len(want) {
+		t.Fatalf("expected %d candidates, got %d: %v", len(want), len(candidates), candidates)
+	}
+	for i, w := range want {
+		if candidates[i] != w {
+			t.Errorf("candidate %d: expected %s, got %s", i, w, candidates[i])
+		}
+	}
+}

--- a/server/internal/config/manager.go
+++ b/server/internal/config/manager.go
@@ -284,7 +284,7 @@ func (m *Manager) merge() (*Config, ConfigSources) {
 		}
 	}
 	if len(cfg.DockerHosts) == 0 {
-		cfg.DockerHosts = []DockerHost{{Name: "local", Host: "unix:///var/run/docker.sock"}}
+		cfg.DockerHosts = []DockerHost{DefaultLocalHost()}
 		sources.DockerHosts = SourceDefault
 	} else if m.envSnapshot.DockerHostsSet && len(m.fileConfig.DockerHosts) > 0 {
 		sources.DockerHosts = SourceMixed

--- a/server/internal/docker/client.go
+++ b/server/internal/docker/client.go
@@ -128,6 +128,30 @@ func (c *MultiHostClient) GetHosts() []config.DockerHost {
 	return c.hosts
 }
 
+// EngineInfo identifies the container engine behind a host. Podman serves the
+// Docker-compatible API and reports itself as a "Podman Engine" component in
+// the version response; anything else is treated as Docker.
+func (c *MultiHostClient) EngineInfo(ctx context.Context, hostName string) (engine, version string, err error) {
+	apiClient, err := c.GetClient(hostName)
+	if err != nil {
+		return "", "", err
+	}
+
+	v, err := apiClient.ServerVersion(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
+	engine = "Docker"
+	for _, component := range v.Components {
+		if strings.Contains(component.Name, "Podman") {
+			engine = "Podman"
+			break
+		}
+	}
+	return engine, v.Version, nil
+}
+
 // Close closes all underlying Docker API clients.
 func (c *MultiHostClient) Close() {
 	for _, cl := range c.clients {

--- a/server/internal/docker/logs_test.go
+++ b/server/internal/docker/logs_test.go
@@ -196,7 +196,9 @@ func TestFollowMonitorHeartbeatsOnlyWhenIdleAndStopsAfterClose(t *testing.T) {
 
 	go func() {
 		stdw := stdcopy.NewStdWriter(rawWriter, stdcopy.Stdout)
-		stdw.Write([]byte("hello world\n"))
+		if _, err := stdw.Write([]byte("hello world\n")); err != nil {
+			t.Errorf("failed to write log entry: %v", err)
+		}
 	}()
 	line, err := reader.ReadString('\n')
 	if err != nil || !strings.Contains(line, "hello world") {


### PR DESCRIPTION
## Summary

Adds first-class Podman support. Podman exposes a Docker-compatible REST API, and every call LogDeck makes (list, inspect, lifecycle, logs, stats, events, exec, env-edit recreate) falls inside that compatibility layer, so the existing docker/docker client works unchanged — the changes are socket detection, engine identification, compose grouping, and documentation.

## Changes

- **Local socket auto-detection**: when no hosts are configured, the server probes `/var/run/docker.sock`, then rootless Podman (`$XDG_RUNTIME_DIR/podman/podman.sock`), then rootful Podman (`/run/podman/podman.sock`), so LogDeck works out of the box on Podman-only machines. Falls back to the Docker socket path when nothing is found.
- **Engine detection in Settings**: the host connection test now calls the version endpoint after a successful ping and reports the engine it reached, e.g. `Connected (Podman 6.0.1)` instead of assuming Docker.
- **Compose grouping**: the containers view recognizes `io.podman.compose.project` as a fallback to `com.docker.compose.project` (older podman-compose releases set only the former).
- **Documentation**: new `podman.md` covering socket activation (rootless/rootful), running LogDeck under Podman (including SELinux notes), remote Podman over SSH via the `podman-docker` shim, TCP, and macOS `podman machine`. Linked from the README, `multi-host.md`, and `env.example`.

## Type of Change

- [x] feat: New feature
- [x] docs: Documentation

## Testing

- Unit tests for the socket probing (real unix sockets, probe order, non-socket files, fallback).
- `go build ./...`, `go vet ./...`, and `go test ./...` pass; frontend build, typecheck, and all 40 vitest tests pass.
- Verified end-to-end against a real Podman 6.0.1 machine (macOS, applehv): container listing with labels, parsed and follow-mode log streaming with stdout/stderr demux, stats, start/stop/restart, the events stream (LogDeck's full event filter set works against Podman), the WebSocket terminal, and the env-edit recreate flow (variables applied, labels preserved, rollback path intact).

https://claude.ai/code/session_01UiF27uXBtshSuNW9LKL28x