### PR TITLE
fix: consolidate auth detection, fail closed, and close security gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,12 @@ FRONTEND_PORT=5173
 # Default: http://localhost:5173,http://127.0.0.1:5173
 # CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 
+# Trust X-Forwarded-For / X-Real-IP headers for client IP detection (used by
+# login rate limiting). Enable ONLY when LogDeck runs behind a reverse proxy
+# (Coolify, Traefik, nginx, ...); on a directly exposed server clients could
+# spoof these headers to bypass the rate limit.
+# TRUST_PROXY_HEADERS=true
+
 # =============================================================================
 # Docker Configuration (Optional)
 # =============================================================================

--- a/env.example
+++ b/env.example
@@ -33,6 +33,12 @@ FRONTEND_PORT=5173
 # Default: http://localhost:5173,http://127.0.0.1:5173
 # CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 
+# Trust X-Forwarded-For / X-Real-IP headers for client IP detection (used by
+# login rate limiting). Enable ONLY when LogDeck runs behind a reverse proxy
+# (Coolify, Traefik, nginx, ...); on a directly exposed server clients could
+# spoof these headers to bypass the rate limit.
+# TRUST_PROXY_HEADERS=true
+
 # =============================================================================
 # Docker Configuration (Optional)
 # =============================================================================

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -1,28 +1,29 @@
 import type React from "react";
 import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
 } from "react";
 
+import { isAuthEnabled as fetchIsAuthEnabled } from "@/lib/auth-config";
 import { API_BASE_URL } from "@/types/api";
 
 interface User {
-  username: string;
-  role: string;
+	username: string;
+	role: string;
 }
 
 interface AuthContextType {
-  user: User | null;
-  token: string | null;
-  isAuthenticated: boolean;
-  isLoading: boolean;
-  isAuthEnabled: boolean;
-  login: (username: string, password: string) => Promise<void>;
-  logout: () => void;
-  checkAuth: () => Promise<boolean>;
+	user: User | null;
+	token: string | null;
+	isAuthenticated: boolean;
+	isLoading: boolean;
+	isAuthEnabled: boolean;
+	login: (username: string, password: string) => Promise<void>;
+	logout: () => void;
+	checkAuth: () => Promise<boolean>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -30,162 +31,151 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const TOKEN_KEY = "logdeck_auth_token";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  const [token, setToken] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isAuthEnabled, setIsAuthEnabled] = useState(true);
+	const [user, setUser] = useState<User | null>(null);
+	const [token, setToken] = useState<string | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [isAuthEnabled, setIsAuthEnabled] = useState(true);
 
-  // Check if authentication is enabled on the backend
-  const checkIfAuthEnabled = useCallback(async () => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ username: "", password: "" }),
-      });
+	// Check if authentication is enabled on the backend
+	const checkIfAuthEnabled = useCallback(async () => {
+		try {
+			setIsAuthEnabled(await fetchIsAuthEnabled());
+		} catch (error) {
+			// Status unknown - keep the default (enabled) to fail closed
+			console.error("Failed to check auth status:", error);
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
 
-      // If we get a 404, auth is disabled. Any other response means auth is enabled
-      if (response.status === 404) {
-        setIsAuthEnabled(false);
-      }
-    } catch (error) {
-      // If the request fails, assume auth is enabled to be safe
-      console.error("Failed to check auth status:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+	const verifyToken = useCallback(async (tokenToVerify: string) => {
+		try {
+			const response = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
+				headers: {
+					Authorization: `Bearer ${tokenToVerify}`,
+				},
+			});
 
-  const verifyToken = useCallback(async (tokenToVerify: string) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
-        headers: {
-          Authorization: `Bearer ${tokenToVerify}`,
-        },
-      });
+			if (response.ok) {
+				const data = await response.json();
+				setUser(data.user);
+				setToken(tokenToVerify);
+				setIsAuthEnabled(true);
+			} else if (response.status === 404) {
+				// Auth endpoint doesn't exist - auth is disabled
+				setIsAuthEnabled(false);
+				localStorage.removeItem(TOKEN_KEY);
+				setToken(null);
+				setUser(null);
+			} else {
+				// Token is invalid, clear it
+				localStorage.removeItem(TOKEN_KEY);
+				setToken(null);
+				setUser(null);
+			}
+		} catch (error) {
+			console.error("Failed to verify token:", error);
+			localStorage.removeItem(TOKEN_KEY);
+			setToken(null);
+			setUser(null);
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
 
-      if (response.ok) {
-        const data = await response.json();
-        setUser(data.user);
-        setToken(tokenToVerify);
-        setIsAuthEnabled(true);
-      } else if (response.status === 404) {
-        // Auth endpoint doesn't exist - auth is disabled
-        setIsAuthEnabled(false);
-        localStorage.removeItem(TOKEN_KEY);
-        setToken(null);
-        setUser(null);
-      } else {
-        // Token is invalid, clear it
-        localStorage.removeItem(TOKEN_KEY);
-        setToken(null);
-        setUser(null);
-      }
-    } catch (error) {
-      console.error("Failed to verify token:", error);
-      localStorage.removeItem(TOKEN_KEY);
-      setToken(null);
-      setUser(null);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+	useEffect(() => {
+		const storedToken = localStorage.getItem(TOKEN_KEY);
+		if (storedToken) {
+			setToken(storedToken);
+			verifyToken(storedToken);
+		} else {
+			checkIfAuthEnabled();
+		}
+	}, [verifyToken, checkIfAuthEnabled]);
 
-  useEffect(() => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
-    if (storedToken) {
-      setToken(storedToken);
-      verifyToken(storedToken);
-    } else {
-      checkIfAuthEnabled();
-    }
-  }, [verifyToken, checkIfAuthEnabled]);
+	// Check authentication status
+	const checkAuth = async (): Promise<boolean> => {
+		const storedToken = localStorage.getItem(TOKEN_KEY);
+		if (!storedToken) {
+			return false;
+		}
 
-  // Check authentication status
-  const checkAuth = async (): Promise<boolean> => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
-    if (!storedToken) {
-      return false;
-    }
+		try {
+			const response = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
+				headers: {
+					Authorization: `Bearer ${storedToken}`,
+				},
+			});
 
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
-        headers: {
-          Authorization: `Bearer ${storedToken}`,
-        },
-      });
+			if (response.ok) {
+				const data = await response.json();
+				setUser(data.user);
+				setToken(storedToken);
+				return true;
+			}
 
-      if (response.ok) {
-        const data = await response.json();
-        setUser(data.user);
-        setToken(storedToken);
-        return true;
-      }
+			// Token is invalid
+			localStorage.removeItem(TOKEN_KEY);
+			setToken(null);
+			setUser(null);
+			return false;
+		} catch (error) {
+			console.error("Failed to check auth:", error);
+			return false;
+		}
+	};
 
-      // Token is invalid
-      localStorage.removeItem(TOKEN_KEY);
-      setToken(null);
-      setUser(null);
-      return false;
-    } catch (error) {
-      console.error("Failed to check auth:", error);
-      return false;
-    }
-  };
+	const login = async (username: string, password: string) => {
+		try {
+			const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ username, password }),
+			});
 
-  const login = async (username: string, password: string) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ username, password }),
-      });
+			if (!response.ok) {
+				const errorText = await response.text();
+				throw new Error(errorText || "Login failed");
+			}
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(errorText || "Login failed");
-      }
+			const data = await response.json();
 
-      const data = await response.json();
+			// Store token and user
+			localStorage.setItem(TOKEN_KEY, data.token);
+			setToken(data.token);
+			setUser(data.user);
+		} catch (error) {
+			console.error("Login error:", error);
+			throw error;
+		}
+	};
 
-      // Store token and user
-      localStorage.setItem(TOKEN_KEY, data.token);
-      setToken(data.token);
-      setUser(data.user);
-    } catch (error) {
-      console.error("Login error:", error);
-      throw error;
-    }
-  };
+	const logout = () => {
+		localStorage.removeItem(TOKEN_KEY);
+		setToken(null);
+		setUser(null);
+	};
 
-  const logout = () => {
-    localStorage.removeItem(TOKEN_KEY);
-    setToken(null);
-    setUser(null);
-  };
+	const value: AuthContextType = {
+		user,
+		token,
+		isAuthenticated: !!token && !!user,
+		isLoading,
+		isAuthEnabled,
+		login,
+		logout,
+		checkAuth,
+	};
 
-  const value: AuthContextType = {
-    user,
-    token,
-    isAuthenticated: !!token && !!user,
-    isLoading,
-    isAuthEnabled,
-    login,
-    logout,
-    checkAuth,
-  };
-
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {
-  const context = useContext(AuthContext);
-  if (context === undefined) {
-    throw new Error("useAuth must be used within an AuthProvider");
-  }
-  return context;
+	const context = useContext(AuthContext);
+	if (context === undefined) {
+		throw new Error("useAuth must be used within an AuthProvider");
+	}
+	return context;
 }

--- a/frontend/src/lib/api-client.test.ts
+++ b/frontend/src/lib/api-client.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { authenticatedFetch } from "./api-client";
+
+const TOKEN_KEY = "logdeck_auth_token";
+
+const fetchMock = vi.fn();
+const originalLocation = window.location;
+
+function stubLocation(pathname: string) {
+	Object.defineProperty(window, "location", {
+		value: { pathname, href: `http://localhost${pathname}` },
+		writable: true,
+		configurable: true,
+	});
+}
+
+beforeEach(() => {
+	vi.stubGlobal("fetch", fetchMock);
+	localStorage.clear();
+	stubLocation("/");
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	fetchMock.mockReset();
+	Object.defineProperty(window, "location", {
+		value: originalLocation,
+		writable: true,
+		configurable: true,
+	});
+});
+
+describe("authenticatedFetch", () => {
+	it("attaches the stored token as a Bearer header", async () => {
+		localStorage.setItem(TOKEN_KEY, "my-token");
+		fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+		await authenticatedFetch("/api/v1/containers");
+
+		const headers = fetchMock.mock.calls[0][1]?.headers as Headers;
+		expect(headers.get("Authorization")).toBe("Bearer my-token");
+	});
+
+	it("clears the token and redirects to /login on 401", async () => {
+		localStorage.setItem(TOKEN_KEY, "expired-token");
+		fetchMock.mockResolvedValue(new Response("unauthorized", { status: 401 }));
+
+		await authenticatedFetch("/api/v1/containers");
+
+		expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+		expect(window.location.href).toBe("/login");
+	});
+
+	it("does not redirect when already on /login", async () => {
+		stubLocation("/login");
+		fetchMock.mockResolvedValue(new Response("unauthorized", { status: 401 }));
+
+		await authenticatedFetch("/api/v1/containers");
+
+		expect(window.location.href).toBe("http://localhost/login");
+	});
+
+	it("never issues an empty-credential login probe", async () => {
+		fetchMock.mockResolvedValue(new Response("unauthorized", { status: 401 }));
+
+		await authenticatedFetch("/api/v1/containers?since=1h");
+
+		// Only the original request goes out - no follow-up POST probing
+		// /auth/login with empty credentials.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock.mock.calls[0][0]).toBe("/api/v1/containers?since=1h");
+	});
+
+	it("passes non-401 responses through untouched", async () => {
+		localStorage.setItem(TOKEN_KEY, "my-token");
+		fetchMock.mockResolvedValue(new Response("boom", { status: 500 }));
+
+		const response = await authenticatedFetch("/api/v1/containers");
+
+		expect(response.status).toBe(500);
+		expect(localStorage.getItem(TOKEN_KEY)).toBe("my-token");
+		expect(window.location.href).toBe("http://localhost/");
+	});
+});

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -5,76 +5,60 @@ const TOKEN_KEY = "logdeck_auth_token";
  * and handles 401 responses by logging out the user
  */
 export async function authenticatedFetch(
-  input: RequestInfo | URL,
-  init?: RequestInit
+	input: RequestInfo | URL,
+	init?: RequestInit,
 ): Promise<Response> {
-  const token = localStorage.getItem(TOKEN_KEY);
+	const token = localStorage.getItem(TOKEN_KEY);
 
-  const headers =
-    input instanceof Request ? new Headers(input.headers) : new Headers();
+	const headers =
+		input instanceof Request ? new Headers(input.headers) : new Headers();
 
-  if (init?.headers) {
-    const initHeaders = new Headers(init.headers);
-    initHeaders.forEach((value, key) => {
-      headers.set(key, value);
-    });
-  }
+	if (init?.headers) {
+		const initHeaders = new Headers(init.headers);
+		initHeaders.forEach((value, key) => {
+			headers.set(key, value);
+		});
+	}
 
-  if (token) {
-    headers.set("Authorization", `Bearer ${token}`);
-  }
+	if (token) {
+		headers.set("Authorization", `Bearer ${token}`);
+	}
 
-  const response = await fetch(input, {
-    ...init,
-    headers,
-  });
+	const response = await fetch(input, {
+		...init,
+		headers,
+	});
 
-  // Handle 401 Unauthorized - token expired or invalid
-  // Only redirect if auth is enabled (check by seeing if login endpoint exists)
-  if (response.status === 401) {
-    localStorage.removeItem(TOKEN_KEY);
+	// Handle 401 Unauthorized - token expired or invalid: clear the token and
+	// send the user to the login page (unless already there).
+	if (response.status === 401) {
+		localStorage.removeItem(TOKEN_KEY);
 
-    // Check if auth is enabled before redirecting
-    try {
-      const authCheck = await fetch(
-        input.toString().replace(/\/api\/v1\/.*/, "/api/v1/auth/login"),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ username: "", password: "" }),
-        }
-      );
+		if (window.location.pathname !== "/login") {
+			window.location.href = "/login";
+		}
+	}
 
-      // Only redirect to login if auth endpoint exists (not 404)
-      if (authCheck.status !== 404 && window.location.pathname !== "/login") {
-        window.location.href = "/login";
-      }
-    } catch (error) {
-      // If check fails, don't redirect
-      console.error("Failed to check auth status:", error);
-    }
-  }
-
-  return response;
+	return response;
 }
 
 /**
  * Helper to get the current auth token
  */
 export function getAuthToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
+	return localStorage.getItem(TOKEN_KEY);
 }
 
 /**
  * Helper to set the auth token
  */
 export function setAuthToken(token: string): void {
-  localStorage.setItem(TOKEN_KEY, token);
+	localStorage.setItem(TOKEN_KEY, token);
 }
 
 /**
  * Helper to remove the auth token
  */
 export function removeAuthToken(): void {
-  localStorage.removeItem(TOKEN_KEY);
+	localStorage.removeItem(TOKEN_KEY);
 }

--- a/frontend/src/lib/auth-config.test.ts
+++ b/frontend/src/lib/auth-config.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	AuthConfigUnavailableError,
+	isAuthEnabled,
+	resetAuthConfigCache,
+} from "./auth-config";
+
+const fetchMock = vi.fn();
+
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+beforeEach(() => {
+	vi.stubGlobal("fetch", fetchMock);
+	resetAuthConfigCache();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	fetchMock.mockReset();
+});
+
+describe("isAuthEnabled", () => {
+	it("returns true when the server reports auth enabled", async () => {
+		fetchMock.mockResolvedValue(jsonResponse(200, { authEnabled: true }));
+		await expect(isAuthEnabled()).resolves.toBe(true);
+	});
+
+	it("returns false when the server reports auth disabled", async () => {
+		fetchMock.mockResolvedValue(jsonResponse(200, { authEnabled: false }));
+		await expect(isAuthEnabled()).resolves.toBe(false);
+	});
+
+	it("caches the result and only fetches once", async () => {
+		fetchMock.mockResolvedValue(jsonResponse(200, { authEnabled: false }));
+		await isAuthEnabled();
+		await isAuthEnabled();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("treats a 404 from an older server as auth enabled (fail closed)", async () => {
+		fetchMock.mockResolvedValue(jsonResponse(404, "not found"));
+		await expect(isAuthEnabled()).resolves.toBe(true);
+	});
+
+	it("throws AuthConfigUnavailableError when the server is unreachable", async () => {
+		fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+		await expect(isAuthEnabled()).rejects.toBeInstanceOf(
+			AuthConfigUnavailableError,
+		);
+	});
+
+	it("does not cache failures, so the next call retries", async () => {
+		fetchMock
+			.mockRejectedValueOnce(new TypeError("Failed to fetch"))
+			.mockResolvedValueOnce(jsonResponse(200, { authEnabled: true }));
+
+		await expect(isAuthEnabled()).rejects.toBeInstanceOf(
+			AuthConfigUnavailableError,
+		);
+		await expect(isAuthEnabled()).resolves.toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/lib/auth-config.ts
+++ b/frontend/src/lib/auth-config.ts
@@ -1,0 +1,56 @@
+import { API_BASE_URL } from "@/types/api";
+
+/** Thrown when the server cannot be reached to determine the auth status. */
+export class AuthConfigUnavailableError extends Error {
+	constructor() {
+		super(
+			"Unable to determine authentication status. Is the LogDeck server reachable?",
+		);
+		this.name = "AuthConfigUnavailableError";
+	}
+}
+
+let authEnabledPromise: Promise<boolean> | null = null;
+
+/**
+ * Whether authentication is enabled on the server, from GET /auth/config.
+ *
+ * The answer is fetched once per page load and cached. Failed lookups are
+ * not cached, so a retry (or route reload) re-fetches. Older servers without
+ * the endpoint respond 404; auth is then treated as enabled (fail closed)
+ * and the login flow reveals whether auth is actually configured.
+ */
+export function isAuthEnabled(): Promise<boolean> {
+	if (!authEnabledPromise) {
+		authEnabledPromise = fetchAuthEnabled().catch((error) => {
+			authEnabledPromise = null;
+			throw error;
+		});
+	}
+	return authEnabledPromise;
+}
+
+async function fetchAuthEnabled(): Promise<boolean> {
+	let response: Response;
+	try {
+		response = await fetch(`${API_BASE_URL}/api/v1/auth/config`);
+	} catch {
+		throw new AuthConfigUnavailableError();
+	}
+
+	if (!response.ok) {
+		return true;
+	}
+
+	try {
+		const config = await response.json();
+		return config.authEnabled === true;
+	} catch {
+		throw new AuthConfigUnavailableError();
+	}
+}
+
+/** Clears the cached auth config. Exposed for tests. */
+export function resetAuthConfigCache(): void {
+	authEnabledPromise = null;
+}

--- a/frontend/src/lib/auth-guard.test.ts
+++ b/frontend/src/lib/auth-guard.test.ts
@@ -1,0 +1,61 @@
+import { isRedirect } from "@tanstack/react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	AuthConfigUnavailableError,
+	resetAuthConfigCache,
+} from "./auth-config";
+import { requireAuthIfEnabled } from "./auth-guard";
+
+const fetchMock = vi.fn();
+
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+beforeEach(() => {
+	vi.stubGlobal("fetch", fetchMock);
+	resetAuthConfigCache();
+	localStorage.clear();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	fetchMock.mockReset();
+});
+
+describe("requireAuthIfEnabled", () => {
+	it("allows access without any network call when a token is stored", async () => {
+		localStorage.setItem("logdeck_auth_token", "some-token");
+		await expect(requireAuthIfEnabled()).resolves.toBeUndefined();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("allows access when auth is disabled", async () => {
+		fetchMock.mockResolvedValue(jsonResponse(200, { authEnabled: false }));
+		await expect(requireAuthIfEnabled()).resolves.toBeUndefined();
+	});
+
+	it("redirects to /login when auth is enabled and no token is stored", async () => {
+		fetchMock.mockResolvedValue(jsonResponse(200, { authEnabled: true }));
+		const error = await requireAuthIfEnabled().catch((e) => e);
+		expect(isRedirect(error)).toBe(true);
+	});
+
+	it("fails closed when the auth status cannot be determined", async () => {
+		fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+		const error = await requireAuthIfEnabled().catch((e) => e);
+		expect(error).toBeInstanceOf(AuthConfigUnavailableError);
+		expect(isRedirect(error)).toBe(false);
+	});
+
+	it("uses the cached auth status on repeat navigations", async () => {
+		fetchMock.mockResolvedValue(jsonResponse(200, { authEnabled: false }));
+		await requireAuthIfEnabled();
+		await requireAuthIfEnabled();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/lib/auth-guard.ts
+++ b/frontend/src/lib/auth-guard.ts
@@ -1,45 +1,24 @@
 import { redirect } from "@tanstack/react-router";
 
-import { API_BASE_URL } from "@/types/api";
+import { isAuthEnabled } from "@/lib/auth-config";
 
 /**
- * Auth guard function that checks if authentication is enabled and redirects to login if needed.
+ * Route guard: redirects to /login when auth is enabled and no token is
+ * stored. The auth status comes from the cached /auth/config lookup, so
+ * navigations after the first do not hit the network.
  *
- * This function:
- * - Gets the token from localStorage
- * - If no token exists, checks if auth is enabled by calling the login endpoint
- * - Returns (allows access) when the endpoint responds with 404 (auth disabled)
- * - Redirects to /login when auth is enabled and no token is present
- * - Preserves existing catch behavior that only rethrows redirect errors
+ * Fails closed: when the auth status cannot be determined, the
+ * AuthConfigUnavailableError from isAuthEnabled propagates and the router's
+ * error boundary is shown instead of the app; its retry re-runs this guard
+ * and re-fetches the status (failures are not cached).
  */
 export async function requireAuthIfEnabled(): Promise<void> {
-  const token = localStorage.getItem("logdeck_auth_token");
+	const token = localStorage.getItem("logdeck_auth_token");
+	if (token) {
+		return;
+	}
 
-  // If no token, check if auth is required
-  if (!token) {
-    try {
-      const authUrl = `${API_BASE_URL}/api/v1/auth/login`.replace(
-        /([^:]\/)\/+/g,
-        "$1"
-      );
-      const response = await fetch(authUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username: "", password: "" }),
-      });
-
-      // If 404, auth is disabled - allow access
-      if (response.status === 404) {
-        return;
-      }
-
-      // Auth is enabled but no token - redirect to login
-      throw redirect({ to: "/login" });
-    } catch (error) {
-      // If we can't reach the server, allow access (fail open for development)
-      if (error instanceof Error && error.message.includes("redirect")) {
-        throw error;
-      }
-    }
-  }
+	if (await isAuthEnabled()) {
+		throw redirect({ to: "/login" });
+	}
 }

--- a/server/internal/api/auth_config_test.go
+++ b/server/internal/api/auth_config_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func getAuthConfig(t *testing.T, router http.Handler) map[string]bool {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/auth/config", nil)
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var body map[string]bool
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return body
+}
+
+func TestAuthConfigEnabled(t *testing.T) {
+	router := newTestRouter(t, newTestAuthService(t))
+
+	body := getAuthConfig(t, router)
+	if !body["authEnabled"] {
+		t.Error("expected authEnabled to be true when auth service is configured")
+	}
+}
+
+func TestAuthConfigDisabled(t *testing.T) {
+	router := newTestRouter(t, nil)
+
+	body := getAuthConfig(t, router)
+	if body["authEnabled"] {
+		t.Error("expected authEnabled to be false when auth service is nil")
+	}
+}

--- a/server/internal/api/ratelimit.go
+++ b/server/internal/api/ratelimit.go
@@ -3,6 +3,8 @@ package api
 import (
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -64,14 +66,34 @@ func (rl *rateLimiter) sweep(now time.Time) {
 	}
 }
 
+// clientIP returns the client IP used as the rate-limit key. Proxy headers
+// (X-Forwarded-For, X-Real-IP) are only trusted when TRUST_PROXY_HEADERS=true
+// is set - behind a reverse proxy every client otherwise collapses to the
+// proxy's IP, while trusting the headers on a directly exposed server would
+// let clients spoof their way past the limit.
+func clientIP(r *http.Request) string {
+	if os.Getenv("TRUST_PROXY_HEADERS") == "true" {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			if ip := strings.TrimSpace(strings.Split(xff, ",")[0]); ip != "" {
+				return ip
+			}
+		}
+		if ip := r.Header.Get("X-Real-IP"); ip != "" {
+			return ip
+		}
+	}
+
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
 // middleware rejects requests over the per-IP limit with 429 Too Many Requests.
 func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			ip = r.RemoteAddr
-		}
-		if !rl.allow(ip) {
+		if !rl.allow(clientIP(r)) {
 			http.Error(w, "Too many login attempts, please try again later", http.StatusTooManyRequests)
 			return
 		}

--- a/server/internal/api/ratelimit_test.go
+++ b/server/internal/api/ratelimit_test.go
@@ -72,3 +72,51 @@ func TestRateLimiterMiddleware(t *testing.T) {
 		t.Errorf("expected 429 over the limit, got %d", w.Code)
 	}
 }
+
+func TestClientIPIgnoresProxyHeadersByDefault(t *testing.T) {
+	t.Setenv("TRUST_PROXY_HEADERS", "")
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7")
+	r.Header.Set("X-Real-IP", "203.0.113.8")
+
+	if got := clientIP(r); got != "10.0.0.1" {
+		t.Errorf("expected spoofed headers to be ignored, got %q", got)
+	}
+}
+
+func TestClientIPHonorsProxyHeadersWhenTrusted(t *testing.T) {
+	t.Setenv("TRUST_PROXY_HEADERS", "true")
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
+
+	if got := clientIP(r); got != "203.0.113.7" {
+		t.Errorf("expected leftmost X-Forwarded-For entry, got %q", got)
+	}
+}
+
+func TestClientIPFallsBackToRealIPWhenTrusted(t *testing.T) {
+	t.Setenv("TRUST_PROXY_HEADERS", "true")
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+	r.Header.Set("X-Real-IP", "203.0.113.8")
+
+	if got := clientIP(r); got != "203.0.113.8" {
+		t.Errorf("expected X-Real-IP, got %q", got)
+	}
+}
+
+func TestClientIPUsesRemoteAddrWithoutHeaders(t *testing.T) {
+	t.Setenv("TRUST_PROXY_HEADERS", "true")
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+
+	if got := clientIP(r); got != "10.0.0.1" {
+		t.Errorf("expected RemoteAddr host, got %q", got)
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -67,6 +67,10 @@ func (ar *APIRouter) Routes() *chi.Mux {
 		// System stats - publicly available
 		r.Get("/system/stats", ar.GetSystemStats)
 
+		// Auth config - publicly available so the frontend can tell whether
+		// auth is enabled without probing the login endpoint
+		r.Get("/auth/config", ar.handleAuthConfig)
+
 		// Auth endpoints (always registered, dynamic behavior)
 		r.With(loginRateLimiter.middleware).Post("/auth/login", ar.handleLogin)
 
@@ -132,6 +136,13 @@ func (ar *APIRouter) registerSettingsRoutes(r chi.Router) {
 		r.Put("/auth", ar.UpdateAuth)
 		r.Post("/test/docker-host", ar.TestDockerHost)
 		r.Post("/test/coolify-host", ar.TestCoolifyHost)
+	})
+}
+
+// handleAuthConfig reports whether authentication is enabled. Public, no auth.
+func (ar *APIRouter) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
+	WriteJsonResponse(w, http.StatusOK, map[string]bool{
+		"authEnabled": ar.registry.Auth() != nil,
 	})
 }
 

--- a/server/internal/api/settings_handlers.go
+++ b/server/internal/api/settings_handlers.go
@@ -247,12 +247,15 @@ func (ar *APIRouter) UpdateAuth(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if req.NewPassword != "" {
-				salt, err := auth.GenerateRandomHex(32)
+				// New passwords are stored as bcrypt hashes. Existing SHA256
+				// hashes keep working (ValidateCredentials detects the format
+				// by prefix) until the password is next changed.
+				hash, err := auth.HashPassword(req.NewPassword)
 				if err != nil {
-					return nil, fmt.Errorf("failed to generate salt")
+					return nil, fmt.Errorf("failed to hash password")
 				}
-				authCfg.AdminPasswordSalt = salt
-				authCfg.AdminPasswordHash = auth.HashPasswordSHA256(req.NewPassword, salt)
+				authCfg.AdminPasswordHash = hash
+				authCfg.AdminPasswordSalt = ""
 			}
 
 			if authCfg.AdminPasswordHash == "" {

--- a/server/internal/api/settings_password_test.go
+++ b/server/internal/api/settings_password_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/auth"
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/services"
+)
+
+func TestUpdateAuthWritesBcryptHash(t *testing.T) {
+	for _, key := range []string{
+		"JWT_SECRET", "ADMIN_USERNAME", "ADMIN_PASSWORD", "ADMIN_PASSWORD_SALT",
+	} {
+		t.Setenv(key, "")
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("CONFIG_PATH", cfgPath)
+
+	manager := config.NewManager()
+	registry := services.NewRegistry(nil, nil, nil, manager.Config())
+	ar := &APIRouter{registry: registry, manager: manager}
+
+	body := `{"enabled":true,"adminUsername":"admin","newPassword":"newpass123"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/settings/auth", strings.NewReader(body))
+	ar.UpdateAuth(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	var file struct {
+		Auth *config.FileAuthConfig `json:"auth"`
+	}
+	if err := json.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("failed to decode config file: %v", err)
+	}
+	if file.Auth == nil {
+		t.Fatal("expected auth section in config file")
+	}
+	if !strings.HasPrefix(file.Auth.AdminPasswordHash, "$2") {
+		t.Errorf("expected bcrypt hash, got %q", file.Auth.AdminPasswordHash)
+	}
+	if file.Auth.AdminPasswordSalt != "" {
+		t.Errorf("expected salt to be cleared, got %q", file.Auth.AdminPasswordSalt)
+	}
+
+	svc := auth.NewServiceFromFileConfig(file.Auth)
+	if svc == nil {
+		t.Fatal("failed to create auth service from written config")
+	}
+	if err := svc.ValidateCredentials("admin", "newpass123"); err != nil {
+		t.Errorf("new password should validate against the bcrypt hash: %v", err)
+	}
+}
+
+func TestExistingSHA256ConfigStillValidates(t *testing.T) {
+	svc := newTestAuthService(t) // configured with a SHA256 hash + salt
+	if err := svc.ValidateCredentials("admin", "password"); err != nil {
+		t.Errorf("existing SHA256 config should keep validating: %v", err)
+	}
+}

--- a/server/internal/api/terminal.go
+++ b/server/internal/api/terminal.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/AmoabaKelvin/logdeck/internal/auth"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
 	"github.com/docker/docker/api/types"
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
@@ -70,6 +74,17 @@ func (ar *APIRouter) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Close()
 
+	// Exec sessions grant shell access inside containers - audit them.
+	user := execAuditUser(r)
+	start := time.Now()
+	slog.Info("exec session opened",
+		"user", user, "host", host, "container", id, "exec_id", execID)
+	defer func() {
+		slog.Info("exec session closed",
+			"user", user, "host", host, "container", id, "exec_id", execID,
+			"duration", time.Since(start))
+	}()
+
 	outputDone := make(chan struct{})
 	inputDone := make(chan struct{})
 
@@ -87,6 +102,15 @@ func (ar *APIRouter) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 	case <-outputDone:
 	case <-inputDone:
 	}
+}
+
+// execAuditUser returns the authenticated username for audit logs, or
+// "anonymous" when auth is disabled.
+func execAuditUser(r *http.Request) string {
+	if user, ok := r.Context().Value(auth.UserContextKey).(models.User); ok {
+		return user.Username
+	}
+	return "anonymous"
 }
 
 func (ar *APIRouter) startExecSession(ctx context.Context, host, containerID string) (string, *types.HijackedResponse, error) {


### PR DESCRIPTION
## Summary

Consolidates authentication state handling and closes several verified gaps. Scope was deliberately limited: no RBAC, multi-user, JWT refresh/revocation, or encrypted config storage - those are separate projects.

**Frontend**

Three independent copies of "is auth enabled?" existed - in auth-context, auth-guard, and api-client - each POSTing empty credentials to /auth/login and inferring the answer from a 404, using two different URL-normalizing regexes. api-client derived the login URL from the failed request path with a greedy regex that dropped query strings, and fired that probe on every 401.

- All three now read a new cached `GET /api/v1/auth/config`. Both regexes and all empty-credential probes are gone.
- `auth-guard` previously **granted access when the server was unreachable** (a comment called it a development convenience; it shipped to production). It now fails closed: the error surfaces through the router error boundary, whose retry re-fetches because failed lookups are not cached. It also no longer detects TanStack's `redirect()` throw by string-matching the error message.
- The api-client 401 handler clears the token and redirects, without probing.

**Server**

- New public `GET /api/v1/auth/config` returning only `{"authEnabled": bool}`. No new disclosure: `/auth/login` already revealed auth-disabled status via its 404.
- **Exec session auditing.** Terminal sessions grant shell access inside containers and were entirely unaudited. Structured slog records now mark session open and close with user, host, container, exec id, and duration.
- **Proxy-aware rate limiting.** The login limiter keyed on `RemoteAddr`, so behind a reverse proxy (the common Coolify/Traefik deployment) every client collapsed to the proxy IP and one attacker could lock out everyone. It now reads `X-Forwarded-For`/`X-Real-IP`, but **only when `TRUST_PROXY_HEADERS=true`** - otherwise a direct attacker could spoof the header to bypass the limit entirely. Documented in env.example.
- **bcrypt for UI-set passwords.** Passwords configured through the settings UI were stored as single-round SHA256+salt while only the env path used bcrypt. New and changed passwords are now bcrypt; existing SHA256 installs keep working untouched, with no forced password reset.

## Tests

Frontend suite goes from 40 to 56 tests: new coverage for auth-config, auth-guard (enabled/disabled/no-token/fail-closed), and api-client (401 clears token and redirects, no empty-credential POST is ever issued) - the two most security-critical frontend files previously had zero. Server adds tests for the config endpoint, client-IP extraction (spoofed header ignored unless trusted), and the bcrypt/SHA256 password paths.

go build, go vet, go test, tsc, biome lint, vitest, and the production build all pass.

https://claude.ai/code/session_01Ksbg2abvq4FA4DrsYjnDoi