### PR TITLE
feat: compose stack start/stop/restart actions

### DIFF
--- a/frontend/src/features/containers/api/compose-actions.ts
+++ b/frontend/src/features/containers/api/compose-actions.ts
@@ -1,0 +1,57 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const BASE_URL = `${API_BASE_URL}/api/v1/compose`;
+
+export type ComposeAction = "start" | "stop" | "restart";
+
+interface ComposeActionFailure {
+  id: string;
+  name: string;
+  error: string;
+}
+
+export interface ComposeActionResult {
+  project: string;
+  host: string;
+  total: number;
+  succeeded: number;
+  failed: ComposeActionFailure[];
+}
+
+export async function performComposeAction(
+  project: string,
+  action: ComposeAction,
+  host: string
+): Promise<ComposeActionResult> {
+  const endpoint = `${BASE_URL}/${encodeURIComponent(project)}/${action}?host=${encodeURIComponent(host)}`;
+  const response = await authenticatedFetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    let message = text || `Failed to ${action} compose project ${project}`;
+    try {
+      const parsed = JSON.parse(text) as Partial<ComposeActionResult> & {
+        error?: string;
+      };
+      if (Array.isArray(parsed.failed) && parsed.failed.length > 0) {
+        const names = parsed.failed
+          .map((failure) => failure.name || failure.id.slice(0, 12))
+          .join(", ");
+        message = `Failed to ${action} ${parsed.failed.length} of ${parsed.total} container(s) in ${project}: ${names}`;
+      } else if (typeof parsed.error === "string") {
+        message = parsed.error;
+      }
+    } catch {
+      // Non-JSON error body; keep the raw text.
+    }
+    throw new Error(message);
+  }
+
+  return (await response.json()) as ComposeActionResult;
+}

--- a/frontend/src/features/containers/components/container-utils.ts
+++ b/frontend/src/features/containers/components/container-utils.ts
@@ -25,7 +25,7 @@ const COMPOSE_PROJECT_LABELS = [
   "io.podman.compose.project",
 ];
 
-function getComposeProject(labels?: Record<string, string>) {
+export function getComposeProject(labels?: Record<string, string>) {
   for (const label of COMPOSE_PROJECT_LABELS) {
     const project = labels?.[label]?.trim();
     if (project) {

--- a/frontend/src/features/containers/components/containers-dashboard.tsx
+++ b/frontend/src/features/containers/components/containers-dashboard.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Spinner } from "@/components/ui/spinner";
 
+import { performComposeAction } from "../api/compose-actions";
 import {
   removeContainer,
   restartContainer,
@@ -38,11 +39,13 @@ import { ContainersTable } from "./containers-table";
 import { ContainersToolbar } from "./containers-toolbar";
 
 import type { DateRange } from "react-day-picker";
+import type { ComposeAction } from "../api/compose-actions";
 import type { GetContainersResponse } from "../api/get-containers";
 import type { ContainerInfo } from "../types";
 import type {
   ContainerActionType,
   GroupByOption,
+  GroupedContainers,
   SortDirection,
 } from "./container-utils";
 
@@ -110,6 +113,10 @@ export function ContainersDashboard() {
   const [pendingAction, setPendingAction] = useState<{
     id: string;
     type: ContainerActionType;
+  } | null>(null);
+  const [pendingComposeAction, setPendingComposeAction] = useState<{
+    project: string;
+    type: ComposeAction;
   } | null>(null);
   const [confirmAction, setConfirmAction] = useState<{
     type: Extract<ContainerActionType, "stop" | "remove">;
@@ -256,6 +263,53 @@ export function ContainersDashboard() {
     } finally {
       setPendingAction(null);
     }
+  };
+
+  const executeComposeAction = async (
+    actionType: ComposeAction,
+    group: GroupedContainers
+  ) => {
+    // A UI group can theoretically span hosts; act once per distinct host.
+    const groupHosts = Array.from(
+      new Set(group.items.map((container) => container.host))
+    );
+    setPendingComposeAction({ project: group.project, type: actionType });
+    try {
+      const results = await Promise.all(
+        groupHosts.map((host) =>
+          performComposeAction(group.project, actionType, host)
+        )
+      );
+      const succeeded = results.reduce(
+        (sum, result) => sum + result.succeeded,
+        0
+      );
+      const verb =
+        actionType === "start"
+          ? "Started"
+          : actionType === "stop"
+            ? "Stopped"
+            : "Restarted";
+      toast.success(
+        `${verb} ${succeeded} container${succeeded === 1 ? "" : "s"} in ${group.project}`
+      );
+      await refetch();
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("Unexpected error while performing compose action.");
+      }
+    } finally {
+      setPendingComposeAction(null);
+    }
+  };
+
+  const handleComposeAction = (
+    action: ComposeAction,
+    group: GroupedContainers
+  ) => {
+    void executeComposeAction(action, group);
   };
 
   const handleConfirmAction = async () => {
@@ -418,12 +472,14 @@ export function ContainersDashboard() {
           groupedItems={groupedItems}
           pageItems={pageItems}
           pendingAction={pendingAction}
+          pendingComposeAction={pendingComposeAction}
           isReadOnly={isReadOnly}
           statsMap={statsMap}
           onStart={handleStartContainer}
           onStop={handleStopContainer}
           onRestart={handleRestartContainer}
           onDelete={handleDeleteContainer}
+          onComposeAction={handleComposeAction}
           onViewLogs={handleViewLogs}
           onRetry={() => {
             void refetch();

--- a/frontend/src/features/containers/components/containers-table.tsx
+++ b/frontend/src/features/containers/components/containers-table.tsx
@@ -26,11 +26,13 @@ import {
   formatCreatedDate,
   formatMemoryStats,
   formatUptime,
+  getComposeProject,
   getStateBadgeClass,
   isCoolifyManaged,
   toTitleCase,
 } from "./container-utils";
 
+import type { ComposeAction } from "../api/compose-actions";
 import type { ContainerInfo, ContainerStatsMap } from "../types";
 
 import type {
@@ -93,12 +95,14 @@ interface ContainersTableProps {
   groupedItems: GroupedContainers[] | null;
   pageItems: ContainerInfo[];
   pendingAction: { id: string; type: ContainerActionType } | null;
+  pendingComposeAction: { project: string; type: ComposeAction } | null;
   isReadOnly: boolean;
   statsMap: ContainerStatsMap;
   onStart: (container: ContainerInfo) => void;
   onStop: (container: ContainerInfo) => void;
   onRestart: (container: ContainerInfo) => void;
   onDelete: (container: ContainerInfo) => void;
+  onComposeAction: (action: ComposeAction, group: GroupedContainers) => void;
   onViewLogs: (container: ContainerInfo) => void;
   onRetry: () => void;
 }
@@ -112,12 +116,14 @@ export function ContainersTable({
   groupedItems,
   pageItems,
   pendingAction,
+  pendingComposeAction,
   isReadOnly,
   statsMap,
   onStart,
   onStop,
   onRestart,
   onDelete,
+  onComposeAction,
   onViewLogs,
   onRetry,
 }: ContainersTableProps) {
@@ -125,6 +131,20 @@ export function ContainersTable({
     pendingAction?.id === id && pendingAction.type === action;
 
   const isBusy = (id: string) => pendingAction?.id === id;
+
+  const isComposePending = (action: ContainerActionType, project: string) =>
+    pendingComposeAction?.project === project &&
+    pendingComposeAction.type === action;
+
+  const isComposeBusy = (project: string) =>
+    pendingComposeAction?.project === project;
+
+  // Only real compose groups get stack actions; the "Standalone" fallback
+  // group has no compose project label to act on.
+  const isComposeGroup = (group: GroupedContainers) =>
+    group.items.some(
+      (container) => getComposeProject(container.labels) === group.project
+    );
 
   const renderContainerRow = (container: ContainerInfo) => {
     const state = container.state.toLowerCase();
@@ -313,8 +333,45 @@ export function ContainersTable({
                     colSpan={8}
                     className="h-10 px-4 text-xs font-medium text-muted-foreground"
                   >
-                    {group.project} · {group.items.length} container
-                    {group.items.length === 1 ? "" : "s"}
+                    <div className="flex items-center justify-between">
+                      <span>
+                        {group.project} · {group.items.length} container
+                        {group.items.length === 1 ? "" : "s"}
+                      </span>
+                      {isComposeGroup(group) && (
+                        <TooltipProvider>
+                          <div className="flex items-center gap-1">
+                            <ActionButton
+                              icon={PlayIcon}
+                              action="start"
+                              containerId={group.project}
+                              onClick={() => onComposeAction("start", group)}
+                              isPending={isComposePending}
+                              busy={isComposeBusy(group.project)}
+                              isReadOnly={isReadOnly}
+                            />
+                            <ActionButton
+                              icon={SquareIcon}
+                              action="stop"
+                              containerId={group.project}
+                              onClick={() => onComposeAction("stop", group)}
+                              isPending={isComposePending}
+                              busy={isComposeBusy(group.project)}
+                              isReadOnly={isReadOnly}
+                            />
+                            <ActionButton
+                              icon={RotateCwIcon}
+                              action="restart"
+                              containerId={group.project}
+                              onClick={() => onComposeAction("restart", group)}
+                              isPending={isComposePending}
+                              busy={isComposeBusy(group.project)}
+                              isReadOnly={isReadOnly}
+                            />
+                          </div>
+                        </TooltipProvider>
+                      )}
+                    </div>
                   </TableCell>
                 </TableRow>
                 {group.items.map(renderContainerRow)}

--- a/server/internal/api/compose_handlers.go
+++ b/server/internal/api/compose_handlers.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/AmoabaKelvin/logdeck/internal/api/middleware"
+	"github.com/go-chi/chi/v5"
+)
+
+var validComposeActions = map[string]bool{
+	"start":   true,
+	"stop":    true,
+	"restart": true,
+}
+
+func (ar *APIRouter) registerComposeRoutes(r chi.Router) {
+	// Mutating routes (blocked in read-only mode)
+	r.Group(func(mutating chi.Router) {
+		mutating.Use(middleware.ReadOnly(func() bool {
+			return ar.registry.Config().ReadOnly
+		}))
+		mutating.Post("/compose/{project}/{action}", ar.ComposeAction)
+	})
+}
+
+// ComposeAction applies start/stop/restart to every container in a compose
+// project on one host. Responds 200 when all containers succeed, 500 with the
+// per-container failures in the body when any fail, and 404 when the project
+// has no containers on the host.
+func (ar *APIRouter) ComposeAction(w http.ResponseWriter, r *http.Request) {
+	project := chi.URLParam(r, "project")
+	action := chi.URLParam(r, "action")
+	host := r.URL.Query().Get("host")
+
+	if host == "" {
+		http.Error(w, "host parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	if !validComposeActions[action] {
+		http.Error(w, "invalid action: must be one of start, stop, restart", http.StatusBadRequest)
+		return
+	}
+
+	result, err := ar.registry.Docker().ComposeProjectAction(r.Context(), host, project, action)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if result.Total == 0 {
+		http.Error(w, "no containers found for compose project "+project, http.StatusNotFound)
+		return
+	}
+
+	status := http.StatusOK
+	if len(result.Failed) > 0 {
+		status = http.StatusInternalServerError
+	}
+	WriteJsonResponse(w, status, result)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -84,6 +84,7 @@ func (ar *APIRouter) Routes() *chi.Mux {
 			protected.Get("/auth/me", ar.handleGetMe)
 			protected.Get("/events", ar.GetContainerEvents)
 			ar.registerContainerRoutes(protected)
+			ar.registerComposeRoutes(protected)
 		})
 	})
 

--- a/server/internal/docker/compose.go
+++ b/server/internal/docker/compose.go
@@ -1,0 +1,112 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/api/types/container"
+)
+
+// Docker Compose and recent podman-compose both set the com.docker label;
+// older podman-compose releases only set the io.podman one.
+var composeProjectLabels = []string{
+	"com.docker.compose.project",
+	"io.podman.compose.project",
+}
+
+// inComposeProject reports whether a container's labels place it in project.
+func inComposeProject(labels map[string]string, project string) bool {
+	for _, label := range composeProjectLabels {
+		if labels[label] == project {
+			return true
+		}
+	}
+	return false
+}
+
+// composeTarget identifies one container a compose action applies to.
+type composeTarget struct {
+	ID   string
+	Name string
+}
+
+// applyToTargets runs apply on each target concurrently and aggregates
+// per-container failures instead of aborting the whole action.
+func applyToTargets(ctx context.Context, targets []composeTarget, apply func(ctx context.Context, id string) error) (succeeded int, failed []models.ComposeContainerFailure) {
+	failed = []models.ComposeContainerFailure{}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, target := range targets {
+		wg.Add(1)
+		go func(t composeTarget) {
+			defer wg.Done()
+			err := apply(ctx, t.ID)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				failed = append(failed, models.ComposeContainerFailure{
+					ID:    t.ID,
+					Name:  t.Name,
+					Error: err.Error(),
+				})
+				return
+			}
+			succeeded++
+		}(target)
+	}
+
+	wg.Wait()
+	return succeeded, failed
+}
+
+// ComposeProjectAction applies start, stop, or restart to every container in a
+// compose project on one host.
+func (c *MultiHostClient) ComposeProjectAction(ctx context.Context, hostName, project, action string) (models.ComposeActionResult, error) {
+	result := models.ComposeActionResult{
+		Project: project,
+		Host:    hostName,
+		Failed:  []models.ComposeContainerFailure{},
+	}
+
+	var apply func(ctx context.Context, id string) error
+	switch action {
+	case "start":
+		apply = func(ctx context.Context, id string) error { return c.StartContainer(ctx, hostName, id) }
+	case "stop":
+		apply = func(ctx context.Context, id string) error { return c.StopContainer(ctx, hostName, id) }
+	case "restart":
+		apply = func(ctx context.Context, id string) error { return c.RestartContainer(ctx, hostName, id) }
+	default:
+		return result, fmt.Errorf("unsupported compose action: %s", action)
+	}
+
+	apiClient, err := c.GetClient(hostName)
+	if err != nil {
+		return result, err
+	}
+
+	containers, err := apiClient.ContainerList(ctx, container.ListOptions{All: true})
+	if err != nil {
+		return result, err
+	}
+
+	targets := []composeTarget{}
+	for _, ctr := range containers {
+		if !inComposeProject(ctr.Labels, project) {
+			continue
+		}
+		name := ""
+		if len(ctr.Names) > 0 {
+			name = strings.TrimPrefix(ctr.Names[0], "/")
+		}
+		targets = append(targets, composeTarget{ID: ctr.ID, Name: name})
+	}
+
+	result.Total = len(targets)
+	result.Succeeded, result.Failed = applyToTargets(ctx, targets, apply)
+	return result, nil
+}

--- a/server/internal/docker/compose_test.go
+++ b/server/internal/docker/compose_test.go
@@ -1,0 +1,87 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestInComposeProject(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		project string
+		want    bool
+	}{
+		{
+			name:    "docker compose label",
+			labels:  map[string]string{"com.docker.compose.project": "web"},
+			project: "web",
+			want:    true,
+		},
+		{
+			name:    "podman compose label",
+			labels:  map[string]string{"io.podman.compose.project": "web"},
+			project: "web",
+			want:    true,
+		},
+		{
+			name:    "different project",
+			labels:  map[string]string{"com.docker.compose.project": "other"},
+			project: "web",
+			want:    false,
+		},
+		{
+			name:    "no labels",
+			labels:  nil,
+			project: "web",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := inComposeProject(tt.labels, tt.project); got != tt.want {
+				t.Errorf("inComposeProject(%v, %q) = %v, want %v", tt.labels, tt.project, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyToTargets(t *testing.T) {
+	targets := []composeTarget{
+		{ID: "1", Name: "web-1"},
+		{ID: "2", Name: "web-2"},
+		{ID: "3", Name: "web-3"},
+	}
+
+	succeeded, failed := applyToTargets(context.Background(), targets, func(_ context.Context, id string) error {
+		if id == "2" {
+			return errors.New("boom")
+		}
+		return nil
+	})
+
+	if succeeded != 2 {
+		t.Errorf("succeeded = %d, want 2", succeeded)
+	}
+	if len(failed) != 1 {
+		t.Fatalf("len(failed) = %d, want 1", len(failed))
+	}
+	if failed[0].ID != "2" || failed[0].Name != "web-2" || failed[0].Error != "boom" {
+		t.Errorf("unexpected failure: %+v", failed[0])
+	}
+}
+
+func TestApplyToTargetsEmpty(t *testing.T) {
+	succeeded, failed := applyToTargets(context.Background(), nil, func(_ context.Context, _ string) error {
+		return nil
+	})
+
+	if succeeded != 0 {
+		t.Errorf("succeeded = %d, want 0", succeeded)
+	}
+	if failed == nil || len(failed) != 0 {
+		t.Errorf("failed = %v, want empty non-nil slice", failed)
+	}
+}

--- a/server/internal/models/compose.go
+++ b/server/internal/models/compose.go
@@ -1,0 +1,17 @@
+package models
+
+// ComposeContainerFailure describes a container that failed a compose action.
+type ComposeContainerFailure struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+// ComposeActionResult summarizes a compose project action across its containers.
+type ComposeActionResult struct {
+	Project   string                    `json:"project"`
+	Host      string                    `json:"host"`
+	Total     int                       `json:"total"`
+	Succeeded int                       `json:"succeeded"`
+	Failed    []ComposeContainerFailure `json:"failed"`
+}


### PR DESCRIPTION
Builds on the compose-project grouping: the group header now has Start / Stop / Restart buttons that act on the whole stack.

## Server
- `POST /api/v1/compose/{project}/{action}?host=` — action must be start, stop, or restart. Matches containers by the `com.docker.compose.project` / `io.podman.compose.project` label on that host, applies the action concurrently, and reports per-container failures: `{project, host, total, succeeded, failed: [{id, name, error}]}`. 404 when no containers match; gated by read-only mode.

## Frontend
- Action buttons on compose group headers (reusing the per-row `ActionButton` look), pending state, toast + refetch on completion. Groups spanning hosts call the endpoint once per distinct host. Hidden for the "Standalone" fallback group.

## Verification
- Unit tests for label matching and result aggregation; verified live against Podman 6.0.1 — full stop/start/restart cycles of a three-container stack via both curl and the UI buttons.

**Merge order: 4 of 6** (stacked on #75).

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV