### PR TITLE
feat: resource-limit and restart-policy editing

### DIFF
--- a/frontend/src/features/containers/api/get-container-resources.ts
+++ b/frontend/src/features/containers/api/get-container-resources.ts
@@ -1,0 +1,28 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+export interface RestartPolicy {
+  name: string;
+  maximumRetryCount: number;
+}
+
+export interface ContainerResources {
+  memoryBytes: number;
+  nanoCPUs: number;
+  restartPolicy: RestartPolicy;
+}
+
+export async function getContainerResources(
+  id: string,
+  host: string
+): Promise<ContainerResources> {
+  const response = await authenticatedFetch(
+    `${API_BASE_URL}/api/v1/containers/${encodeURIComponent(id)}/resources?host=${encodeURIComponent(host)}`
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch container resources");
+  }
+
+  return response.json();
+}

--- a/frontend/src/features/containers/api/update-container-resources.ts
+++ b/frontend/src/features/containers/api/update-container-resources.ts
@@ -1,0 +1,32 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+import type { RestartPolicy } from "./get-container-resources";
+
+export interface UpdateResourcesRequest {
+  memoryBytes?: number;
+  nanoCPUs?: number;
+  restartPolicy?: RestartPolicy;
+}
+
+export async function updateContainerResources(
+  id: string,
+  host: string,
+  request: UpdateResourcesRequest
+): Promise<void> {
+  const response = await authenticatedFetch(
+    `${API_BASE_URL}/api/v1/containers/${encodeURIComponent(id)}/resources?host=${encodeURIComponent(host)}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    }
+  );
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message.trim() || "Failed to update container resources");
+  }
+}

--- a/frontend/src/features/containers/components/parse-memory.test.ts
+++ b/frontend/src/features/containers/components/parse-memory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMemoryBytes, parseMemoryInput } from "./parse-memory";
+
+describe("parseMemoryInput", () => {
+  it("treats empty input as unlimited", () => {
+    expect(parseMemoryInput("")).toBe(0);
+    expect(parseMemoryInput("   ")).toBe(0);
+  });
+
+  it("parses plain byte values", () => {
+    expect(parseMemoryInput("1073741824")).toBe(1073741824);
+    expect(parseMemoryInput("512b")).toBe(512);
+  });
+
+  it("parses unit suffixes", () => {
+    expect(parseMemoryInput("512k")).toBe(512 * 1024);
+    expect(parseMemoryInput("512m")).toBe(512 * 1024 ** 2);
+    expect(parseMemoryInput("1g")).toBe(1024 ** 3);
+  });
+
+  it("accepts two-letter suffixes, uppercase, and whitespace", () => {
+    expect(parseMemoryInput("512MB")).toBe(512 * 1024 ** 2);
+    expect(parseMemoryInput("1 GB")).toBe(1024 ** 3);
+    expect(parseMemoryInput(" 2kb ")).toBe(2 * 1024);
+  });
+
+  it("parses fractional values", () => {
+    expect(parseMemoryInput("1.5g")).toBe(1.5 * 1024 ** 3);
+    expect(parseMemoryInput("0.5m")).toBe(512 * 1024);
+  });
+
+  it("rejects invalid input", () => {
+    expect(parseMemoryInput("abc")).toBeNull();
+    expect(parseMemoryInput("12x")).toBeNull();
+    expect(parseMemoryInput("-512m")).toBeNull();
+    expect(parseMemoryInput("m512")).toBeNull();
+    expect(parseMemoryInput("1.2.3g")).toBeNull();
+  });
+});
+
+describe("formatMemoryBytes", () => {
+  it("formats 0 and negative values as empty (unlimited)", () => {
+    expect(formatMemoryBytes(0)).toBe("");
+    expect(formatMemoryBytes(-1)).toBe("");
+  });
+
+  it("uses the largest exact unit", () => {
+    expect(formatMemoryBytes(1024 ** 3)).toBe("1g");
+    expect(formatMemoryBytes(512 * 1024 ** 2)).toBe("512m");
+    expect(formatMemoryBytes(2 * 1024)).toBe("2k");
+    expect(formatMemoryBytes(1000)).toBe("1000");
+  });
+
+  it("round-trips fractional gigabytes", () => {
+    expect(formatMemoryBytes(parseMemoryInput("1.5g") ?? 0)).toBe("1536m");
+  });
+});

--- a/frontend/src/features/containers/components/parse-memory.ts
+++ b/frontend/src/features/containers/components/parse-memory.ts
@@ -1,0 +1,44 @@
+const UNIT_MULTIPLIERS: Record<string, number> = {
+  b: 1,
+  k: 1024,
+  m: 1024 ** 2,
+  g: 1024 ** 3,
+};
+
+// Parses a human memory value like "512m", "1.5g", "1073741824" into bytes.
+// Empty input means unlimited (0). Returns null when the input is invalid.
+export function parseMemoryInput(input: string): number | null {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed === "") {
+    return 0;
+  }
+
+  const match = /^(\d+(?:\.\d+)?)\s*(b|kb?|mb?|gb?)?$/.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+
+  const value = Number.parseFloat(match[1]);
+  const unit = match[2]?.[0] ?? "b";
+  return Math.round(value * UNIT_MULTIPLIERS[unit]);
+}
+
+// Formats bytes back into the largest exact unit, e.g. 536870912 -> "512m".
+// Returns "" for 0 or negative values (unlimited).
+export function formatMemoryBytes(bytes: number): string {
+  if (bytes <= 0) {
+    return "";
+  }
+
+  const units: Array<[string, number]> = [
+    ["g", 1024 ** 3],
+    ["m", 1024 ** 2],
+    ["k", 1024],
+  ];
+  for (const [suffix, size] of units) {
+    if (bytes % size === 0) {
+      return `${bytes / size}${suffix}`;
+    }
+  }
+  return `${bytes}`;
+}

--- a/frontend/src/features/containers/components/resource-limits.tsx
+++ b/frontend/src/features/containers/components/resource-limits.tsx
@@ -1,0 +1,241 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Save } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+import { getContainerResources } from "../api/get-container-resources";
+import {
+  type UpdateResourcesRequest,
+  updateContainerResources,
+} from "../api/update-container-resources";
+import { formatMemoryBytes, parseMemoryInput } from "./parse-memory";
+
+interface ResourceLimitsProps {
+  containerId: string;
+  containerHost: string;
+  isReadOnly?: boolean;
+}
+
+const RESTART_POLICIES = [
+  { value: "no", label: "No" },
+  { value: "always", label: "Always" },
+  { value: "unless-stopped", label: "Unless stopped" },
+  { value: "on-failure", label: "On failure" },
+];
+
+export function ResourceLimits({
+  containerId,
+  containerHost,
+  isReadOnly = false,
+}: ResourceLimitsProps) {
+  const queryClient = useQueryClient();
+  const [memory, setMemory] = useState("");
+  const [cpus, setCpus] = useState("");
+  const [restartPolicy, setRestartPolicy] = useState("no");
+  const [maxRetries, setMaxRetries] = useState("");
+  const memoryId = useId();
+  const cpusId = useId();
+  const maxRetriesId = useId();
+
+  const {
+    data: resources,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["container-resources", containerId, containerHost],
+    queryFn: () => getContainerResources(containerId, containerHost),
+    enabled: !!containerId && !!containerHost,
+  });
+
+  useEffect(() => {
+    if (!resources) return;
+    setMemory(formatMemoryBytes(resources.memoryBytes));
+    setCpus(resources.nanoCPUs > 0 ? String(resources.nanoCPUs / 1e9) : "");
+    setRestartPolicy(resources.restartPolicy.name || "no");
+    setMaxRetries(
+      resources.restartPolicy.maximumRetryCount > 0
+        ? String(resources.restartPolicy.maximumRetryCount)
+        : ""
+    );
+  }, [resources]);
+
+  const updateMutation = useMutation({
+    mutationFn: (request: UpdateResourcesRequest) =>
+      updateContainerResources(containerId, containerHost, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["container-resources", containerId, containerHost],
+      });
+      toast.success("Resource limits updated", {
+        description: "Applied live — no container restart needed.",
+      });
+    },
+    onError: (error: Error) => {
+      toast.error("Failed to update resource limits", {
+        description: error.message,
+      });
+    },
+  });
+
+  const handleSave = () => {
+    const memoryBytes = parseMemoryInput(memory);
+    if (memoryBytes === null) {
+      toast.error("Invalid memory limit", {
+        description: 'Use a number with an optional unit, e.g. "512m" or "1g".',
+      });
+      return;
+    }
+
+    const cpuValue = cpus.trim() === "" ? 0 : Number.parseFloat(cpus);
+    if (Number.isNaN(cpuValue) || cpuValue < 0) {
+      toast.error("Invalid CPU limit", {
+        description: "Use a positive number, e.g. 0.5 or 2.",
+      });
+      return;
+    }
+
+    const retryCount =
+      restartPolicy === "on-failure"
+        ? Number.parseInt(maxRetries, 10) || 0
+        : 0;
+
+    updateMutation.mutate({
+      memoryBytes,
+      nanoCPUs: Math.round(cpuValue * 1e9),
+      restartPolicy: {
+        name: restartPolicy,
+        maximumRetryCount: retryCount,
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+        Loading resource limits...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-4 text-sm text-destructive">
+        Failed to load resource limits
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 pt-2">
+      <div className="flex items-center gap-2 justify-end border-b pb-2">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={handleSave}
+                disabled={isReadOnly || updateMutation.isPending}
+                className="h-8"
+              >
+                <Save className="mr-2 h-3.5 w-3.5" />
+                {updateMutation.isPending ? "Saving..." : "Save"}
+              </Button>
+            </TooltipTrigger>
+            {isReadOnly && (
+              <TooltipContent>Cannot edit in read-only mode</TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+
+      <div className="rounded-lg border p-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="space-y-1.5">
+            <Label htmlFor={memoryId} className="text-xs font-medium">
+              Memory limit
+            </Label>
+            <Input
+              id={memoryId}
+              value={memory}
+              onChange={(e) => setMemory(e.target.value)}
+              disabled={isReadOnly}
+              placeholder="e.g. 512m, 1g (empty = unlimited)"
+              className="font-mono text-xs h-8"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={cpusId} className="text-xs font-medium">
+              CPUs
+            </Label>
+            <Input
+              id={cpusId}
+              type="number"
+              min="0"
+              step="0.1"
+              value={cpus}
+              onChange={(e) => setCpus(e.target.value)}
+              disabled={isReadOnly}
+              placeholder="e.g. 1.5 (empty = unlimited)"
+              className="font-mono text-xs h-8"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium">Restart policy</Label>
+            <Select
+              value={restartPolicy}
+              onValueChange={setRestartPolicy}
+              disabled={isReadOnly}
+            >
+              <SelectTrigger className="h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RESTART_POLICIES.map((policy) => (
+                  <SelectItem key={policy.value} value={policy.value}>
+                    {policy.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {restartPolicy === "on-failure" && (
+            <div className="space-y-1.5">
+              <Label htmlFor={maxRetriesId} className="text-xs font-medium">
+                Max retries
+              </Label>
+              <Input
+                id={maxRetriesId}
+                type="number"
+                min="0"
+                step="1"
+                value={maxRetries}
+                onChange={(e) => setMaxRetries(e.target.value)}
+                disabled={isReadOnly}
+                placeholder="0 = unlimited retries"
+                className="font-mono text-xs h-8"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/containers/$containerId/logs.tsx
+++ b/frontend/src/routes/containers/$containerId/logs.tsx
@@ -25,6 +25,7 @@ import { EnvironmentVariables } from "@/features/containers/components/environme
 import type { LogViewerHandle } from "@/features/containers/components/log-viewer/log-viewer";
 import { LogViewer } from "@/features/containers/components/log-viewer/log-viewer";
 import { useUrlLogViewState } from "@/features/containers/components/log-viewer/use-log-view-state";
+import { ResourceLimits } from "@/features/containers/components/resource-limits";
 import { Terminal } from "@/features/containers/components/terminal";
 import { useContainerStats } from "@/features/containers/hooks/use-container-stats";
 import { useLiveContainersQuery } from "@/features/containers/hooks/use-live-containers-query";
@@ -44,6 +45,7 @@ function ContainerLogsPage() {
 
 	const [showLabels, setShowLabels] = useState(false);
 	const [showEnvVariables, setShowEnvVariables] = useState(false);
+	const [showResourceLimits, setShowResourceLimits] = useState(false);
 	const [showTerminal, setShowTerminal] = useState(false);
 	const logViewerRef = useRef<LogViewerHandle>(null);
 	const logViewState = useUrlLogViewState();
@@ -293,6 +295,30 @@ function ContainerLogsPage() {
 													onContainerIdChange={handleContainerRecreated}
 												/>
 											</div>
+										)}
+									</div>
+
+									{/* Resource Limits Section */}
+									<div className="space-y-2 border-t pt-4">
+										<Button
+											variant="ghost"
+											size="sm"
+											onClick={() => setShowResourceLimits((value) => !value)}
+											className="h-8 w-full justify-start text-muted-foreground hover:text-foreground"
+										>
+											<ChevronDownIcon
+												className={`mr-2 size-4 transition-transform ${
+													showResourceLimits ? "rotate-180" : ""
+												}`}
+											/>
+											{showResourceLimits ? "Hide" : "Show"} resource limits
+										</Button>
+										{showResourceLimits && container && (
+											<ResourceLimits
+												containerId={actualContainerId}
+												containerHost={container.host}
+												isReadOnly={containersData?.readOnly}
+											/>
 										)}
 									</div>
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -108,6 +108,7 @@ func (ar *APIRouter) registerContainerRoutes(r chi.Router) {
 		r.Get("/", ar.GetContainer)
 		r.Get("/logs/parsed", ar.GetContainerLogsParsed)
 		r.Get("/env", ar.GetEnvVariables)
+		r.Get("/resources", ar.GetContainerResources)
 
 		// Mutating routes (blocked in read-only mode)
 		r.Group(func(mutating chi.Router) {
@@ -119,6 +120,7 @@ func (ar *APIRouter) registerContainerRoutes(r chi.Router) {
 			mutating.Post("/restart", ar.RestartContainer)
 			mutating.Post("/remove", ar.RemoveContainer)
 			mutating.Put("/env", ar.UpdateEnvVariables)
+			mutating.Put("/resources", ar.UpdateContainerResources)
 			mutating.Get("/exec", ar.HandleTerminal)
 		})
 	})

--- a/server/internal/api/update_handlers.go
+++ b/server/internal/api/update_handlers.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/go-chi/chi/v5"
+)
+
+func (ar *APIRouter) GetContainerResources(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host := r.URL.Query().Get("host")
+
+	if host == "" {
+		http.Error(w, "host parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	container, err := ar.registry.Docker().GetContainer(r.Context(), host, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resources := models.ContainerResources{}
+	if container.HostConfig != nil {
+		resources.MemoryBytes = container.HostConfig.Memory
+		resources.NanoCPUs = container.HostConfig.NanoCPUs
+		resources.RestartPolicy = models.RestartPolicySpec{
+			Name:              string(container.HostConfig.RestartPolicy.Name),
+			MaximumRetryCount: container.HostConfig.RestartPolicy.MaximumRetryCount,
+		}
+	}
+
+	WriteJsonResponse(w, http.StatusOK, resources)
+}
+
+func (ar *APIRouter) UpdateContainerResources(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host := r.URL.Query().Get("host")
+
+	if host == "" {
+		http.Error(w, "host parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	var req models.UpdateResourcesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := ar.registry.Docker().UpdateContainerResources(r.Context(), host, id, req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	WriteJsonResponse(w, http.StatusOK, map[string]any{
+		"message": "Container resources updated",
+	})
+}

--- a/server/internal/api/update_handlers.go
+++ b/server/internal/api/update_handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
 	"github.com/AmoabaKelvin/logdeck/internal/models"
 	"github.com/go-chi/chi/v5"
 )
@@ -26,7 +27,11 @@ func (ar *APIRouter) GetContainerResources(w http.ResponseWriter, r *http.Reques
 	resources := models.ContainerResources{}
 	if container.HostConfig != nil {
 		resources.MemoryBytes = container.HostConfig.Memory
-		resources.NanoCPUs = container.HostConfig.NanoCPUs
+		resources.NanoCPUs = docker.NanoCPUsFromHostConfig(
+			container.HostConfig.NanoCPUs,
+			container.HostConfig.CPUQuota,
+			container.HostConfig.CPUPeriod,
+		)
 		resources.RestartPolicy = models.RestartPolicySpec{
 			Name:              string(container.HostConfig.RestartPolicy.Name),
 			MaximumRetryCount: container.HostConfig.RestartPolicy.MaximumRetryCount,

--- a/server/internal/docker/update.go
+++ b/server/internal/docker/update.go
@@ -7,6 +7,21 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
+// cpuPeriod is the standard CFS scheduler period (100ms in microseconds).
+const cpuPeriod = 100000
+
+// NanoCPUsFromHostConfig returns the effective CPU limit in nano-CPUs,
+// whether the engine stored it as NanoCPUs or as quota/period.
+func NanoCPUsFromHostConfig(nanoCPUs, quota, period int64) int64 {
+	if nanoCPUs > 0 {
+		return nanoCPUs
+	}
+	if quota > 0 && period > 0 {
+		return quota * 1e9 / period
+	}
+	return 0
+}
+
 // buildUpdateConfig maps an update request onto Docker's UpdateConfig.
 // The daemon treats zero-valued resource fields as "unchanged".
 func buildUpdateConfig(req models.UpdateResourcesRequest) container.UpdateConfig {
@@ -21,8 +36,12 @@ func buildUpdateConfig(req models.UpdateResourcesRequest) container.UpdateConfig
 		}
 	}
 
-	if req.NanoCPUs != nil {
-		cfg.NanoCPUs = *req.NanoCPUs
+	if req.NanoCPUs != nil && *req.NanoCPUs > 0 {
+		// Express the CPU limit as quota/period instead of NanoCPUs:
+		// Podman's compat update endpoint silently ignores NanoCpus,
+		// while quota/period works on both Docker and Podman.
+		cfg.CPUPeriod = cpuPeriod
+		cfg.CPUQuota = *req.NanoCPUs * cpuPeriod / 1e9
 	}
 
 	if req.RestartPolicy != nil {

--- a/server/internal/docker/update.go
+++ b/server/internal/docker/update.go
@@ -1,0 +1,48 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/api/types/container"
+)
+
+// buildUpdateConfig maps an update request onto Docker's UpdateConfig.
+// The daemon treats zero-valued resource fields as "unchanged".
+func buildUpdateConfig(req models.UpdateResourcesRequest) container.UpdateConfig {
+	var cfg container.UpdateConfig
+
+	if req.MemoryBytes != nil {
+		cfg.Memory = *req.MemoryBytes
+		if *req.MemoryBytes > 0 {
+			// Unlimited swap avoids the "memoryswap must be >= memory"
+			// daemon error when raising the memory limit.
+			cfg.MemorySwap = -1
+		}
+	}
+
+	if req.NanoCPUs != nil {
+		cfg.NanoCPUs = *req.NanoCPUs
+	}
+
+	if req.RestartPolicy != nil {
+		cfg.RestartPolicy = container.RestartPolicy{
+			Name:              container.RestartPolicyMode(req.RestartPolicy.Name),
+			MaximumRetryCount: req.RestartPolicy.MaximumRetryCount,
+		}
+	}
+
+	return cfg
+}
+
+// UpdateContainerResources applies resource limits and restart policy via the
+// Docker update API — a live update with no container recreate and no downtime.
+func (c *MultiHostClient) UpdateContainerResources(ctx context.Context, hostName, id string, req models.UpdateResourcesRequest) error {
+	apiClient, err := c.GetClient(hostName)
+	if err != nil {
+		return err
+	}
+
+	_, err = apiClient.ContainerUpdate(ctx, id, buildUpdateConfig(req))
+	return err
+}

--- a/server/internal/docker/update.go
+++ b/server/internal/docker/update.go
@@ -62,6 +62,21 @@ func (c *MultiHostClient) UpdateContainerResources(ctx context.Context, hostName
 		return err
 	}
 
-	_, err = apiClient.ContainerUpdate(ctx, id, buildUpdateConfig(req))
+	cfg := buildUpdateConfig(req)
+
+	// Podman resets the restart policy to "no" when an update omits it
+	// (Docker leaves it unchanged), so carry the current policy over
+	// explicitly when the request doesn't set one.
+	if req.RestartPolicy == nil {
+		inspect, err := apiClient.ContainerInspect(ctx, id)
+		if err != nil {
+			return err
+		}
+		if inspect.HostConfig != nil {
+			cfg.RestartPolicy = inspect.HostConfig.RestartPolicy
+		}
+	}
+
+	_, err = apiClient.ContainerUpdate(ctx, id, cfg)
 	return err
 }

--- a/server/internal/docker/update_test.go
+++ b/server/internal/docker/update_test.go
@@ -1,0 +1,41 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestBuildUpdateConfigCPUAsQuotaPeriod(t *testing.T) {
+	cfg := buildUpdateConfig(models.UpdateResourcesRequest{NanoCPUs: int64Ptr(1500000000)})
+
+	if cfg.NanoCPUs != 0 {
+		t.Errorf("NanoCPUs should not be set directly, got %d", cfg.NanoCPUs)
+	}
+	if cfg.CPUPeriod != 100000 {
+		t.Errorf("CPUPeriod = %d, want 100000", cfg.CPUPeriod)
+	}
+	if cfg.CPUQuota != 150000 {
+		t.Errorf("CPUQuota = %d, want 150000", cfg.CPUQuota)
+	}
+}
+
+func TestNanoCPUsFromHostConfig(t *testing.T) {
+	tests := []struct {
+		name                    string
+		nanoCPUs, quota, period int64
+		want                    int64
+	}{
+		{"nano cpus set", 1500000000, 0, 0, 1500000000},
+		{"quota and period", 0, 50000, 100000, 500000000},
+		{"nano cpus wins", 2000000000, 50000, 100000, 2000000000},
+		{"unlimited", 0, 0, 0, 0},
+	}
+	for _, tt := range tests {
+		if got := NanoCPUsFromHostConfig(tt.nanoCPUs, tt.quota, tt.period); got != tt.want {
+			t.Errorf("%s: got %d, want %d", tt.name, got, tt.want)
+		}
+	}
+}

--- a/server/internal/models/resources_update.go
+++ b/server/internal/models/resources_update.go
@@ -1,0 +1,53 @@
+package models
+
+import "fmt"
+
+// RestartPolicySpec describes a container restart policy.
+type RestartPolicySpec struct {
+	Name              string `json:"name"`
+	MaximumRetryCount int    `json:"maximumRetryCount"`
+}
+
+// UpdateResourcesRequest carries resource-limit and restart-policy changes.
+// Pointer fields: omitted means unchanged.
+type UpdateResourcesRequest struct {
+	MemoryBytes   *int64             `json:"memoryBytes,omitempty"`
+	NanoCPUs      *int64             `json:"nanoCPUs,omitempty"`
+	RestartPolicy *RestartPolicySpec `json:"restartPolicy,omitempty"`
+}
+
+// ContainerResources is the API response for a container's current limits.
+type ContainerResources struct {
+	MemoryBytes   int64             `json:"memoryBytes"`
+	NanoCPUs      int64             `json:"nanoCPUs"`
+	RestartPolicy RestartPolicySpec `json:"restartPolicy"`
+}
+
+var validRestartPolicyNames = map[string]bool{
+	"no":             true,
+	"always":         true,
+	"unless-stopped": true,
+	"on-failure":     true,
+}
+
+// Validate checks the request for values the Docker API would reject.
+func (r UpdateResourcesRequest) Validate() error {
+	if r.MemoryBytes != nil && *r.MemoryBytes < 0 {
+		return fmt.Errorf("memoryBytes must be >= 0")
+	}
+	if r.NanoCPUs != nil && *r.NanoCPUs < 0 {
+		return fmt.Errorf("nanoCPUs must be >= 0")
+	}
+	if rp := r.RestartPolicy; rp != nil {
+		if !validRestartPolicyNames[rp.Name] {
+			return fmt.Errorf("invalid restart policy: %q (must be one of no, always, unless-stopped, on-failure)", rp.Name)
+		}
+		if rp.MaximumRetryCount < 0 {
+			return fmt.Errorf("maximumRetryCount must be >= 0")
+		}
+		if rp.MaximumRetryCount > 0 && rp.Name != "on-failure" {
+			return fmt.Errorf("maximumRetryCount is only valid with the on-failure restart policy")
+		}
+	}
+	return nil
+}

--- a/server/internal/models/resources_update_test.go
+++ b/server/internal/models/resources_update_test.go
@@ -1,0 +1,37 @@
+package models
+
+import "testing"
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestUpdateResourcesRequestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     UpdateResourcesRequest
+		wantErr bool
+	}{
+		{name: "empty request", req: UpdateResourcesRequest{}},
+		{name: "valid memory", req: UpdateResourcesRequest{MemoryBytes: int64Ptr(512 * 1024 * 1024)}},
+		{name: "zero memory removes limit", req: UpdateResourcesRequest{MemoryBytes: int64Ptr(0)}},
+		{name: "negative memory", req: UpdateResourcesRequest{MemoryBytes: int64Ptr(-1)}, wantErr: true},
+		{name: "valid nano cpus", req: UpdateResourcesRequest{NanoCPUs: int64Ptr(1500000000)}},
+		{name: "negative nano cpus", req: UpdateResourcesRequest{NanoCPUs: int64Ptr(-5)}, wantErr: true},
+		{name: "valid restart policy no", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: "no"}}},
+		{name: "valid restart policy always", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: "always"}}},
+		{name: "valid restart policy unless-stopped", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: "unless-stopped"}}},
+		{name: "on-failure with retries", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: "on-failure", MaximumRetryCount: 3}}},
+		{name: "invalid restart policy name", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: "sometimes"}}, wantErr: true},
+		{name: "empty restart policy name", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: ""}}, wantErr: true},
+		{name: "retries without on-failure", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: "always", MaximumRetryCount: 3}}, wantErr: true},
+		{name: "negative retries", req: UpdateResourcesRequest{RestartPolicy: &RestartPolicySpec{Name: "on-failure", MaximumRetryCount: -1}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Edit memory limits, CPU limits, and restart policies from the container page — applied live via the engine's `ContainerUpdate` API, so no container recreate and no downtime.

## Server
- `GET /api/v1/containers/{id}/resources` — current values from inspect (nanoCPUs derived from quota/period when the engine stores it that way).
- `PUT /api/v1/containers/{id}/resources` — pointer fields, omitted = unchanged; validates policy names and retry-count usage; gated by read-only mode.
- Podman compatibility (found during live verification):
  - CPU limits are sent as `CpuQuota`/`CpuPeriod` — Podman's compat update endpoint silently ignores `NanoCpus`; quota/period works on both engines.
  - The current restart policy is carried over from inspect when a request omits it — Podman resets it to "no" otherwise (Docker leaves it unchanged).

## Frontend
- Collapsible "Resource limits" section on the container page: memory input with human units (512m, 1g), CPUs input, restart-policy select with max-retries for on-failure. Unit parser is unit-tested.

Known engine limitation: `docker/podman update` treats zero values as "unchanged", so an already-set limit cannot be cleared without a recreate.

## Verification
- Validation table tests + unit tests pass; verified live against Podman 6.0.1 (limits confirmed via `podman inspect`, policy-preservation regression exercised end-to-end).

**Merge order: 3 of 6** (stacked on #74).

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV