### PR TITLE
feat: aggregated multi-container log view for compose stacks

### DIFF
--- a/frontend/src/features/containers/api/get-aggregated-logs.ts
+++ b/frontend/src/features/containers/api/get-aggregated-logs.ts
@@ -1,0 +1,127 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { iterateNDJSONStream } from "@/lib/ndjson";
+import { API_BASE_URL } from "@/types/api";
+
+import type {
+  ContainerLogsOptions,
+  ContainerLogsParsedResponse,
+  LogEntry,
+  LogStreamHeartbeat,
+} from "./get-container-logs-parsed";
+
+const AGGREGATE_URL = `${API_BASE_URL}/api/v1/logs/aggregate`;
+
+export interface AggregateLogTarget {
+  id: string;
+  host: string;
+  name?: string;
+}
+
+const DEFAULT_OPTIONS: Required<
+  Pick<ContainerLogsOptions, "tail" | "details" | "stdout" | "stderr">
+> = {
+  tail: "100",
+  details: false,
+  stdout: true,
+  stderr: true,
+};
+
+// Mirrors buildLogsUrl in get-container-logs-parsed.ts; targets are passed
+// as repeated "host~id~name" triples ("~" cannot appear in container names
+// or IDs).
+function buildAggregateLogsUrl(
+  targets: AggregateLogTarget[],
+  options?: ContainerLogsOptions
+) {
+  const query = new URLSearchParams();
+  const merged: ContainerLogsOptions = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+
+  for (const target of targets) {
+    query.append("targets", `${target.host}~${target.id}~${target.name ?? ""}`);
+  }
+
+  if (merged.since) {
+    query.set("since", merged.since);
+  }
+  if (merged.until) {
+    query.set("until", merged.until);
+  }
+  if (merged.tail !== undefined) {
+    query.set("tail", String(merged.tail));
+  }
+  if (merged.details !== undefined) {
+    query.set("details", String(merged.details));
+  }
+  if (merged.stdout !== undefined) {
+    query.set("stdout", String(merged.stdout));
+  }
+  if (merged.stderr !== undefined) {
+    query.set("stderr", String(merged.stderr));
+  }
+  if (merged.follow !== undefined) {
+    query.set("follow", String(merged.follow));
+  }
+  if (merged.search) {
+    query.set("search", merged.search);
+  }
+
+  return `${AGGREGATE_URL}?${query.toString()}`;
+}
+
+export async function getAggregatedLogs(
+  targets: AggregateLogTarget[],
+  options?: ContainerLogsOptions
+): Promise<LogEntry[]> {
+  const response = await authenticatedFetch(
+    buildAggregateLogsUrl(targets, options),
+    {
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || "Failed to fetch aggregated logs");
+  }
+
+  const data: ContainerLogsParsedResponse = await response.json();
+  return data.logs || [];
+}
+
+export async function* streamAggregatedLogs(
+  targets: AggregateLogTarget[],
+  options?: ContainerLogsOptions,
+  signal?: AbortSignal
+): AsyncGenerator<LogEntry | LogStreamHeartbeat, void, unknown> {
+  const streamOptions = { ...options, follow: true };
+  const response = await authenticatedFetch(
+    buildAggregateLogsUrl(targets, streamOptions),
+    {
+      headers: {
+        Accept: "application/x-ndjson",
+      },
+      signal,
+    }
+  );
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || "Failed to stream aggregated logs");
+  }
+
+  if (!response.body) {
+    throw new Error("Streaming is not supported in this environment.");
+  }
+
+  for await (const entry of iterateNDJSONStream<LogEntry | LogStreamHeartbeat>(
+    response.body,
+    signal
+  )) {
+    yield entry;
+  }
+}

--- a/frontend/src/features/containers/api/get-container-logs-parsed.ts
+++ b/frontend/src/features/containers/api/get-container-logs-parsed.ts
@@ -23,6 +23,9 @@ export interface LogEntry {
   raw?: string;
   fields?: Record<string, string>;
   continuationCount?: number;
+  // Present only on aggregated multi-container streams.
+  containerId?: string;
+  containerName?: string;
 }
 
 export interface ContainerLogsParsedResponse {
@@ -208,6 +211,9 @@ export function groupRelatedLogEntries<TLogEntry extends LogEntry>(
 
 function isContinuationLogEntry(entry: LogEntry, previous: LogEntry): boolean {
   if (entry.level !== "UNKNOWN") return false;
+  // Aggregate streams interleave containers; never fold a line into another
+  // container's entry.
+  if (entry.containerName !== previous.containerName) return false;
 
   const message = (entry.message ?? entry.raw ?? "").trim();
   const previousMessage = (previous.message ?? previous.raw ?? "").trim();

--- a/frontend/src/features/containers/components/container-utils.ts
+++ b/frontend/src/features/containers/components/container-utils.ts
@@ -25,7 +25,7 @@ const COMPOSE_PROJECT_LABELS = [
   "io.podman.compose.project",
 ];
 
-function getComposeProject(labels?: Record<string, string>) {
+export function getComposeProject(labels?: Record<string, string>) {
   for (const label of COMPOSE_PROJECT_LABELS) {
     const project = labels?.[label]?.trim();
     if (project) {

--- a/frontend/src/features/containers/components/containers-table.tsx
+++ b/frontend/src/features/containers/components/containers-table.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { FileTextIcon, PlayIcon, RotateCwIcon, SquareIcon, Trash2Icon } from "lucide-react";
 import { Fragment } from "react";
 import type { LucideIcon } from "lucide-react";
@@ -313,8 +314,22 @@ export function ContainersTable({
                     colSpan={8}
                     className="h-10 px-4 text-xs font-medium text-muted-foreground"
                   >
-                    {group.project} · {group.items.length} container
-                    {group.items.length === 1 ? "" : "s"}
+                    <div className="flex items-center justify-between">
+                      <span>
+                        {group.project} · {group.items.length} container
+                        {group.items.length === 1 ? "" : "s"}
+                      </span>
+                      {group.project !== "Standalone" && (
+                        <Link
+                          to="/stacks/$project/logs"
+                          params={{ project: group.project }}
+                          className="inline-flex items-center gap-1 text-primary hover:underline"
+                        >
+                          <FileTextIcon className="size-3" />
+                          Stack logs
+                        </Link>
+                      )}
+                    </div>
                   </TableCell>
                 </TableRow>
                 {group.items.map(renderContainerRow)}

--- a/frontend/src/features/containers/components/log-viewer/log-viewer.tsx
+++ b/frontend/src/features/containers/components/log-viewer/log-viewer.tsx
@@ -58,7 +58,13 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { AggregateLogTarget } from "@/features/containers/api/get-aggregated-logs";
+import {
+	getAggregatedLogs,
+	streamAggregatedLogs,
+} from "@/features/containers/api/get-aggregated-logs";
 import type {
+	ContainerLogsOptions,
 	LogEntry,
 	LogLevel,
 } from "@/features/containers/api/get-container-logs-parsed";
@@ -98,11 +104,36 @@ interface LogViewerProps {
 	// Host-owned view state: local in the sheet, URL-persisted on the full
 	// page (see use-log-view-state.ts).
 	viewState: LogViewState;
+	// Aggregate mode: merge these containers' logs into one view instead of
+	// containerId/host. Entries carry containerName for the per-row badge.
+	targets?: AggregateLogTarget[];
 	ref?: React.Ref<LogViewerHandle>;
 }
 
 const activeToggleButtonClass =
 	"h-8 text-xs data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=true]:border-border data-[active=true]:ring-1 data-[active=true]:ring-primary/30 dark:data-[active=true]:bg-primary/15 dark:data-[active=true]:ring-primary/50 dark:data-[active=true]:border-primary/30";
+
+// Deterministic per-container badge color for aggregate views.
+const CONTAINER_NAME_BADGE_COLORS = [
+	"bg-sky-100 text-sky-700 dark:bg-sky-900 dark:text-sky-300",
+	"bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300",
+	"bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300",
+	"bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
+	"bg-pink-100 text-pink-700 dark:bg-pink-900 dark:text-pink-300",
+	"bg-cyan-100 text-cyan-700 dark:bg-cyan-900 dark:text-cyan-300",
+	"bg-lime-100 text-lime-700 dark:bg-lime-900 dark:text-lime-300",
+	"bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900 dark:text-fuchsia-300",
+];
+
+function getContainerNameBadgeColor(name: string): string {
+	let hash = 0;
+	for (let i = 0; i < name.length; i++) {
+		hash = (hash * 31 + name.charCodeAt(i)) | 0;
+	}
+	return CONTAINER_NAME_BADGE_COLORS[
+		Math.abs(hash) % CONTAINER_NAME_BADGE_COLORS.length
+	];
+}
 
 function formatLogEntryLine(entry: LogEntry): string {
 	const timestamp = entry.timestamp
@@ -119,6 +150,7 @@ export function LogViewer({
 	host,
 	containerName,
 	viewState,
+	targets,
 	ref,
 }: LogViewerProps) {
 	const {
@@ -184,6 +216,34 @@ export function LogViewer({
 		[timeRange],
 	);
 
+	// Aggregate mode reuses the single-stream hook untouched: the targets are
+	// baked into the fetch/stream functions, and a targets-derived key stands
+	// in for containerId/host so the hook refetches when the set changes.
+	const getLogs = useMemo(
+		() =>
+			targets
+				? (_id: string, _host: string, options: ContainerLogsOptions) =>
+						getAggregatedLogs(targets, options)
+				: getContainerLogsParsed,
+		[targets],
+	);
+	const streamLogs = useMemo(
+		() =>
+			targets
+				? (
+						_id: string,
+						_host: string,
+						options: ContainerLogsOptions,
+						signal: AbortSignal,
+					) => streamAggregatedLogs(targets, options, signal)
+				: streamContainerLogsParsed,
+		[targets],
+	);
+	const streamContainerId = targets
+		? targets.map((t) => t.id).join(",")
+		: containerId;
+	const streamHost = targets ? "aggregate" : host;
+
 	const {
 		animatedRange,
 		bufferedCount,
@@ -199,13 +259,13 @@ export function LogViewer({
 		togglePauseStreaming,
 		toggleStreaming,
 	} = useContainerLogStream<LogEntry>({
-		containerId,
-		host,
+		containerId: streamContainerId,
+		host: streamHost,
 		tail: logLines,
 		since,
 		until,
-		getLogs: getContainerLogsParsed,
-		streamLogs: streamContainerLogsParsed,
+		getLogs,
+		streamLogs,
 		scrollToBottom,
 		onResetState: () => {
 			resetPinsRef.current();
@@ -1442,6 +1502,14 @@ export function LogViewer({
 									>
 										{entry.level ?? "UNKNOWN"}
 									</Badge>
+									{entry.containerName && (
+										<Badge
+											variant="outline"
+											className={`shrink-0 text-xs px-1.5 py-0 h-5 ${getContainerNameBadgeColor(entry.containerName)}`}
+										>
+											{entry.containerName}
+										</Badge>
+									)}
 									<span
 										className={`text-foreground flex-1 ${wrapText ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}
 									>

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as NetworksRouteImport } from './routes/networks'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ImagesRouteImport } from './routes/images'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as StacksProjectLogsRouteImport } from './routes/stacks/$project/logs'
 import { Route as ContainersContainerIdLogsRouteImport } from './routes/containers/$containerId/logs'
 
 const VolumesRoute = VolumesRouteImport.update({
@@ -47,6 +48,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const StacksProjectLogsRoute = StacksProjectLogsRouteImport.update({
+  id: '/stacks/$project/logs',
+  path: '/stacks/$project/logs',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ContainersContainerIdLogsRoute =
   ContainersContainerIdLogsRouteImport.update({
     id: '/containers/$containerId/logs',
@@ -62,6 +68,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/volumes': typeof VolumesRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
+  '/stacks/$project/logs': typeof StacksProjectLogsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -71,6 +78,7 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/volumes': typeof VolumesRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
+  '/stacks/$project/logs': typeof StacksProjectLogsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -81,6 +89,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/volumes': typeof VolumesRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
+  '/stacks/$project/logs': typeof StacksProjectLogsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -92,6 +101,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/volumes'
     | '/containers/$containerId/logs'
+    | '/stacks/$project/logs'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -101,6 +111,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/volumes'
     | '/containers/$containerId/logs'
+    | '/stacks/$project/logs'
   id:
     | '__root__'
     | '/'
@@ -110,6 +121,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/volumes'
     | '/containers/$containerId/logs'
+    | '/stacks/$project/logs'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -120,6 +132,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   VolumesRoute: typeof VolumesRoute
   ContainersContainerIdLogsRoute: typeof ContainersContainerIdLogsRoute
+  StacksProjectLogsRoute: typeof StacksProjectLogsRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -166,6 +179,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/stacks/$project/logs': {
+      id: '/stacks/$project/logs'
+      path: '/stacks/$project/logs'
+      fullPath: '/stacks/$project/logs'
+      preLoaderRoute: typeof StacksProjectLogsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/containers/$containerId/logs': {
       id: '/containers/$containerId/logs'
       path: '/containers/$containerId/logs'
@@ -184,6 +204,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   VolumesRoute: VolumesRoute,
   ContainersContainerIdLogsRoute: ContainersContainerIdLogsRoute,
+  StacksProjectLogsRoute: StacksProjectLogsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as StacksProjectLogsRouteImport } from './routes/stacks/$project/logs'
 import { Route as ContainersContainerIdLogsRouteImport } from './routes/containers/$containerId/logs'
 
 const SettingsRoute = SettingsRouteImport.update({
@@ -29,6 +30,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const StacksProjectLogsRoute = StacksProjectLogsRouteImport.update({
+  id: '/stacks/$project/logs',
+  path: '/stacks/$project/logs',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ContainersContainerIdLogsRoute =
   ContainersContainerIdLogsRouteImport.update({
     id: '/containers/$containerId/logs',
@@ -41,12 +47,14 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
+  '/stacks/$project/logs': typeof StacksProjectLogsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
+  '/stacks/$project/logs': typeof StacksProjectLogsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -54,18 +62,30 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/containers/$containerId/logs': typeof ContainersContainerIdLogsRoute
+  '/stacks/$project/logs': typeof StacksProjectLogsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/settings' | '/containers/$containerId/logs'
+  fullPaths:
+    | '/'
+    | '/login'
+    | '/settings'
+    | '/containers/$containerId/logs'
+    | '/stacks/$project/logs'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/settings' | '/containers/$containerId/logs'
+  to:
+    | '/'
+    | '/login'
+    | '/settings'
+    | '/containers/$containerId/logs'
+    | '/stacks/$project/logs'
   id:
     | '__root__'
     | '/'
     | '/login'
     | '/settings'
     | '/containers/$containerId/logs'
+    | '/stacks/$project/logs'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -73,6 +93,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   SettingsRoute: typeof SettingsRoute
   ContainersContainerIdLogsRoute: typeof ContainersContainerIdLogsRoute
+  StacksProjectLogsRoute: typeof StacksProjectLogsRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -98,6 +119,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/stacks/$project/logs': {
+      id: '/stacks/$project/logs'
+      path: '/stacks/$project/logs'
+      fullPath: '/stacks/$project/logs'
+      preLoaderRoute: typeof StacksProjectLogsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/containers/$containerId/logs': {
       id: '/containers/$containerId/logs'
       path: '/containers/$containerId/logs'
@@ -113,6 +141,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   SettingsRoute: SettingsRoute,
   ContainersContainerIdLogsRoute: ContainersContainerIdLogsRoute,
+  StacksProjectLogsRoute: StacksProjectLogsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/stacks/$project/logs.tsx
+++ b/frontend/src/routes/stacks/$project/logs.tsx
@@ -1,0 +1,95 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { ArrowLeftIcon } from "lucide-react";
+import { useMemo } from "react";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { Button } from "@/components/ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { AggregateLogTarget } from "@/features/containers/api/get-aggregated-logs";
+import {
+	formatContainerName,
+	getComposeProject,
+} from "@/features/containers/components/container-utils";
+import { LogViewer } from "@/features/containers/components/log-viewer/log-viewer";
+import { useUrlLogViewState } from "@/features/containers/components/log-viewer/use-log-view-state";
+import { useLiveContainersQuery } from "@/features/containers/hooks/use-live-containers-query";
+import { requireAuthIfEnabled } from "@/lib/auth-guard";
+
+export const Route = createFileRoute("/stacks/$project/logs")({
+	beforeLoad: async () => {
+		await requireAuthIfEnabled();
+	},
+	component: StackLogsPage,
+});
+
+function StackLogsPage() {
+	const { project: encodedProject } = Route.useParams();
+	const navigate = useNavigate();
+
+	const project = decodeURIComponent(encodedProject);
+	const logViewState = useUrlLogViewState();
+
+	const { data: containersData } = useLiveContainersQuery();
+	const containers = containersData?.containers ?? [];
+
+	const targets: AggregateLogTarget[] | undefined = useMemo(() => {
+		const stackContainers = containers.filter(
+			(container) => getComposeProject(container.labels) === project,
+		);
+		if (stackContainers.length === 0) return undefined;
+		return stackContainers.map((container) => ({
+			id: container.id,
+			host: container.host,
+			name: formatContainerName(container.names),
+		}));
+	}, [containers, project]);
+
+	return (
+		<div className="min-h-screen bg-background">
+			<div className="container mx-auto px-4 py-6">
+				<div className="space-y-6">
+					{/* Header */}
+					<div className="flex items-center gap-4">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={() =>
+										navigate({
+											to: "/",
+										})
+									}
+								>
+									<ArrowLeftIcon className="size-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Back to Dashboard</TooltipContent>
+						</Tooltip>
+						<div className="flex-1">
+							<h1 className="text-2xl font-bold">Stack Logs</h1>
+							<p className="text-sm text-muted-foreground">
+								{project}
+								{targets
+									? ` · ${targets.length} container${targets.length === 1 ? "" : "s"}`
+									: " · no containers found"}
+							</p>
+						</div>
+						<ThemeToggle />
+					</div>
+
+					{/* Aggregated Logs Card */}
+					<LogViewer
+						variant="page"
+						containerName={project}
+						viewState={logViewState}
+						targets={targets}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/server/internal/api/aggregate_logs_handlers.go
+++ b/server/internal/api/aggregate_logs_handlers.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+)
+
+// maxAggregateTargets bounds how many container streams one aggregate
+// request may open.
+const maxAggregateTargets = 20
+
+// GetAggregatedLogs serves merged logs for multiple containers. Targets are
+// passed as repeated (or comma-separated) "host~id~name" triples in the
+// "targets" query param; "~" and "," cannot appear in Docker container names
+// or IDs. All other query params match the single-container logs endpoint.
+func (ar *APIRouter) GetAggregatedLogs(w http.ResponseWriter, r *http.Request) {
+	targets, err := parseAggregateTargets(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	options := parseLogOptions(r)
+
+	if options.Search != "" {
+		if _, err := regexp.Compile(options.Search); err != nil {
+			http.Error(w, fmt.Sprintf("invalid search pattern: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	if options.Follow {
+		stream, err := ar.registry.Docker().StreamAggregatedLogsParsed(r.Context(), targets, options)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer stream.Close()
+		writeNDJSONStream(w, stream)
+		return
+	}
+
+	logs, err := ar.registry.Docker().GetAggregatedLogsParsed(r.Context(), targets, options)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	WriteJsonResponse(w, http.StatusOK, map[string]any{
+		"logs":  logs,
+		"count": len(logs),
+	})
+}
+
+func parseAggregateTargets(r *http.Request) ([]docker.LogTarget, error) {
+	var targets []docker.LogTarget
+
+	for _, value := range r.URL.Query()["targets"] {
+		for _, triple := range strings.Split(value, ",") {
+			triple = strings.TrimSpace(triple)
+			if triple == "" {
+				continue
+			}
+			parts := strings.SplitN(triple, "~", 3)
+			if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+				return nil, fmt.Errorf("invalid target %q: expected host~id~name", triple)
+			}
+			target := docker.LogTarget{Host: parts[0], ID: parts[1]}
+			if len(parts) == 3 {
+				target.Name = parts[2]
+			}
+			targets = append(targets, target)
+		}
+	}
+
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("targets parameter is required")
+	}
+	if len(targets) > maxAggregateTargets {
+		return nil, fmt.Errorf("too many targets: %d (max %d)", len(targets), maxAggregateTargets)
+	}
+
+	return targets, nil
+}
+
+// writeNDJSONStream copies an NDJSON stream to the client, flushing per read
+// so follow mode delivers lines as they arrive. Mirrors streamParsedLogs.
+func writeNDJSONStream(w http.ResponseWriter, stream io.Reader) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	buffer := make([]byte, 32*1024)
+	for {
+		n, readErr := stream.Read(buffer)
+		if n > 0 {
+			if _, writeErr := w.Write(buffer[:n]); writeErr != nil {
+				break
+			}
+			flusher.Flush()
+		}
+		if readErr != nil {
+			break
+		}
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -103,6 +103,7 @@ func (ar *APIRouter) Routes() *chi.Mux {
 func (ar *APIRouter) registerContainerRoutes(r chi.Router) {
 	r.Get("/containers", ar.GetContainers)
 	r.Get("/containers/stats", ar.GetContainerStats)
+	r.Get("/logs/aggregate", ar.GetAggregatedLogs)
 	r.Route("/containers/{id}", func(r chi.Router) {
 		// Read-only routes (always available)
 		r.Get("/", ar.GetContainer)

--- a/server/internal/docker/logs_aggregate.go
+++ b/server/internal/docker/logs_aggregate.go
@@ -1,0 +1,173 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sort"
+	"sync"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// LogTarget identifies one container in an aggregated log request.
+type LogTarget struct {
+	Host string
+	ID   string
+	Name string
+}
+
+// GetAggregatedLogsParsed fetches parsed logs for every target concurrently,
+// tags each entry with its container, and merges them by timestamp. A failing
+// target is skipped; an error is returned only when every target failed.
+func (c *MultiHostClient) GetAggregatedLogsParsed(ctx context.Context, targets []LogTarget, options models.LogOptions) ([]models.LogEntry, error) {
+	histOptions := options
+	histOptions.Follow = false
+
+	batches := make([][]models.LogEntry, len(targets))
+	errs := make([]error, len(targets))
+
+	var wg sync.WaitGroup
+	for i, target := range targets {
+		wg.Add(1)
+		go func(i int, target LogTarget) {
+			defer wg.Done()
+			entries, err := c.GetContainerLogsParsed(ctx, target.Host, target.ID, histOptions)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			tagLogEntries(entries, target)
+			batches[i] = entries
+		}(i, target)
+	}
+	wg.Wait()
+
+	failed := 0
+	var firstErr error
+	for _, err := range errs {
+		if err != nil {
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	if failed == len(targets) {
+		return nil, firstErr
+	}
+
+	return mergeLogEntriesByTimestamp(batches), nil
+}
+
+// StreamAggregatedLogsParsed multiplexes the targets' parsed logs onto one
+// NDJSON pipe. The historical phase is fetched up front and emitted in
+// timestamp order; when following, each target's live stream (tail=0, since
+// history was already emitted) is then fanned into the pipe as entries
+// arrive. One target failing does not kill the aggregate; the pipe closes
+// once every live stream has ended or ctx is done. Per-stream heartbeats are
+// passed through, so the client's liveness watchdog keeps working.
+func (c *MultiHostClient) StreamAggregatedLogsParsed(ctx context.Context, targets []LogTarget, options models.LogOptions) (io.ReadCloser, error) {
+	pipeReader, pipeWriter := io.Pipe()
+	encoder := json.NewEncoder(pipeWriter)
+	var mu sync.Mutex
+
+	go func() {
+		defer pipeWriter.Close()
+
+		historical, err := c.GetAggregatedLogsParsed(ctx, targets, options)
+		if err != nil {
+			pipeWriter.CloseWithError(err)
+			return
+		}
+		for _, entry := range historical {
+			if err := encoder.Encode(entry); err != nil {
+				return
+			}
+		}
+
+		if !options.Follow {
+			return
+		}
+
+		liveOptions := options
+		liveOptions.Tail = "0" // historical lines were already emitted
+
+		var wg sync.WaitGroup
+		for _, target := range targets {
+			stream, err := c.StreamContainerLogsParsed(ctx, target.Host, target.ID, liveOptions)
+			if err != nil {
+				continue // a missing or failed target must not kill the aggregate
+			}
+			wg.Add(1)
+			go func(target LogTarget, stream io.ReadCloser) {
+				defer wg.Done()
+				defer stream.Close()
+				copyTaggedEntries(encoder, &mu, stream, target)
+			}(target, stream)
+		}
+		wg.Wait()
+	}()
+
+	return pipeReader, nil
+}
+
+// copyTaggedEntries re-encodes one container's NDJSON log stream onto the
+// shared aggregate encoder, tagging each entry with its container. Heartbeats
+// pass through untouched. Any error ends this target's stream only.
+func copyTaggedEntries(encoder *json.Encoder, mu *sync.Mutex, stream io.Reader, target LogTarget) {
+	decoder := json.NewDecoder(stream)
+	for {
+		var line struct {
+			models.LogEntry
+			Type string `json:"type"`
+		}
+		if err := decoder.Decode(&line); err != nil {
+			return
+		}
+
+		var payload any
+		if line.Type == "heartbeat" {
+			payload = map[string]string{"type": "heartbeat"}
+		} else {
+			entry := line.LogEntry
+			entry.ContainerID = target.ID
+			entry.ContainerName = target.Name
+			payload = entry
+		}
+
+		mu.Lock()
+		err := encoder.Encode(payload)
+		mu.Unlock()
+		if err != nil {
+			return
+		}
+	}
+}
+
+func tagLogEntries(entries []models.LogEntry, target LogTarget) {
+	for i := range entries {
+		entries[i].ContainerID = target.ID
+		entries[i].ContainerName = target.Name
+	}
+}
+
+// mergeLogEntriesByTimestamp flattens per-container batches into one slice
+// ordered by timestamp. Each batch is already in log order, so a stable sort
+// keeps same-timestamp lines in their original relative order.
+func mergeLogEntriesByTimestamp(batches [][]models.LogEntry) []models.LogEntry {
+	total := 0
+	for _, batch := range batches {
+		total += len(batch)
+	}
+
+	merged := make([]models.LogEntry, 0, total)
+	for _, batch := range batches {
+		merged = append(merged, batch...)
+	}
+
+	sort.SliceStable(merged, func(i, j int) bool {
+		return merged[i].Timestamp.Before(merged[j].Timestamp)
+	})
+	return merged
+}

--- a/server/internal/docker/logs_aggregate_test.go
+++ b/server/internal/docker/logs_aggregate_test.go
@@ -1,0 +1,69 @@
+package docker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+func TestMergeLogEntriesByTimestamp(t *testing.T) {
+	at := func(sec int) time.Time {
+		return time.Date(2026, 7, 9, 12, 0, sec, 0, time.UTC)
+	}
+	entry := func(name string, ts time.Time, msg string) models.LogEntry {
+		return models.LogEntry{Timestamp: ts, Message: msg, ContainerName: name}
+	}
+
+	batches := [][]models.LogEntry{
+		{
+			entry("api", at(1), "api-1"),
+			entry("api", at(3), "api-3"),
+			entry("api", at(3), "api-3b"),
+		},
+		{
+			entry("db", at(0), "db-0"),
+			entry("db", at(2), "db-2"),
+			entry("db", at(3), "db-3"),
+		},
+		nil, // a failed target contributes nothing
+	}
+
+	merged := mergeLogEntriesByTimestamp(batches)
+
+	wantMessages := []string{"db-0", "api-1", "db-2", "api-3", "api-3b", "db-3"}
+	if len(merged) != len(wantMessages) {
+		t.Fatalf("expected %d merged entries, got %d", len(wantMessages), len(merged))
+	}
+	for i, want := range wantMessages {
+		if merged[i].Message != want {
+			t.Fatalf("entry %d: expected %q, got %q", i, want, merged[i].Message)
+		}
+	}
+
+	for i := 1; i < len(merged); i++ {
+		if merged[i].Timestamp.Before(merged[i-1].Timestamp) {
+			t.Fatalf("entries out of timestamp order at index %d", i)
+		}
+	}
+}
+
+func TestMergeLogEntriesByTimestampEmpty(t *testing.T) {
+	if got := mergeLogEntriesByTimestamp(nil); len(got) != 0 {
+		t.Fatalf("expected empty result for nil batches, got %d entries", len(got))
+	}
+	if got := mergeLogEntriesByTimestamp([][]models.LogEntry{nil, {}}); len(got) != 0 {
+		t.Fatalf("expected empty result for empty batches, got %d entries", len(got))
+	}
+}
+
+func TestTagLogEntries(t *testing.T) {
+	entries := []models.LogEntry{{Message: "a"}, {Message: "b"}}
+	tagLogEntries(entries, LogTarget{Host: "local", ID: "abc123", Name: "web"})
+
+	for i, entry := range entries {
+		if entry.ContainerID != "abc123" || entry.ContainerName != "web" {
+			t.Fatalf("entry %d not tagged: %+v", i, entry)
+		}
+	}
+}

--- a/server/internal/models/logs.go
+++ b/server/internal/models/logs.go
@@ -17,6 +17,10 @@ type LogEntry struct {
 	Raw               string            `json:"raw"`    // Original log line
 	Fields            map[string]string `json:"fields,omitempty"`
 	ContinuationCount int               `json:"continuationCount,omitempty"`
+	// Set only on aggregated multi-container streams; omitempty keeps the
+	// single-container payload unchanged.
+	ContainerID   string `json:"containerId,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
 }
 
 // LogLevel represents the severity of a log entry


### PR DESCRIPTION
One log view for a whole compose stack: N container streams multiplexed server-side and merged by timestamp.

## Server
- `GET /api/v1/logs/aggregate?targets=host~id~name,...` — up to 20 targets, all existing log params supported (follow, tail, since/until, search, level, stdout/stderr).
- Historical phase fetches every target concurrently and merge-sorts by timestamp (unit-tested); follow mode then fans each target's live parsed stream into one NDJSON pipe in arrival order (no reordering buffer by design). One target failing does not kill the stream; per-stream heartbeats pass through so the client watchdog works unchanged.
- `LogEntry` gains optional `containerId`/`containerName` (omitempty — single-container responses are byte-identical).

## Frontend
- New `/stacks/{project}/logs` page resolving the project's containers across hosts.
- LogViewer renders a deterministic-color container badge when entries carry a container name; continuation grouping guarded so interleaved streams never fold lines across containers.
- "Stack logs" link on compose group headers.

## Verification
- Merge and tagging unit tests; verified live against Podman 6.0.1 — one-shot merge order confirmed and three containers interleaving in real time in the browser.

**Merge order: 5 of 6** (stacked on #76).

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV