### PR TITLE
feat: per-host system stats

### DIFF
--- a/frontend/src/features/containers/api/get-hosts-stats.ts
+++ b/frontend/src/features/containers/api/get-hosts-stats.ts
@@ -1,0 +1,34 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+export interface HostStats {
+	host: string;
+	available: boolean;
+	error?: string;
+	name?: string;
+	operating_system?: string;
+	architecture?: string;
+	server_version?: string;
+	ncpu: number;
+	mem_total: number;
+	containers_running: number;
+	containers_paused: number;
+	containers_stopped: number;
+	images: number;
+}
+
+export interface GetHostsStatsResponse {
+	hosts: HostStats[];
+}
+
+export async function getHostsStats(): Promise<GetHostsStatsResponse> {
+	const response = await authenticatedFetch(
+		`${API_BASE_URL}/api/v1/hosts/stats`,
+	);
+
+	if (!response.ok) {
+		throw new Error("Failed to fetch hosts stats");
+	}
+
+	return response.json();
+}

--- a/frontend/src/features/containers/components/containers-dashboard.tsx
+++ b/frontend/src/features/containers/components/containers-dashboard.tsx
@@ -23,6 +23,7 @@ import {
 import { useContainersDashboardUrlState } from "../hooks/use-containers-dashboard-url-state";
 import { useLiveContainersQuery } from "../hooks/use-live-containers-query";
 import { useContainerStats } from "../hooks/use-container-stats";
+import { useHostsStats } from "../hooks/use-hosts-stats";
 import { useSystemStats } from "../hooks/use-system-stats";
 
 import {
@@ -57,6 +58,7 @@ export function ContainersDashboard() {
   const isReadOnly = data?.readOnly ?? false;
   const hosts = data?.hosts ?? [];
   const hostErrors = data?.hostErrors ?? [];
+  const { data: hostsStatsData } = useHostsStats(hosts.length > 1);
 
   useEffect(() => {
     for (const he of hostErrors) {
@@ -384,6 +386,7 @@ export function ContainersDashboard() {
         totalContainers={containers.length}
         hostInfo={hostInfo}
         systemUsage={systemUsage}
+        hostsStats={hostsStatsData?.hosts}
       />
 
       <section className="space-y-4">

--- a/frontend/src/features/containers/components/containers-summary-cards.tsx
+++ b/frontend/src/features/containers/components/containers-summary-cards.tsx
@@ -22,31 +22,79 @@ interface ContainersSummaryCardsProps {
   hostsStats?: HostStats[];
 }
 
+function HostRow({ host }: { host: HostStats }) {
+  return (
+    <div className="space-y-0.5">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-medium truncate" title={host.host}>
+          {host.host}
+        </p>
+        {host.available ? (
+          <span className="text-xs text-muted-foreground shrink-0">
+            v{host.server_version}
+          </span>
+        ) : (
+          <span className="text-xs font-medium text-destructive shrink-0">
+            Unreachable
+          </span>
+        )}
+      </div>
+      {host.available ? (
+        <p className="text-xs text-muted-foreground">
+          {host.ncpu} CPUs • {formatBytes(host.mem_total)} •{" "}
+          {host.containers_running} running / {host.containers_stopped} stopped
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground truncate" title={host.error}>
+          {host.error ?? "Host could not be reached"}
+        </p>
+      )}
+    </div>
+  );
+}
+
 export function ContainersSummaryCards({
   totalContainers,
   hostInfo,
   systemUsage,
   hostsStats,
 }: ContainersSummaryCardsProps) {
+  const multiHost = hostsStats && hostsStats.length > 1;
+
   return (
     <section className="space-y-3">
       <div className="grid gap-3 md:grid-cols-3">
-        <Card className="py-4">
-          <CardContent className="px-6 py-0">
-            <div className="space-y-1">
-              <p className="text-sm text-muted-foreground">Host</p>
-              <p
-                className="text-2xl font-semibold truncate"
-                title={hostInfo.hostname}
-              >
-                {hostInfo.hostname}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {hostInfo.os} • {hostInfo.kernel}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+        {multiHost ? (
+          <Card className="py-4">
+            <CardContent className="px-6 py-0">
+              <div className="space-y-2">
+                <p className="text-sm text-muted-foreground">Hosts</p>
+                <div className="max-h-24 space-y-2 overflow-y-auto">
+                  {hostsStats.map((host) => (
+                    <HostRow key={host.host} host={host} />
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card className="py-4">
+            <CardContent className="px-6 py-0">
+              <div className="space-y-1">
+                <p className="text-sm text-muted-foreground">Host</p>
+                <p
+                  className="text-2xl font-semibold truncate"
+                  title={hostInfo.hostname}
+                >
+                  {hostInfo.hostname}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {hostInfo.os} • {hostInfo.kernel}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         <Card className="py-4">
           <CardContent className="px-6 py-0">
@@ -90,49 +138,6 @@ export function ContainersSummaryCards({
         </Card>
       </div>
 
-      {hostsStats && hostsStats.length > 1 && (
-        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {hostsStats.map((host) => (
-            <Card key={host.host} className="py-3">
-              <CardContent className="px-6 py-0">
-                <div className="space-y-1">
-                  <div className="flex items-center justify-between gap-2">
-                    <p
-                      className="text-sm font-medium truncate"
-                      title={host.host}
-                    >
-                      {host.host}
-                    </p>
-                    {host.available ? (
-                      <span className="text-xs text-muted-foreground shrink-0">
-                        v{host.server_version}
-                      </span>
-                    ) : (
-                      <span className="text-xs font-medium text-destructive shrink-0">
-                        Unreachable
-                      </span>
-                    )}
-                  </div>
-                  {host.available ? (
-                    <p className="text-xs text-muted-foreground">
-                      {host.ncpu} CPUs • {formatBytes(host.mem_total)} •{" "}
-                      {host.containers_running} running /{" "}
-                      {host.containers_stopped} stopped
-                    </p>
-                  ) : (
-                    <p
-                      className="text-xs text-muted-foreground truncate"
-                      title={host.error}
-                    >
-                      {host.error ?? "Host could not be reached"}
-                    </p>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
     </section>
   );
 }

--- a/frontend/src/features/containers/components/containers-summary-cards.tsx
+++ b/frontend/src/features/containers/components/containers-summary-cards.tsx
@@ -1,5 +1,9 @@
 import { Card, CardContent } from "@/components/ui/card";
 
+import type { HostStats } from "../api/get-hosts-stats";
+
+import { formatBytes } from "./container-utils";
+
 interface HostInfo {
   hostname: string;
   os: string;
@@ -15,70 +19,120 @@ interface ContainersSummaryCardsProps {
   totalContainers: number;
   hostInfo: HostInfo;
   systemUsage: SystemUsage;
+  hostsStats?: HostStats[];
 }
 
 export function ContainersSummaryCards({
   totalContainers,
   hostInfo,
   systemUsage,
+  hostsStats,
 }: ContainersSummaryCardsProps) {
   return (
-    <section className="grid gap-3 md:grid-cols-3">
-      <Card className="py-4">
-        <CardContent className="px-6 py-0">
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">Host</p>
-            <p
-              className="text-2xl font-semibold truncate"
-              title={hostInfo.hostname}
-            >
-              {hostInfo.hostname}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {hostInfo.os} • {hostInfo.kernel}
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+    <section className="space-y-3">
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card className="py-4">
+          <CardContent className="px-6 py-0">
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">Host</p>
+              <p
+                className="text-2xl font-semibold truncate"
+                title={hostInfo.hostname}
+              >
+                {hostInfo.hostname}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {hostInfo.os} • {hostInfo.kernel}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
 
-      <Card className="py-4">
-        <CardContent className="px-6 py-0">
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">Containers</p>
-            <p className="text-2xl font-semibold">{totalContainers}</p>
-          </div>
-        </CardContent>
-      </Card>
+        <Card className="py-4">
+          <CardContent className="px-6 py-0">
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">Containers</p>
+              <p className="text-2xl font-semibold">{totalContainers}</p>
+            </div>
+          </CardContent>
+        </Card>
 
-      <Card className="py-4">
-        <CardContent className="px-6 py-0">
-          <div className="space-y-2">
-            <p className="text-sm text-muted-foreground">System</p>
-            <div className="space-y-1.5">
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">CPU</span>
-                <span className="font-medium">{systemUsage.cpu}%</span>
-              </div>
-              <div className="h-1.5 w-full rounded-full bg-muted">
-                <div
-                  className="h-1.5 rounded-full bg-foreground"
-                  style={{ width: `${systemUsage.cpu}%` }}
-                />
-              </div>
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">Memory</span>
-                <span className="font-medium">{systemUsage.memory}%</span>
-              </div>
-              <div className="h-1.5 w-full rounded-full bg-muted">
-                <div
-                  className="h-1.5 rounded-full bg-foreground"
-                  style={{ width: `${systemUsage.memory}%` }}
-                />
+        <Card className="py-4">
+          <CardContent className="px-6 py-0">
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                System (LogDeck host)
+              </p>
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground">CPU</span>
+                  <span className="font-medium">{systemUsage.cpu}%</span>
+                </div>
+                <div className="h-1.5 w-full rounded-full bg-muted">
+                  <div
+                    className="h-1.5 rounded-full bg-foreground"
+                    style={{ width: `${systemUsage.cpu}%` }}
+                  />
+                </div>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground">Memory</span>
+                  <span className="font-medium">{systemUsage.memory}%</span>
+                </div>
+                <div className="h-1.5 w-full rounded-full bg-muted">
+                  <div
+                    className="h-1.5 rounded-full bg-foreground"
+                    style={{ width: `${systemUsage.memory}%` }}
+                  />
+                </div>
               </div>
             </div>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
+
+      {hostsStats && hostsStats.length > 1 && (
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {hostsStats.map((host) => (
+            <Card key={host.host} className="py-3">
+              <CardContent className="px-6 py-0">
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <p
+                      className="text-sm font-medium truncate"
+                      title={host.host}
+                    >
+                      {host.host}
+                    </p>
+                    {host.available ? (
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        v{host.server_version}
+                      </span>
+                    ) : (
+                      <span className="text-xs font-medium text-destructive shrink-0">
+                        Unreachable
+                      </span>
+                    )}
+                  </div>
+                  {host.available ? (
+                    <p className="text-xs text-muted-foreground">
+                      {host.ncpu} CPUs • {formatBytes(host.mem_total)} •{" "}
+                      {host.containers_running} running /{" "}
+                      {host.containers_stopped} stopped
+                    </p>
+                  ) : (
+                    <p
+                      className="text-xs text-muted-foreground truncate"
+                      title={host.error}
+                    >
+                      {host.error ?? "Host could not be reached"}
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/features/containers/hooks/use-hosts-stats.ts
+++ b/frontend/src/features/containers/hooks/use-hosts-stats.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getHostsStats } from "../api/get-hosts-stats";
+
+import { useDocumentVisible } from "./use-document-visible";
+
+export function useHostsStats(enabled: boolean) {
+	const isVisible = useDocumentVisible();
+	return useQuery({
+		queryKey: ["hosts-stats"],
+		queryFn: getHostsStats,
+		enabled,
+		refetchInterval: isVisible ? 10000 : false, // Refresh every 10 seconds while the page is visible
+	});
+}

--- a/server/internal/api/host_handlers.go
+++ b/server/internal/api/host_handlers.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// GetHostsStats returns engine-level info for every configured Docker host.
+// Unreachable hosts are included with available=false instead of failing the
+// whole response.
+func (ar *APIRouter) GetHostsStats(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	hosts := ar.registry.Docker().GetHostsInfo(ctx)
+
+	WriteJsonResponse(w, http.StatusOK, map[string]any{
+		"hosts": hosts,
+	})
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -83,6 +83,7 @@ func (ar *APIRouter) Routes() *chi.Mux {
 
 			protected.Get("/auth/me", ar.handleGetMe)
 			protected.Get("/events", ar.GetContainerEvents)
+			protected.Get("/hosts/stats", ar.GetHostsStats)
 			ar.registerContainerRoutes(protected)
 		})
 	})

--- a/server/internal/docker/host_info.go
+++ b/server/internal/docker/host_info.go
@@ -1,0 +1,59 @@
+package docker
+
+import (
+	"context"
+	"sync"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/api/types/system"
+)
+
+// GetHostsInfo fetches engine-level info for every configured host
+// concurrently. Unreachable hosts are reported as unavailable instead of
+// failing the whole call.
+func (c *MultiHostClient) GetHostsInfo(ctx context.Context) []models.HostInfo {
+	result := make([]models.HostInfo, len(c.hosts))
+	var wg sync.WaitGroup
+
+	for i, host := range c.hosts {
+		wg.Add(1)
+		go func(idx int, hostName string) {
+			defer wg.Done()
+
+			apiClient, err := c.GetClient(hostName)
+			if err != nil {
+				result[idx] = models.HostInfo{Host: hostName, Error: err.Error()}
+				return
+			}
+
+			engineInfo, err := apiClient.Info(ctx)
+			if err != nil {
+				result[idx] = models.HostInfo{Host: hostName, Error: err.Error()}
+				return
+			}
+
+			result[idx] = hostInfoFromEngine(hostName, engineInfo)
+		}(i, host.Name)
+	}
+
+	wg.Wait()
+	return result
+}
+
+// hostInfoFromEngine maps the engine's Info response to the API model.
+func hostInfoFromEngine(hostName string, info system.Info) models.HostInfo {
+	return models.HostInfo{
+		Host:              hostName,
+		Available:         true,
+		Name:              info.Name,
+		OperatingSystem:   info.OperatingSystem,
+		Architecture:      info.Architecture,
+		ServerVersion:     info.ServerVersion,
+		NCPU:              info.NCPU,
+		MemTotal:          info.MemTotal,
+		ContainersRunning: info.ContainersRunning,
+		ContainersPaused:  info.ContainersPaused,
+		ContainersStopped: info.ContainersStopped,
+		Images:            info.Images,
+	}
+}

--- a/server/internal/docker/host_info_test.go
+++ b/server/internal/docker/host_info_test.go
@@ -1,0 +1,64 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/system"
+)
+
+func TestHostInfoFromEngine(t *testing.T) {
+	engineInfo := system.Info{
+		Name:              "daemon-host",
+		OperatingSystem:   "Ubuntu 24.04 LTS",
+		Architecture:      "x86_64",
+		ServerVersion:     "28.0.1",
+		NCPU:              8,
+		MemTotal:          16 * 1024 * 1024 * 1024,
+		ContainersRunning: 3,
+		ContainersPaused:  1,
+		ContainersStopped: 2,
+		Images:            10,
+	}
+
+	got := hostInfoFromEngine("production", engineInfo)
+
+	if got.Host != "production" {
+		t.Errorf("Host = %q, want %q", got.Host, "production")
+	}
+	if !got.Available {
+		t.Error("Available = false, want true")
+	}
+	if got.Error != "" {
+		t.Errorf("Error = %q, want empty", got.Error)
+	}
+	if got.Name != engineInfo.Name {
+		t.Errorf("Name = %q, want %q", got.Name, engineInfo.Name)
+	}
+	if got.OperatingSystem != engineInfo.OperatingSystem {
+		t.Errorf("OperatingSystem = %q, want %q", got.OperatingSystem, engineInfo.OperatingSystem)
+	}
+	if got.Architecture != engineInfo.Architecture {
+		t.Errorf("Architecture = %q, want %q", got.Architecture, engineInfo.Architecture)
+	}
+	if got.ServerVersion != engineInfo.ServerVersion {
+		t.Errorf("ServerVersion = %q, want %q", got.ServerVersion, engineInfo.ServerVersion)
+	}
+	if got.NCPU != engineInfo.NCPU {
+		t.Errorf("NCPU = %d, want %d", got.NCPU, engineInfo.NCPU)
+	}
+	if got.MemTotal != engineInfo.MemTotal {
+		t.Errorf("MemTotal = %d, want %d", got.MemTotal, engineInfo.MemTotal)
+	}
+	if got.ContainersRunning != engineInfo.ContainersRunning {
+		t.Errorf("ContainersRunning = %d, want %d", got.ContainersRunning, engineInfo.ContainersRunning)
+	}
+	if got.ContainersPaused != engineInfo.ContainersPaused {
+		t.Errorf("ContainersPaused = %d, want %d", got.ContainersPaused, engineInfo.ContainersPaused)
+	}
+	if got.ContainersStopped != engineInfo.ContainersStopped {
+		t.Errorf("ContainersStopped = %d, want %d", got.ContainersStopped, engineInfo.ContainersStopped)
+	}
+	if got.Images != engineInfo.Images {
+		t.Errorf("Images = %d, want %d", got.Images, engineInfo.Images)
+	}
+}

--- a/server/internal/models/host.go
+++ b/server/internal/models/host.go
@@ -1,0 +1,19 @@
+package models
+
+// HostInfo represents engine-level capacity and inventory info for a
+// configured Docker host, as reported by the engine's Info API.
+type HostInfo struct {
+	Host              string `json:"host"`
+	Available         bool   `json:"available"`
+	Error             string `json:"error,omitempty"`
+	Name              string `json:"name,omitempty"`
+	OperatingSystem   string `json:"operating_system,omitempty"`
+	Architecture      string `json:"architecture,omitempty"`
+	ServerVersion     string `json:"server_version,omitempty"`
+	NCPU              int    `json:"ncpu"`
+	MemTotal          int64  `json:"mem_total"`
+	ContainersRunning int    `json:"containers_running"`
+	ContainersPaused  int    `json:"containers_paused"`
+	ContainersStopped int    `json:"containers_stopped"`
+	Images            int    `json:"images"`
+}


### PR DESCRIPTION
The "System" stats card only ever described the machine running LogDeck — actively misleading in multi-host setups. This makes host stats honest.

## Server
- `GET /api/v1/hosts/stats` — engine `Info` per configured host, fetched concurrently: daemon name, OS, architecture, server version, CPUs, total memory, container counts, image count. Unreachable hosts return `available: false` with the error instead of failing the response.

## Frontend
- With more than one host configured, the first summary slot becomes a "Hosts" card with compact stacked per-host rows (name, version, CPUs, memory, running/stopped, unreachable state). Single-host setups keep the original Host card.
- The System card is retitled "System (LogDeck host)" so its scope is explicit.

This intentionally shows engine capacity/inventory, not fake live CPU for remote hosts (the engine API does not expose that).

## Verification
- Full Go + frontend suites pass; verified live against Podman 6.0.1 with a two-host configuration.

**Merge order: 2 of 6** (stacked on #73).

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV