### PR TITLE
feat: read-only images, volumes, and networks views

### DIFF
--- a/frontend/src/features/containers/components/containers-dashboard.tsx
+++ b/frontend/src/features/containers/components/containers-dashboard.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Spinner } from "@/components/ui/spinner";
 
+import { ResourceNav } from "@/features/resources/components/resource-nav";
+
 import {
   removeContainer,
   restartContainer,
@@ -380,6 +382,7 @@ export function ContainersDashboard() {
 
   return (
     <div className="w-full space-y-8">
+      <ResourceNav />
       <ContainersSummaryCards
         totalContainers={containers.length}
         hostInfo={hostInfo}

--- a/frontend/src/features/resources/api/get-resources.ts
+++ b/frontend/src/features/resources/api/get-resources.ts
@@ -1,0 +1,47 @@
+import type { HostError } from "@/features/containers/types";
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+import type { ImageInfo, NetworkInfo, VolumeInfo } from "../types";
+
+export interface ResourceResponse<T> {
+	items: T[];
+	hostErrors: HostError[];
+}
+
+async function getResource<T>(
+	path: string,
+	key: string,
+): Promise<ResourceResponse<T>> {
+	const response = await authenticatedFetch(`${API_BASE_URL}/api/v1/${path}`);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || `Request failed with status ${response.status}`);
+	}
+
+	const data = (await response.json()) as Record<string, unknown> | null;
+	const items = data?.[key];
+
+	if (!Array.isArray(items)) {
+		throw new Error("Unexpected response format");
+	}
+
+	const hostErrors = data?.hostErrors;
+
+	return {
+		items: items as T[],
+		hostErrors: Array.isArray(hostErrors) ? (hostErrors as HostError[]) : [],
+	};
+}
+
+export function getImages(): Promise<ResourceResponse<ImageInfo>> {
+	return getResource<ImageInfo>("images", "images");
+}
+
+export function getVolumes(): Promise<ResourceResponse<VolumeInfo>> {
+	return getResource<VolumeInfo>("volumes", "volumes");
+}
+
+export function getNetworks(): Promise<ResourceResponse<NetworkInfo>> {
+	return getResource<NetworkInfo>("networks", "networks");
+}

--- a/frontend/src/features/resources/components/images-page.tsx
+++ b/frontend/src/features/resources/components/images-page.tsx
@@ -1,0 +1,64 @@
+import { formatDistanceToNow } from "date-fns";
+import { useMemo } from "react";
+
+import { formatBytes } from "@/features/containers/components/container-utils";
+
+import { useImagesQuery } from "../hooks/use-resources";
+import type { ImageInfo } from "../types";
+import type { ResourceColumn } from "./resource-page";
+import { ResourcePage } from "./resource-page";
+
+export function ImagesPage() {
+	const { data, isLoading, error, isFetching, refetch } = useImagesQuery();
+	const items = data?.items ?? [];
+	const hostErrors = data?.hostErrors ?? [];
+
+	const showHost = useMemo(
+		() => new Set(items.map((item) => item.host)).size > 1,
+		[items],
+	);
+
+	const columns: ResourceColumn<ImageInfo>[] = [
+		{
+			header: "Tags",
+			cell: (image) =>
+				image.repo_tags?.length ? (
+					image.repo_tags.join(", ")
+				) : (
+					<span className="text-muted-foreground">&lt;none&gt; (dangling)</span>
+				),
+		},
+		{
+			header: "ID",
+			cell: (image) => <span className="font-mono text-xs">{image.id}</span>,
+		},
+		{ header: "Size", cell: (image) => formatBytes(image.size) },
+		{
+			header: "Created",
+			cell: (image) =>
+				formatDistanceToNow(new Date(image.created * 1000), {
+					addSuffix: true,
+				}),
+		},
+		...(showHost
+			? [{ header: "Host", cell: (image: ImageInfo) => image.host }]
+			: []),
+	];
+
+	return (
+		<ResourcePage
+			title="Images"
+			items={items}
+			hostErrors={hostErrors}
+			isLoading={isLoading}
+			error={error}
+			isFetching={isFetching}
+			onRefresh={() => void refetch()}
+			columns={columns}
+			rowKey={(image) => `${image.host}-${image.id}`}
+			filterText={(image) =>
+				`${(image.repo_tags ?? []).join(" ")} ${image.id} ${image.host}`
+			}
+		/>
+	);
+}

--- a/frontend/src/features/resources/components/networks-page.tsx
+++ b/frontend/src/features/resources/components/networks-page.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+
+import { useNetworksQuery } from "../hooks/use-resources";
+import type { NetworkInfo } from "../types";
+import type { ResourceColumn } from "./resource-page";
+import { ResourcePage } from "./resource-page";
+
+export function NetworksPage() {
+	const { data, isLoading, error, isFetching, refetch } = useNetworksQuery();
+	const items = data?.items ?? [];
+	const hostErrors = data?.hostErrors ?? [];
+
+	const showHost = useMemo(
+		() => new Set(items.map((item) => item.host)).size > 1,
+		[items],
+	);
+
+	const columns: ResourceColumn<NetworkInfo>[] = [
+		{ header: "Name", cell: (network) => network.name },
+		{
+			header: "ID",
+			cell: (network) => (
+				<span className="font-mono text-xs">{network.id}</span>
+			),
+		},
+		{ header: "Driver", cell: (network) => network.driver },
+		{ header: "Scope", cell: (network) => network.scope },
+		{
+			header: "Subnets",
+			cell: (network) => network.subnets?.join(", ") ?? "—",
+		},
+		...(showHost
+			? [{ header: "Host", cell: (network: NetworkInfo) => network.host }]
+			: []),
+	];
+
+	return (
+		<ResourcePage
+			title="Networks"
+			items={items}
+			hostErrors={hostErrors}
+			isLoading={isLoading}
+			error={error}
+			isFetching={isFetching}
+			onRefresh={() => void refetch()}
+			columns={columns}
+			rowKey={(network) => `${network.host}-${network.id}`}
+			filterText={(network) =>
+				`${network.name} ${network.id} ${network.driver} ${network.scope} ${(network.subnets ?? []).join(" ")} ${network.host}`
+			}
+		/>
+	);
+}

--- a/frontend/src/features/resources/components/resource-nav.tsx
+++ b/frontend/src/features/resources/components/resource-nav.tsx
@@ -1,0 +1,19 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+
+export function ResourceNav() {
+	return (
+		<nav className="flex items-center gap-1">
+			<Button variant="ghost" size="sm" asChild>
+				<Link to="/images">Images</Link>
+			</Button>
+			<Button variant="ghost" size="sm" asChild>
+				<Link to="/volumes">Volumes</Link>
+			</Button>
+			<Button variant="ghost" size="sm" asChild>
+				<Link to="/networks">Networks</Link>
+			</Button>
+		</nav>
+	);
+}

--- a/frontend/src/features/resources/components/resource-page.tsx
+++ b/frontend/src/features/resources/components/resource-page.tsx
@@ -1,0 +1,139 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowLeftIcon, RefreshCcwIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import type { HostError } from "@/features/containers/types";
+
+export interface ResourceColumn<T> {
+	header: string;
+	cell: (item: T) => ReactNode;
+}
+
+interface ResourcePageProps<T> {
+	title: string;
+	items: T[];
+	hostErrors: HostError[];
+	isLoading: boolean;
+	error: Error | null;
+	isFetching: boolean;
+	onRefresh: () => void;
+	columns: ResourceColumn<T>[];
+	rowKey: (item: T) => string;
+	filterText: (item: T) => string;
+}
+
+export function ResourcePage<T>({
+	title,
+	items,
+	hostErrors,
+	isLoading,
+	error,
+	isFetching,
+	onRefresh,
+	columns,
+	rowKey,
+	filterText,
+}: ResourcePageProps<T>) {
+	const [filter, setFilter] = useState("");
+
+	const filtered = useMemo(() => {
+		const query = filter.trim().toLowerCase();
+		if (!query) return items;
+		return items.filter((item) =>
+			filterText(item).toLowerCase().includes(query),
+		);
+	}, [items, filter, filterText]);
+
+	return (
+		<div className="w-full space-y-4">
+			<div className="flex items-center justify-between gap-4">
+				<div className="flex items-center gap-2">
+					<Button variant="ghost" size="sm" className="h-9 shrink-0" asChild>
+						<Link to="/" aria-label="Back to dashboard">
+							<ArrowLeftIcon className="size-4" />
+						</Link>
+					</Button>
+					<h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+				</div>
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={onRefresh}
+					className="h-9 shrink-0"
+				>
+					<RefreshCcwIcon
+						className={`size-4 ${isFetching ? "animate-spin" : ""}`}
+					/>
+				</Button>
+			</div>
+
+			{hostErrors.map((hostError) => (
+				<p key={hostError.host} className="text-sm text-muted-foreground">
+					Could not reach host "{hostError.host}": {hostError.message}
+				</p>
+			))}
+
+			<Input
+				placeholder={`Filter ${title.toLowerCase()}...`}
+				value={filter}
+				onChange={(event) => setFilter(event.target.value)}
+				className="max-w-sm"
+			/>
+
+			{isLoading ? (
+				<div className="flex items-center justify-center py-20">
+					<Spinner className="size-6" />
+				</div>
+			) : error ? (
+				<p className="text-sm text-destructive">
+					Failed to load {title.toLowerCase()}: {error.message}
+				</p>
+			) : (
+				<div className="rounded-md border">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								{columns.map((column) => (
+									<TableHead key={column.header}>{column.header}</TableHead>
+								))}
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{filtered.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={columns.length}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No {title.toLowerCase()} found.
+									</TableCell>
+								</TableRow>
+							) : (
+								filtered.map((item) => (
+									<TableRow key={rowKey(item)}>
+										{columns.map((column) => (
+											<TableCell key={column.header}>
+												{column.cell(item)}
+											</TableCell>
+										))}
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/features/resources/components/volumes-page.tsx
+++ b/frontend/src/features/resources/components/volumes-page.tsx
@@ -1,0 +1,60 @@
+import { formatDistanceToNow } from "date-fns";
+import { useMemo } from "react";
+
+import { useVolumesQuery } from "../hooks/use-resources";
+import type { VolumeInfo } from "../types";
+import type { ResourceColumn } from "./resource-page";
+import { ResourcePage } from "./resource-page";
+
+function formatCreated(created: string): string {
+	const date = new Date(created);
+	if (!created || Number.isNaN(date.getTime())) return "—";
+	return formatDistanceToNow(date, { addSuffix: true });
+}
+
+export function VolumesPage() {
+	const { data, isLoading, error, isFetching, refetch } = useVolumesQuery();
+	const items = data?.items ?? [];
+	const hostErrors = data?.hostErrors ?? [];
+
+	const showHost = useMemo(
+		() => new Set(items.map((item) => item.host)).size > 1,
+		[items],
+	);
+
+	const columns: ResourceColumn<VolumeInfo>[] = [
+		{ header: "Name", cell: (volume) => volume.name },
+		{ header: "Driver", cell: (volume) => volume.driver },
+		{
+			header: "Mountpoint",
+			cell: (volume) => (
+				<span className="font-mono text-xs">{volume.mountpoint}</span>
+			),
+		},
+		{ header: "Created", cell: (volume) => formatCreated(volume.created) },
+		{
+			header: "Labels",
+			cell: (volume) => Object.keys(volume.labels ?? {}).length,
+		},
+		...(showHost
+			? [{ header: "Host", cell: (volume: VolumeInfo) => volume.host }]
+			: []),
+	];
+
+	return (
+		<ResourcePage
+			title="Volumes"
+			items={items}
+			hostErrors={hostErrors}
+			isLoading={isLoading}
+			error={error}
+			isFetching={isFetching}
+			onRefresh={() => void refetch()}
+			columns={columns}
+			rowKey={(volume) => `${volume.host}-${volume.name}`}
+			filterText={(volume) =>
+				`${volume.name} ${volume.driver} ${volume.mountpoint} ${volume.host}`
+			}
+		/>
+	);
+}

--- a/frontend/src/features/resources/hooks/use-resources.ts
+++ b/frontend/src/features/resources/hooks/use-resources.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getImages, getNetworks, getVolumes } from "../api/get-resources";
+
+export function useImagesQuery() {
+	return useQuery({
+		queryKey: ["images"],
+		queryFn: getImages,
+		staleTime: 10_000,
+	});
+}
+
+export function useVolumesQuery() {
+	return useQuery({
+		queryKey: ["volumes"],
+		queryFn: getVolumes,
+		staleTime: 10_000,
+	});
+}
+
+export function useNetworksQuery() {
+	return useQuery({
+		queryKey: ["networks"],
+		queryFn: getNetworks,
+		staleTime: 10_000,
+	});
+}

--- a/frontend/src/features/resources/types.ts
+++ b/frontend/src/features/resources/types.ts
@@ -1,0 +1,25 @@
+export interface ImageInfo {
+	id: string;
+	repo_tags: string[] | null;
+	size: number;
+	created: number;
+	host: string;
+}
+
+export interface VolumeInfo {
+	name: string;
+	driver: string;
+	mountpoint: string;
+	created: string;
+	labels?: Record<string, string>;
+	host: string;
+}
+
+export interface NetworkInfo {
+	id: string;
+	name: string;
+	driver: string;
+	scope: string;
+	subnets?: string[];
+	host: string;
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -9,19 +9,37 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as VolumesRouteImport } from './routes/volumes'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as NetworksRouteImport } from './routes/networks'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as ImagesRouteImport } from './routes/images'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ContainersContainerIdLogsRouteImport } from './routes/containers/$containerId/logs'
 
+const VolumesRoute = VolumesRouteImport.update({
+  id: '/volumes',
+  path: '/volumes',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
+const NetworksRoute = NetworksRouteImport.update({
+  id: '/networks',
+  path: '/networks',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ImagesRoute = ImagesRouteImport.update({
+  id: '/images',
+  path: '/images',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -38,45 +56,81 @@ const ContainersContainerIdLogsRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/images': typeof ImagesRoute
   '/login': typeof LoginRoute
+  '/networks': typeof NetworksRoute
   '/settings': typeof SettingsRoute
+  '/volumes': typeof VolumesRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/images': typeof ImagesRoute
   '/login': typeof LoginRoute
+  '/networks': typeof NetworksRoute
   '/settings': typeof SettingsRoute
+  '/volumes': typeof VolumesRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/images': typeof ImagesRoute
   '/login': typeof LoginRoute
+  '/networks': typeof NetworksRoute
   '/settings': typeof SettingsRoute
+  '/volumes': typeof VolumesRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/settings' | '/containers/$containerId/logs'
+  fullPaths:
+    | '/'
+    | '/images'
+    | '/login'
+    | '/networks'
+    | '/settings'
+    | '/volumes'
+    | '/containers/$containerId/logs'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/settings' | '/containers/$containerId/logs'
+  to:
+    | '/'
+    | '/images'
+    | '/login'
+    | '/networks'
+    | '/settings'
+    | '/volumes'
+    | '/containers/$containerId/logs'
   id:
     | '__root__'
     | '/'
+    | '/images'
     | '/login'
+    | '/networks'
     | '/settings'
+    | '/volumes'
     | '/containers/$containerId/logs'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ImagesRoute: typeof ImagesRoute
   LoginRoute: typeof LoginRoute
+  NetworksRoute: typeof NetworksRoute
   SettingsRoute: typeof SettingsRoute
+  VolumesRoute: typeof VolumesRoute
   ContainersContainerIdLogsRoute: typeof ContainersContainerIdLogsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/volumes': {
+      id: '/volumes'
+      path: '/volumes'
+      fullPath: '/volumes'
+      preLoaderRoute: typeof VolumesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/settings': {
       id: '/settings'
       path: '/settings'
@@ -84,11 +138,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/networks': {
+      id: '/networks'
+      path: '/networks'
+      fullPath: '/networks'
+      preLoaderRoute: typeof NetworksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/images': {
+      id: '/images'
+      path: '/images'
+      fullPath: '/images'
+      preLoaderRoute: typeof ImagesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -110,8 +178,11 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ImagesRoute: ImagesRoute,
   LoginRoute: LoginRoute,
+  NetworksRoute: NetworksRoute,
   SettingsRoute: SettingsRoute,
+  VolumesRoute: VolumesRoute,
   ContainersContainerIdLogsRoute: ContainersContainerIdLogsRoute,
 }
 export const routeTree = rootRouteImport

--- a/frontend/src/routes/images.tsx
+++ b/frontend/src/routes/images.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { ImagesPage } from "@/features/resources/components/images-page";
+import { requireAuthIfEnabled } from "@/lib/auth-guard";
+
+export const Route = createFileRoute("/images")({
+	beforeLoad: async () => {
+		await requireAuthIfEnabled();
+	},
+	component: Images,
+});
+
+function Images() {
+	return (
+		<main className="container mx-auto px-4 py-8">
+			<ImagesPage />
+		</main>
+	);
+}

--- a/frontend/src/routes/networks.tsx
+++ b/frontend/src/routes/networks.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { NetworksPage } from "@/features/resources/components/networks-page";
+import { requireAuthIfEnabled } from "@/lib/auth-guard";
+
+export const Route = createFileRoute("/networks")({
+	beforeLoad: async () => {
+		await requireAuthIfEnabled();
+	},
+	component: Networks,
+});
+
+function Networks() {
+	return (
+		<main className="container mx-auto px-4 py-8">
+			<NetworksPage />
+		</main>
+	);
+}

--- a/frontend/src/routes/volumes.tsx
+++ b/frontend/src/routes/volumes.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { VolumesPage } from "@/features/resources/components/volumes-page";
+import { requireAuthIfEnabled } from "@/lib/auth-guard";
+
+export const Route = createFileRoute("/volumes")({
+	beforeLoad: async () => {
+		await requireAuthIfEnabled();
+	},
+	component: Volumes,
+});
+
+function Volumes() {
+	return (
+		<main className="container mx-auto px-4 py-8">
+			<VolumesPage />
+		</main>
+	);
+}

--- a/server/internal/api/resources_handlers.go
+++ b/server/internal/api/resources_handlers.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+)
+
+func hostErrorMessages(hostErrors []docker.HostError) []map[string]string {
+	messages := make([]map[string]string, 0, len(hostErrors))
+	for _, he := range hostErrors {
+		messages = append(messages, map[string]string{
+			"host":    he.HostName,
+			"message": he.Err.Error(),
+		})
+	}
+	return messages
+}
+
+func (ar *APIRouter) GetImages(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	images, hostErrors := ar.registry.Docker().ListImagesAllHosts(ctx)
+	sort.Slice(images, func(i, j int) bool {
+		return images[i].Created > images[j].Created
+	})
+
+	WriteJsonResponse(w, http.StatusOK, map[string]any{
+		"images":     images,
+		"hostErrors": hostErrorMessages(hostErrors),
+	})
+}
+
+func (ar *APIRouter) GetVolumes(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	volumes, hostErrors := ar.registry.Docker().ListVolumesAllHosts(ctx)
+	sort.Slice(volumes, func(i, j int) bool {
+		return volumes[i].Name < volumes[j].Name
+	})
+
+	WriteJsonResponse(w, http.StatusOK, map[string]any{
+		"volumes":    volumes,
+		"hostErrors": hostErrorMessages(hostErrors),
+	})
+}
+
+func (ar *APIRouter) GetNetworks(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	networks, hostErrors := ar.registry.Docker().ListNetworksAllHosts(ctx)
+	sort.Slice(networks, func(i, j int) bool {
+		return networks[i].Name < networks[j].Name
+	})
+
+	WriteJsonResponse(w, http.StatusOK, map[string]any{
+		"networks":   networks,
+		"hostErrors": hostErrorMessages(hostErrors),
+	})
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -83,6 +83,9 @@ func (ar *APIRouter) Routes() *chi.Mux {
 
 			protected.Get("/auth/me", ar.handleGetMe)
 			protected.Get("/events", ar.GetContainerEvents)
+			protected.Get("/images", ar.GetImages)
+			protected.Get("/volumes", ar.GetVolumes)
+			protected.Get("/networks", ar.GetNetworks)
 			ar.registerContainerRoutes(protected)
 		})
 	})

--- a/server/internal/docker/resources.go
+++ b/server/internal/docker/resources.go
@@ -1,0 +1,141 @@
+package docker
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+)
+
+// shortID trims the sha256: prefix and truncates to the familiar 12 chars.
+func shortID(id string) string {
+	id = strings.TrimPrefix(id, "sha256:")
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}
+
+func (c *MultiHostClient) ListImagesAllHosts(ctx context.Context) ([]models.ImageInfo, []HostError) {
+	result := []models.ImageInfo{}
+	var hostErrors []HostError
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for hostName, apiClient := range c.clients {
+		wg.Add(1)
+		go func(name string, cl *client.Client) {
+			defer wg.Done()
+
+			images, err := cl.ImageList(ctx, image.ListOptions{})
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				hostErrors = append(hostErrors, HostError{HostName: name, Err: err})
+				return
+			}
+
+			for _, img := range images {
+				result = append(result, models.ImageInfo{
+					ID:       shortID(img.ID),
+					RepoTags: img.RepoTags,
+					Size:     img.Size,
+					Created:  img.Created,
+					Host:     name,
+				})
+			}
+		}(hostName, apiClient)
+	}
+
+	wg.Wait()
+	return result, hostErrors
+}
+
+func (c *MultiHostClient) ListVolumesAllHosts(ctx context.Context) ([]models.VolumeInfo, []HostError) {
+	result := []models.VolumeInfo{}
+	var hostErrors []HostError
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for hostName, apiClient := range c.clients {
+		wg.Add(1)
+		go func(name string, cl *client.Client) {
+			defer wg.Done()
+
+			volumes, err := cl.VolumeList(ctx, volume.ListOptions{})
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				hostErrors = append(hostErrors, HostError{HostName: name, Err: err})
+				return
+			}
+
+			for _, vol := range volumes.Volumes {
+				if vol == nil {
+					continue
+				}
+				result = append(result, models.VolumeInfo{
+					Name:       vol.Name,
+					Driver:     vol.Driver,
+					Mountpoint: vol.Mountpoint,
+					Created:    vol.CreatedAt,
+					Labels:     vol.Labels,
+					Host:       name,
+				})
+			}
+		}(hostName, apiClient)
+	}
+
+	wg.Wait()
+	return result, hostErrors
+}
+
+func (c *MultiHostClient) ListNetworksAllHosts(ctx context.Context) ([]models.NetworkInfo, []HostError) {
+	result := []models.NetworkInfo{}
+	var hostErrors []HostError
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for hostName, apiClient := range c.clients {
+		wg.Add(1)
+		go func(name string, cl *client.Client) {
+			defer wg.Done()
+
+			networks, err := cl.NetworkList(ctx, network.ListOptions{})
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				hostErrors = append(hostErrors, HostError{HostName: name, Err: err})
+				return
+			}
+
+			for _, nw := range networks {
+				var subnets []string
+				for _, cfg := range nw.IPAM.Config {
+					if cfg.Subnet != "" {
+						subnets = append(subnets, cfg.Subnet)
+					}
+				}
+				result = append(result, models.NetworkInfo{
+					ID:      shortID(nw.ID),
+					Name:    nw.Name,
+					Driver:  nw.Driver,
+					Scope:   nw.Scope,
+					Subnets: subnets,
+					Host:    name,
+				})
+			}
+		}(hostName, apiClient)
+	}
+
+	wg.Wait()
+	return result, hostErrors
+}

--- a/server/internal/models/resources.go
+++ b/server/internal/models/resources.go
@@ -1,0 +1,30 @@
+package models
+
+// ImageInfo represents the minimal image information exposed by the API
+type ImageInfo struct {
+	ID       string   `json:"id"`
+	RepoTags []string `json:"repo_tags"`
+	Size     int64    `json:"size"`
+	Created  int64    `json:"created"`
+	Host     string   `json:"host"`
+}
+
+// VolumeInfo represents the minimal volume information exposed by the API
+type VolumeInfo struct {
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	Mountpoint string            `json:"mountpoint"`
+	Created    string            `json:"created"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	Host       string            `json:"host"`
+}
+
+// NetworkInfo represents the minimal network information exposed by the API
+type NetworkInfo struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Driver  string   `json:"driver"`
+	Scope   string   `json:"scope"`
+	Subnets []string `json:"subnets,omitempty"`
+	Host    string   `json:"host"`
+}


### PR DESCRIPTION
Adds read-only visibility into what lives on your hosts beyond containers.

## Server
- `GET /api/v1/images`, `GET /api/v1/volumes`, `GET /api/v1/networks` — each fans out per configured host concurrently (same pattern as `ListContainersAllHosts`), so an unreachable host degrades to a `hostErrors` entry instead of failing the call.
- New models in `internal/models/resources.go`; SDK wrappers in `internal/docker/resources.go`.

## Frontend
- New `/images`, `/volumes`, `/networks` pages sharing one table layout (`features/resources/`): text filter, refresh, host column when items span multiple hosts, per-host error lines.
- Compact nav links on the dashboard header.

Read-only v1 by design: no pagination, no actions.

## Verification
- `go build ./... && go test ./...` and frontend vitest + build pass.
- Verified live against Podman 6.0.1 (endpoints curled; pages exercised in the browser).

**Merge order: 1 of 6.** This wave is a stacked chain — merge this first; the next PR retargets automatically.

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource dashboards for Docker images, volumes, and networks.
  * Added navigation between the new resource views and the containers dashboard.
  * Added filtering, sorting, refresh controls, loading states, and empty states.
  * Resource listings now show host-specific errors while displaying available results.
  * Added protected API support for retrieving resources across connected hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->