### PR TITLE
refactor: container detail page UX and repo-wide formatting

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -15,6 +15,7 @@
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.3.3",
+        "@radix-ui/react-tabs": "^1.1.17",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/vite": "^4.0.6",
         "@tanstack/react-devtools": "^0.7.0",
@@ -272,7 +273,7 @@
 
     "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
-    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA=="],
+    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.5", "@radix-ui/react-collection": "1.1.12", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.2.0", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-is-hydrated": "0.1.1", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg=="],
 
     "@radix-ui/react-scroll-area": ["@radix-ui/react-scroll-area@1.2.10", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A=="],
 
@@ -284,6 +285,8 @@
 
     "@radix-ui/react-switch": ["@radix-ui/react-switch@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.5", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.2.0", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ=="],
 
+    "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.17", "", { "dependencies": { "@radix-ui/primitive": "1.1.5", "@radix-ui/react-context": "1.2.0", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-presence": "1.1.7", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-roving-focus": "1.1.15", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ=="],
+
     "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
@@ -293,6 +296,8 @@
     "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
 
     "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
@@ -842,7 +847,29 @@
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "@radix-ui/react-menu/@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA=="],
+
     "@radix-ui/react-popper/@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/primitive": ["@radix-ui/primitive@1.1.5", "", {}, "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.12", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.2.0", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-context": ["@radix-ui/react-context@1.2.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
 
     "@radix-ui/react-switch/@radix-ui/primitive": ["@radix-ui/primitive@1.1.5", "", {}, "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg=="],
 
@@ -855,6 +882,20 @@
     "@radix-ui/react-switch/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
 
     "@radix-ui/react-switch/@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/primitive": ["@radix-ui/primitive@1.1.5", "", {}, "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-context": ["@radix-ui/react-context@1.2.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.7", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
 
     "@radix-ui/react-use-size/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
 
@@ -884,10 +925,28 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@radix-ui/react-roving-focus/@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
     "@radix-ui/react-switch/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
 
     "@radix-ui/react-switch/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
 
     "@radix-ui/react-switch/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.3.3",
+    "@radix-ui/react-tabs": "^1.1.17",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-devtools": "^0.7.0",

--- a/frontend/src/components/default-error-component.tsx
+++ b/frontend/src/components/default-error-component.tsx
@@ -3,12 +3,7 @@ import { useRouter } from "@tanstack/react-router";
 import { AlertTriangleIcon, RefreshCcwIcon, RotateCcwIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 // Router-level error boundary fallback (see defaultErrorComponent in
 // src/main.tsx). Rendered in place of a route that threw during render or

--- a/frontend/src/components/dev-tools.tsx
+++ b/frontend/src/components/dev-tools.tsx
@@ -4,18 +4,18 @@ import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import TanStackQueryDevtools from "@/integrations/tanstack-query/devtools";
 
 export function DevTools() {
-  return (
-    <TanStackDevtools
-      config={{
-        position: "bottom-right",
-      }}
-      plugins={[
-        {
-          name: "Tanstack Router",
-          render: <TanStackRouterDevtoolsPanel />,
-        },
-        TanStackQueryDevtools,
-      ]}
-    />
-  );
+	return (
+		<TanStackDevtools
+			config={{
+				position: "bottom-right",
+			}}
+			plugins={[
+				{
+					name: "Tanstack Router",
+					render: <TanStackRouterDevtoolsPanel />,
+				},
+				TanStackQueryDevtools,
+			]}
+		/>
+	);
 }

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,64 @@
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+	className,
+	...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+	return (
+		<TabsPrimitive.Root
+			data-slot="tabs"
+			className={cn("flex flex-col gap-2", className)}
+			{...props}
+		/>
+	);
+}
+
+function TabsList({
+	className,
+	...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+	return (
+		<TabsPrimitive.List
+			data-slot="tabs-list"
+			className={cn(
+				"bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TabsTrigger({
+	className,
+	...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+	return (
+		<TabsPrimitive.Trigger
+			data-slot="tabs-trigger"
+			className={cn(
+				"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TabsContent({
+	className,
+	...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+	return (
+		<TabsPrimitive.Content
+			data-slot="tabs-content"
+			className={cn("flex-1 outline-none", className)}
+			{...props}
+		/>
+	);
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/src/features/containers/api/container-actions.ts
+++ b/frontend/src/features/containers/api/container-actions.ts
@@ -6,48 +6,48 @@ const BASE_URL = `${API_BASE_URL}/api/v1/containers`;
 type ContainerAction = "start" | "stop" | "restart" | "remove";
 
 interface ActionResponse {
-  message?: string;
+	message?: string;
 }
 
 async function performContainerAction(
-  id: string,
-  action: ContainerAction,
-  host: string
+	id: string,
+	action: ContainerAction,
+	host: string,
 ): Promise<string> {
-  const endpoint = `${BASE_URL}/${encodeURIComponent(id)}/${action}?host=${encodeURIComponent(host)}`;
-  const response = await authenticatedFetch(endpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
+	const endpoint = `${BASE_URL}/${encodeURIComponent(id)}/${action}?host=${encodeURIComponent(host)}`;
+	const response = await authenticatedFetch(endpoint, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Failed to ${action} container`);
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || `Failed to ${action} container`);
+	}
 
-  const data = (await response.json()) as ActionResponse | undefined;
+	const data = (await response.json()) as ActionResponse | undefined;
 
-  if (data && typeof data.message === "string") {
-    return data.message;
-  }
+	if (data && typeof data.message === "string") {
+		return data.message;
+	}
 
-  return "Action completed successfully";
+	return "Action completed successfully";
 }
 
 export function startContainer(id: string, host: string) {
-  return performContainerAction(id, "start", host);
+	return performContainerAction(id, "start", host);
 }
 
 export function stopContainer(id: string, host: string) {
-  return performContainerAction(id, "stop", host);
+	return performContainerAction(id, "stop", host);
 }
 
 export function restartContainer(id: string, host: string) {
-  return performContainerAction(id, "restart", host);
+	return performContainerAction(id, "restart", host);
 }
 
 export function removeContainer(id: string, host: string) {
-  return performContainerAction(id, "remove", host);
+	return performContainerAction(id, "remove", host);
 }

--- a/frontend/src/features/containers/api/get-container-env-variables.ts
+++ b/frontend/src/features/containers/api/get-container-env-variables.ts
@@ -2,21 +2,21 @@ import { authenticatedFetch } from "@/lib/api-client";
 import { API_BASE_URL } from "@/types/api";
 
 interface EnvVariablesResponse {
-  env: Record<string, string>;
+	env: Record<string, string>;
 }
 
 export async function getContainerEnvVariables(
-  id: string,
-  host: string
+	id: string,
+	host: string,
 ): Promise<Record<string, string>> {
-  const response = await authenticatedFetch(
-    `${API_BASE_URL}/api/v1/containers/${encodeURIComponent(id)}/env?host=${encodeURIComponent(host)}`
-  );
+	const response = await authenticatedFetch(
+		`${API_BASE_URL}/api/v1/containers/${encodeURIComponent(id)}/env?host=${encodeURIComponent(host)}`,
+	);
 
-  if (!response.ok) {
-    throw new Error("Failed to fetch container environment variables");
-  }
+	if (!response.ok) {
+		throw new Error("Failed to fetch container environment variables");
+	}
 
-  const data: EnvVariablesResponse = await response.json();
-  return data.env || {};
+	const data: EnvVariablesResponse = await response.json();
+	return data.env || {};
 }

--- a/frontend/src/features/containers/api/get-container-events.ts
+++ b/frontend/src/features/containers/api/get-container-events.ts
@@ -5,34 +5,34 @@ import { API_BASE_URL } from "@/types/api";
 const EVENTS_ENDPOINT = `${API_BASE_URL}/api/v1/events`;
 
 export interface ContainerEvent {
-  host: string;
-  containerId: string;
-  containerName: string;
-  action: string;
-  timestamp: number;
+	host: string;
+	containerId: string;
+	containerName: string;
+	action: string;
+	timestamp: number;
 }
 
 export async function* streamContainerEvents(
-  signal?: AbortSignal,
-  onOpen?: () => void
+	signal?: AbortSignal,
+	onOpen?: () => void,
 ): AsyncGenerator<ContainerEvent, void, unknown> {
-  const response = await authenticatedFetch(EVENTS_ENDPOINT, {
-    headers: {
-      Accept: "application/x-ndjson",
-    },
-    signal,
-  });
+	const response = await authenticatedFetch(EVENTS_ENDPOINT, {
+		headers: {
+			Accept: "application/x-ndjson",
+		},
+		signal,
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || "Failed to subscribe to container events");
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to subscribe to container events");
+	}
 
-  if (!response.body) {
-    throw new Error("Streaming is not supported in this environment.");
-  }
+	if (!response.body) {
+		throw new Error("Streaming is not supported in this environment.");
+	}
 
-  onOpen?.();
+	onOpen?.();
 
-  yield* iterateNDJSONStream<ContainerEvent>(response.body, signal);
+	yield* iterateNDJSONStream<ContainerEvent>(response.body, signal);
 }

--- a/frontend/src/features/containers/api/get-container-logs-parsed.ts
+++ b/frontend/src/features/containers/api/get-container-logs-parsed.ts
@@ -5,260 +5,265 @@ import { API_BASE_URL } from "@/types/api";
 const BASE_URL = `${API_BASE_URL}/api/v1/containers`;
 
 export type LogLevel =
-  | "TRACE"
-  | "DEBUG"
-  | "INFO"
-  | "WARN"
-  | "WARNING"
-  | "ERROR"
-  | "FATAL"
-  | "PANIC"
-  | "UNKNOWN";
+	| "TRACE"
+	| "DEBUG"
+	| "INFO"
+	| "WARN"
+	| "WARNING"
+	| "ERROR"
+	| "FATAL"
+	| "PANIC"
+	| "UNKNOWN";
 
 export interface LogEntry {
-  timestamp?: string;
-  level: LogLevel;
-  message?: string;
-  stream?: "stdout" | "stderr";
-  raw?: string;
-  fields?: Record<string, string>;
-  continuationCount?: number;
-  // Present only on aggregated multi-container streams.
-  containerId?: string;
-  containerName?: string;
+	timestamp?: string;
+	level: LogLevel;
+	message?: string;
+	stream?: "stdout" | "stderr";
+	raw?: string;
+	fields?: Record<string, string>;
+	continuationCount?: number;
+	// Present only on aggregated multi-container streams.
+	containerId?: string;
+	containerName?: string;
 }
 
 export interface ContainerLogsParsedResponse {
-  logs: LogEntry[];
-  count: number;
+	logs: LogEntry[];
+	count: number;
 }
 
 // Liveness line the server writes on quiet follow streams. Never displayed;
 // consumers use it to tell a quiet stream from a dead one.
 export interface LogStreamHeartbeat {
-  type: "heartbeat";
+	type: "heartbeat";
 }
 
 export function isLogStreamHeartbeat(
-  value: unknown
+	value: unknown,
 ): value is LogStreamHeartbeat {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as { type?: unknown }).type === "heartbeat"
-  );
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		(value as { type?: unknown }).type === "heartbeat"
+	);
 }
 
 export interface ContainerLogsOptions {
-  since?: string;
-  until?: string;
-  tail?: string | number;
-  details?: boolean;
-  stdout?: boolean;
-  stderr?: boolean;
-  follow?: boolean;
-  search?: string;
+	since?: string;
+	until?: string;
+	tail?: string | number;
+	details?: boolean;
+	stdout?: boolean;
+	stderr?: boolean;
+	follow?: boolean;
+	search?: string;
 }
 
 const DEFAULT_OPTIONS: Required<
-  Pick<ContainerLogsOptions, "tail" | "details" | "stdout" | "stderr">
+	Pick<ContainerLogsOptions, "tail" | "details" | "stdout" | "stderr">
 > = {
-  tail: "100",
-  details: false,
-  stdout: true,
-  stderr: true,
+	tail: "100",
+	details: false,
+	stdout: true,
+	stderr: true,
 };
 
-function buildLogsUrl(id: string, host: string, options?: ContainerLogsOptions) {
-  const query = new URLSearchParams();
-  const merged: ContainerLogsOptions = {
-    ...DEFAULT_OPTIONS,
-    ...options,
-  };
+function buildLogsUrl(
+	id: string,
+	host: string,
+	options?: ContainerLogsOptions,
+) {
+	const query = new URLSearchParams();
+	const merged: ContainerLogsOptions = {
+		...DEFAULT_OPTIONS,
+		...options,
+	};
 
-  query.set("host", host);
+	query.set("host", host);
 
-  if (merged.since) {
-    query.set("since", merged.since);
-  }
-  if (merged.until) {
-    query.set("until", merged.until);
-  }
-  if (merged.tail !== undefined) {
-    query.set("tail", String(merged.tail));
-  }
-  if (merged.details !== undefined) {
-    query.set("details", String(merged.details));
-  }
-  if (merged.stdout !== undefined) {
-    query.set("stdout", String(merged.stdout));
-  }
-  if (merged.stderr !== undefined) {
-    query.set("stderr", String(merged.stderr));
-  }
-  if (merged.follow !== undefined) {
-    query.set("follow", String(merged.follow));
-  }
-  if (merged.search) {
-    query.set("search", merged.search);
-  }
+	if (merged.since) {
+		query.set("since", merged.since);
+	}
+	if (merged.until) {
+		query.set("until", merged.until);
+	}
+	if (merged.tail !== undefined) {
+		query.set("tail", String(merged.tail));
+	}
+	if (merged.details !== undefined) {
+		query.set("details", String(merged.details));
+	}
+	if (merged.stdout !== undefined) {
+		query.set("stdout", String(merged.stdout));
+	}
+	if (merged.stderr !== undefined) {
+		query.set("stderr", String(merged.stderr));
+	}
+	if (merged.follow !== undefined) {
+		query.set("follow", String(merged.follow));
+	}
+	if (merged.search) {
+		query.set("search", merged.search);
+	}
 
-  const path = `${BASE_URL}/${encodeURIComponent(id)}/logs/parsed`;
-  const queryString = query.toString();
-  return queryString ? `${path}?${queryString}` : path;
+	const path = `${BASE_URL}/${encodeURIComponent(id)}/logs/parsed`;
+	const queryString = query.toString();
+	return queryString ? `${path}?${queryString}` : path;
 }
 
 export async function getContainerLogsParsed(
-  id: string,
-  host: string,
-  options?: ContainerLogsOptions
+	id: string,
+	host: string,
+	options?: ContainerLogsOptions,
 ): Promise<LogEntry[]> {
-  const response = await authenticatedFetch(buildLogsUrl(id, host, options), {
-    headers: {
-      Accept: "application/json",
-    },
-  });
+	const response = await authenticatedFetch(buildLogsUrl(id, host, options), {
+		headers: {
+			Accept: "application/json",
+		},
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Failed to fetch logs for container ${id}`);
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || `Failed to fetch logs for container ${id}`);
+	}
 
-  const data: ContainerLogsParsedResponse = await response.json();
-  return data.logs || [];
+	const data: ContainerLogsParsedResponse = await response.json();
+	return data.logs || [];
 }
 
 export async function* streamContainerLogsParsed(
-  id: string,
-  host: string,
-  options?: ContainerLogsOptions,
-  signal?: AbortSignal
+	id: string,
+	host: string,
+	options?: ContainerLogsOptions,
+	signal?: AbortSignal,
 ): AsyncGenerator<LogEntry | LogStreamHeartbeat, void, unknown> {
-  const streamOptions = { ...options, follow: true };
-  const response = await authenticatedFetch(buildLogsUrl(id, host, streamOptions), {
-    headers: {
-      Accept: "application/x-ndjson",
-    },
-    signal,
-  });
+	const streamOptions = { ...options, follow: true };
+	const response = await authenticatedFetch(
+		buildLogsUrl(id, host, streamOptions),
+		{
+			headers: {
+				Accept: "application/x-ndjson",
+			},
+			signal,
+		},
+	);
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(
-      message || `Failed to stream logs for container ${id}`
-    );
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || `Failed to stream logs for container ${id}`);
+	}
 
-  if (!response.body) {
-    throw new Error("Streaming is not supported in this environment.");
-  }
+	if (!response.body) {
+		throw new Error("Streaming is not supported in this environment.");
+	}
 
-  for await (const entry of iterateNDJSONStream<LogEntry | LogStreamHeartbeat>(
-    response.body,
-    signal
-  )) {
-    yield entry;
-  }
+	for await (const entry of iterateNDJSONStream<LogEntry | LogStreamHeartbeat>(
+		response.body,
+		signal,
+	)) {
+		yield entry;
+	}
 }
 
 export function getLogLevelBadgeColor(level: LogLevel | undefined): string {
-  switch (level ?? "UNKNOWN") {
-    case "TRACE":
-    case "DEBUG":
-      return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
-    case "INFO":
-      return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
-    case "WARN":
-    case "WARNING":
-      return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300";
-    case "ERROR":
-      return "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300";
-    case "FATAL":
-    case "PANIC":
-      return "bg-red-200 text-red-900 dark:bg-red-950 dark:text-red-200 font-semibold";
-    default:
-      return "bg-muted text-muted-foreground";
-  }
+	switch (level ?? "UNKNOWN") {
+		case "TRACE":
+		case "DEBUG":
+			return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+		case "INFO":
+			return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
+		case "WARN":
+		case "WARNING":
+			return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300";
+		case "ERROR":
+			return "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300";
+		case "FATAL":
+		case "PANIC":
+			return "bg-red-200 text-red-900 dark:bg-red-950 dark:text-red-200 font-semibold";
+		default:
+			return "bg-muted text-muted-foreground";
+	}
 }
 
 const STRUCTURED_FIELD_REGEX = /^([A-Za-z_][A-Za-z0-9_.-]*)\s*[:=]\s*(.+)$/;
 const STACK_TRACE_PREFIXES = [
-  "at ",
-  "File ",
-  "Traceback ",
-  "Caused by:",
-  "... ",
-  "goroutine ",
+	"at ",
+	"File ",
+	"Traceback ",
+	"Caused by:",
+	"... ",
+	"goroutine ",
 ];
 
 export function groupRelatedLogEntries<TLogEntry extends LogEntry>(
-  entries: TLogEntry[]
+	entries: TLogEntry[],
 ): TLogEntry[] {
-  const grouped: TLogEntry[] = [];
+	const grouped: TLogEntry[] = [];
 
-  for (const entry of entries) {
-    const previous = grouped.at(-1);
-    if (previous && isContinuationLogEntry(entry, previous)) {
-      grouped[grouped.length - 1] = appendContinuationLogEntry(previous, entry);
-      continue;
-    }
+	for (const entry of entries) {
+		const previous = grouped.at(-1);
+		if (previous && isContinuationLogEntry(entry, previous)) {
+			grouped[grouped.length - 1] = appendContinuationLogEntry(previous, entry);
+			continue;
+		}
 
-    grouped.push(entry);
-  }
+		grouped.push(entry);
+	}
 
-  return grouped;
+	return grouped;
 }
 
 function isContinuationLogEntry(entry: LogEntry, previous: LogEntry): boolean {
-  if (entry.level !== "UNKNOWN") return false;
-  // Aggregate streams interleave containers; never fold a line into another
-  // container's entry.
-  if (entry.containerName !== previous.containerName) return false;
+	if (entry.level !== "UNKNOWN") return false;
+	// Aggregate streams interleave containers; never fold a line into another
+	// container's entry.
+	if (entry.containerName !== previous.containerName) return false;
 
-  const message = (entry.message ?? entry.raw ?? "").trim();
-  const previousMessage = (previous.message ?? previous.raw ?? "").trim();
-  if (!message || !previousMessage) return false;
+	const message = (entry.message ?? entry.raw ?? "").trim();
+	const previousMessage = (previous.message ?? previous.raw ?? "").trim();
+	if (!message || !previousMessage) return false;
 
-  if (STRUCTURED_FIELD_REGEX.test(message)) return true;
+	if (STRUCTURED_FIELD_REGEX.test(message)) return true;
 
-  return isProblemLevel(previous.level) && isStackTraceContinuation(message);
+	return isProblemLevel(previous.level) && isStackTraceContinuation(message);
 }
 
 function appendContinuationLogEntry<TLogEntry extends LogEntry>(
-  entry: TLogEntry,
-  continuation: LogEntry
+	entry: TLogEntry,
+	continuation: LogEntry,
 ): TLogEntry {
-  const message = (continuation.message ?? continuation.raw ?? "").trim();
-  const raw = continuation.raw?.trim();
-  const fields = { ...(entry.fields ?? {}) };
-  const fieldMatch = message.match(STRUCTURED_FIELD_REGEX);
+	const message = (continuation.message ?? continuation.raw ?? "").trim();
+	const raw = continuation.raw?.trim();
+	const fields = { ...(entry.fields ?? {}) };
+	const fieldMatch = message.match(STRUCTURED_FIELD_REGEX);
 
-  if (fieldMatch) {
-    fields[fieldMatch[1]] = fieldMatch[2].trim();
-  }
+	if (fieldMatch) {
+		fields[fieldMatch[1]] = fieldMatch[2].trim();
+	}
 
-  return {
-    ...entry,
-    message: [entry.message, message].filter(Boolean).join("\n"),
-    raw: [entry.raw, raw].filter(Boolean).join("\n"),
-    fields: Object.keys(fields).length > 0 ? fields : entry.fields,
-    continuationCount: (entry.continuationCount ?? 0) + 1,
-  } as TLogEntry;
+	return {
+		...entry,
+		message: [entry.message, message].filter(Boolean).join("\n"),
+		raw: [entry.raw, raw].filter(Boolean).join("\n"),
+		fields: Object.keys(fields).length > 0 ? fields : entry.fields,
+		continuationCount: (entry.continuationCount ?? 0) + 1,
+	} as TLogEntry;
 }
 
 function isProblemLevel(level: LogLevel | undefined): boolean {
-  return (
-    level === "WARN" ||
-    level === "WARNING" ||
-    level === "ERROR" ||
-    level === "FATAL" ||
-    level === "PANIC"
-  );
+	return (
+		level === "WARN" ||
+		level === "WARNING" ||
+		level === "ERROR" ||
+		level === "FATAL" ||
+		level === "PANIC"
+	);
 }
 
 function isStackTraceContinuation(message: string): boolean {
-  return (
-    STACK_TRACE_PREFIXES.some((prefix) => message.startsWith(prefix)) ||
-    (message.startsWith("/") && message.includes(":"))
-  );
+	return (
+		STACK_TRACE_PREFIXES.some((prefix) => message.startsWith(prefix)) ||
+		(message.startsWith("/") && message.includes(":"))
+	);
 }

--- a/frontend/src/features/containers/api/get-container-stats.ts
+++ b/frontend/src/features/containers/api/get-container-stats.ts
@@ -6,15 +6,18 @@ import type { ContainerStats } from "../types";
 const CONTAINER_STATS_ENDPOINT = `${API_BASE_URL}/api/v1/containers/stats`;
 
 export interface GetContainerStatsResponse {
-  stats: ContainerStats[];
+	stats: ContainerStats[];
 }
 
 export async function getContainerStats(): Promise<GetContainerStatsResponse> {
-  const response = await authenticatedFetch(CONTAINER_STATS_ENDPOINT);
+	const response = await authenticatedFetch(CONTAINER_STATS_ENDPOINT);
 
-  if (!response.ok) {
-    throw new Error((await response.text()) || `Request failed with status ${response.status}`);
-  }
+	if (!response.ok) {
+		throw new Error(
+			(await response.text()) ||
+				`Request failed with status ${response.status}`,
+		);
+	}
 
-  return response.json();
+	return response.json();
 }

--- a/frontend/src/features/containers/api/get-containers.ts
+++ b/frontend/src/features/containers/api/get-containers.ts
@@ -6,46 +6,47 @@ import type { ContainerInfo, DockerHost, HostError } from "../types";
 const CONTAINERS_ENDPOINT = `${API_BASE_URL}/api/v1/containers`;
 
 export interface GetContainersResponse {
-  containers: ContainerInfo[];
-  readOnly: boolean;
-  hosts: DockerHost[];
-  hostErrors: HostError[];
-  coolifyConfigured: boolean;
+	containers: ContainerInfo[];
+	readOnly: boolean;
+	hosts: DockerHost[];
+	hostErrors: HostError[];
+	coolifyConfigured: boolean;
 }
 
 export async function getContainers(): Promise<GetContainersResponse> {
-  const response = await authenticatedFetch(CONTAINERS_ENDPOINT);
+	const response = await authenticatedFetch(CONTAINERS_ENDPOINT);
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed with status ${response.status}`);
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || `Request failed with status ${response.status}`);
+	}
 
-  const data = (await response.json()) as unknown;
+	const data = (await response.json()) as unknown;
 
-  if (!data || typeof data !== "object" || data === null) {
-    throw new Error("Unexpected response format");
-  }
+	if (!data || typeof data !== "object" || data === null) {
+		throw new Error("Unexpected response format");
+	}
 
-  const containers = (data as { containers?: unknown }).containers;
-  const readOnly = (data as { readOnly?: boolean }).readOnly ?? false;
-  const hosts = (data as { hosts?: unknown }).hosts;
-  const hostErrors = (data as { hostErrors?: unknown }).hostErrors;
-  const coolifyConfigured = (data as { coolifyConfigured?: boolean }).coolifyConfigured ?? false;
+	const containers = (data as { containers?: unknown }).containers;
+	const readOnly = (data as { readOnly?: boolean }).readOnly ?? false;
+	const hosts = (data as { hosts?: unknown }).hosts;
+	const hostErrors = (data as { hostErrors?: unknown }).hostErrors;
+	const coolifyConfigured =
+		(data as { coolifyConfigured?: boolean }).coolifyConfigured ?? false;
 
-  if (!Array.isArray(containers)) {
-    throw new Error("Unexpected response format");
-  }
+	if (!Array.isArray(containers)) {
+		throw new Error("Unexpected response format");
+	}
 
-  if (!Array.isArray(hosts)) {
-    throw new Error("Unexpected response format");
-  }
+	if (!Array.isArray(hosts)) {
+		throw new Error("Unexpected response format");
+	}
 
-  return {
-    containers: containers as ContainerInfo[],
-    readOnly,
-    hosts: hosts as DockerHost[],
-    hostErrors: Array.isArray(hostErrors) ? (hostErrors as HostError[]) : [],
-    coolifyConfigured,
-  };
+	return {
+		containers: containers as ContainerInfo[],
+		readOnly,
+		hosts: hosts as DockerHost[],
+		hostErrors: Array.isArray(hostErrors) ? (hostErrors as HostError[]) : [],
+		coolifyConfigured,
+	};
 }

--- a/frontend/src/features/containers/api/get-system-stats.ts
+++ b/frontend/src/features/containers/api/get-system-stats.ts
@@ -2,30 +2,30 @@ import { authenticatedFetch } from "@/lib/api-client";
 import { API_BASE_URL } from "@/types/api";
 
 export interface SystemStats {
-  hostInfo: {
-    hostname: string;
-    platform: string;
-    platformVersion: string;
-    kernelVersion: string;
-    arch: string;
-    uptime: number;
-  };
-  usage: {
-    cpuPercent: number;
-    memoryPercent: number;
-    memoryTotal: number;
-    memoryUsed: number;
-  };
+	hostInfo: {
+		hostname: string;
+		platform: string;
+		platformVersion: string;
+		kernelVersion: string;
+		arch: string;
+		uptime: number;
+	};
+	usage: {
+		cpuPercent: number;
+		memoryPercent: number;
+		memoryTotal: number;
+		memoryUsed: number;
+	};
 }
 
 export async function getSystemStats(): Promise<SystemStats> {
-  const response = await authenticatedFetch(
-    `${API_BASE_URL}/api/v1/system/stats`
-  );
+	const response = await authenticatedFetch(
+		`${API_BASE_URL}/api/v1/system/stats`,
+	);
 
-  if (!response.ok) {
-    throw new Error("Failed to fetch system stats");
-  }
+	if (!response.ok) {
+		throw new Error("Failed to fetch system stats");
+	}
 
-  return response.json();
+	return response.json();
 }

--- a/frontend/src/features/containers/api/update-container-env-variables.ts
+++ b/frontend/src/features/containers/api/update-container-env-variables.ts
@@ -2,42 +2,42 @@ import { authenticatedFetch } from "@/lib/api-client";
 import { API_BASE_URL } from "@/types/api";
 
 interface UpdateEnvResponse {
-  message: string;
-  new_container_id: string;
-  coolify_synced?: boolean;
-  coolify_error?: string;
+	message: string;
+	new_container_id: string;
+	coolify_synced?: boolean;
+	coolify_error?: string;
 }
 
 export interface UpdateEnvResult {
-  newContainerId: string;
-  coolifySynced?: boolean;
-  coolifyError?: string;
+	newContainerId: string;
+	coolifySynced?: boolean;
+	coolifyError?: string;
 }
 
 export async function updateContainerEnvVariables(
-  id: string,
-  host: string,
-  env: Record<string, string>
+	id: string,
+	host: string,
+	env: Record<string, string>,
 ): Promise<UpdateEnvResult> {
-  const response = await authenticatedFetch(
-    `${API_BASE_URL}/api/v1/containers/${encodeURIComponent(id)}/env?host=${encodeURIComponent(host)}`,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ env }),
-    }
-  );
+	const response = await authenticatedFetch(
+		`${API_BASE_URL}/api/v1/containers/${encodeURIComponent(id)}/env?host=${encodeURIComponent(host)}`,
+		{
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ env }),
+		},
+	);
 
-  if (!response.ok) {
-    throw new Error("Failed to update container environment variables");
-  }
+	if (!response.ok) {
+		throw new Error("Failed to update container environment variables");
+	}
 
-  const data: UpdateEnvResponse = await response.json();
-  return {
-    newContainerId: data.new_container_id,
-    coolifySynced: data.coolify_synced,
-    coolifyError: data.coolify_error,
-  };
+	const data: UpdateEnvResponse = await response.json();
+	return {
+		newContainerId: data.new_container_id,
+		coolifySynced: data.coolify_synced,
+		coolifyError: data.coolify_error,
+	};
 }

--- a/frontend/src/features/containers/components/collapsible-json.tsx
+++ b/frontend/src/features/containers/components/collapsible-json.tsx
@@ -27,32 +27,40 @@ function colorizeJson(jsonStr: string): React.ReactNode {
 		for (const match of remaining.matchAll(tokenRegex)) {
 			if (match.index > lastIndex) {
 				parts.push(
-		<span key={partIdx++}>{remaining.slice(lastIndex, match.index)}</span>,
+					<span key={partIdx++}>
+						{remaining.slice(lastIndex, match.index)}
+					</span>,
 				);
 			}
 
 			if (match[1]) {
 				parts.push(
-		<span key={partIdx++} className="text-blue-600 dark:text-blue-400">
+					<span key={partIdx++} className="text-blue-600 dark:text-blue-400">
 						{match[1]}
 					</span>,
 				);
-parts.push(<span key={partIdx++}>:</span>);
+				parts.push(<span key={partIdx++}>:</span>);
 			} else if (match[2]) {
 				parts.push(
-		<span key={partIdx++} className="text-green-600 dark:text-green-400">
+					<span key={partIdx++} className="text-green-600 dark:text-green-400">
 						{match[2]}
 					</span>,
 				);
 			} else if (match[3]) {
 				parts.push(
-		<span key={partIdx++} className="text-orange-600 dark:text-orange-400">
+					<span
+						key={partIdx++}
+						className="text-orange-600 dark:text-orange-400"
+					>
 						{match[3]}
 					</span>,
 				);
 			} else if (match[4]) {
 				parts.push(
-		<span key={partIdx++} className="text-purple-600 dark:text-purple-400">
+					<span
+						key={partIdx++}
+						className="text-purple-600 dark:text-purple-400"
+					>
 						{match[4]}
 					</span>,
 				);
@@ -99,9 +107,7 @@ export function CollapsibleJson({
 				>
 					<ChevronRightIcon className="size-3" />
 				</button>
-				{highlightSearchText
-					? highlightSearchText(text, isCurrentMatch)
-					: text}
+				{highlightSearchText ? highlightSearchText(text, isCurrentMatch) : text}
 			</span>
 		);
 	}

--- a/frontend/src/features/containers/components/container-utils.ts
+++ b/frontend/src/features/containers/components/container-utils.ts
@@ -5,123 +5,123 @@ export type GroupByOption = "none" | "compose";
 export type ContainerActionType = "start" | "stop" | "restart" | "remove";
 
 export interface GroupedContainers {
-  project: string;
-  items: ContainerInfo[];
+	project: string;
+	items: ContainerInfo[];
 }
 
 export interface StateCounts {
-  running: number;
-  exited: number;
-  paused: number;
-  restarting: number;
-  dead: number;
-  other: number;
+	running: number;
+	exited: number;
+	paused: number;
+	restarting: number;
+	dead: number;
+	other: number;
 }
 
 // Docker Compose and recent podman-compose both set the com.docker label;
 // older podman-compose releases only set the io.podman one.
 const COMPOSE_PROJECT_LABELS = [
-  "com.docker.compose.project",
-  "io.podman.compose.project",
+	"com.docker.compose.project",
+	"io.podman.compose.project",
 ];
 
 export function getComposeProject(labels?: Record<string, string>) {
-  for (const label of COMPOSE_PROJECT_LABELS) {
-    const project = labels?.[label]?.trim();
-    if (project) {
-      return project;
-    }
-  }
-  return undefined;
+	for (const label of COMPOSE_PROJECT_LABELS) {
+		const project = labels?.[label]?.trim();
+		if (project) {
+			return project;
+		}
+	}
+	return undefined;
 }
 
 export function formatContainerName(names: string[]) {
-  if (!names.length) {
-    return "—";
-  }
-  const [primary] = names;
-  return primary.startsWith("/") ? primary.slice(1) : primary;
+	if (!names.length) {
+		return "—";
+	}
+	const [primary] = names;
+	return primary.startsWith("/") ? primary.slice(1) : primary;
 }
 
 export function formatCreatedDate(createdSeconds: number) {
-  const createdDate = new Date(createdSeconds * 1000);
-  return createdDate.toLocaleString(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
+	const createdDate = new Date(createdSeconds * 1000);
+	return createdDate.toLocaleString(undefined, {
+		dateStyle: "medium",
+		timeStyle: "short",
+	});
 }
 
 export function formatUptime(createdSeconds: number) {
-  const now = Date.now();
-  const createdMs = createdSeconds * 1000;
-  const diffMs = now - createdMs;
+	const now = Date.now();
+	const createdMs = createdSeconds * 1000;
+	const diffMs = now - createdMs;
 
-  const seconds = Math.floor(diffMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
-  const weeks = Math.floor(days / 7);
-  const months = Math.floor(days / 30);
-  const years = Math.floor(days / 365);
+	const seconds = Math.floor(diffMs / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+	const weeks = Math.floor(days / 7);
+	const months = Math.floor(days / 30);
+	const years = Math.floor(days / 365);
 
-  if (years > 0) return `${years} year${years > 1 ? "s" : ""}`;
-  if (months > 0) return `${months} month${months > 1 ? "s" : ""}`;
-  if (weeks > 0) return `${weeks} week${weeks > 1 ? "s" : ""}`;
-  if (days > 0) return `${days} day${days > 1 ? "s" : ""}`;
-  if (hours > 0) return `${hours} hour${hours > 1 ? "s" : ""}`;
-  if (minutes > 0) return `${minutes} minute${minutes > 1 ? "s" : ""}`;
-  return `${seconds} second${seconds !== 1 ? "s" : ""}`;
+	if (years > 0) return `${years} year${years > 1 ? "s" : ""}`;
+	if (months > 0) return `${months} month${months > 1 ? "s" : ""}`;
+	if (weeks > 0) return `${weeks} week${weeks > 1 ? "s" : ""}`;
+	if (days > 0) return `${days} day${days > 1 ? "s" : ""}`;
+	if (hours > 0) return `${hours} hour${hours > 1 ? "s" : ""}`;
+	if (minutes > 0) return `${minutes} minute${minutes > 1 ? "s" : ""}`;
+	return `${seconds} second${seconds !== 1 ? "s" : ""}`;
 }
 
 export function toTitleCase(value: string) {
-  if (!value) return value;
-  return value.charAt(0).toUpperCase() + value.slice(1);
+	if (!value) return value;
+	return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 export function getStateBadgeClass(state: string) {
-  const normalized = state.toLowerCase();
-  switch (normalized) {
-    case "running":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
-    case "paused":
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-400";
-    case "exited":
-    case "dead":
-      return "bg-rose-500/10 text-rose-700 dark:text-rose-400";
-    case "restarting":
-      return "bg-blue-500/10 text-blue-700 dark:text-blue-400";
-    default:
-      return "bg-muted text-muted-foreground";
-  }
+	const normalized = state.toLowerCase();
+	switch (normalized) {
+		case "running":
+			return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
+		case "paused":
+			return "bg-amber-500/10 text-amber-700 dark:text-amber-400";
+		case "exited":
+		case "dead":
+			return "bg-rose-500/10 text-rose-700 dark:text-rose-400";
+		case "restarting":
+			return "bg-blue-500/10 text-blue-700 dark:text-blue-400";
+		default:
+			return "bg-muted text-muted-foreground";
+	}
 }
 
 export function groupByCompose(
-  containers: ContainerInfo[]
+	containers: ContainerInfo[],
 ): GroupedContainers[] {
-  const groups = new Map<string, ContainerInfo[]>();
+	const groups = new Map<string, ContainerInfo[]>();
 
-  containers.forEach((container) => {
-    const key = getComposeProject(container.labels) || "Standalone";
-    if (!groups.has(key)) {
-      groups.set(key, []);
-    }
-    groups.get(key)?.push(container)
-  });
+	containers.forEach((container) => {
+		const key = getComposeProject(container.labels) || "Standalone";
+		if (!groups.has(key)) {
+			groups.set(key, []);
+		}
+		groups.get(key)?.push(container);
+	});
 
-  return Array.from(groups.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([project, items]) => ({ project, items }));
+	return Array.from(groups.entries())
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([project, items]) => ({ project, items }));
 }
 
 export function getInitialStateCounts(): StateCounts {
-  return {
-    running: 0,
-    exited: 0,
-    paused: 0,
-    restarting: 0,
-    dead: 0,
-    other: 0,
-  };
+	return {
+		running: 0,
+		exited: 0,
+		paused: 0,
+		restarting: 0,
+		dead: 0,
+		other: 0,
+	};
 }
 
 /**
@@ -129,39 +129,42 @@ export function getInitialStateCounts(): StateCounts {
  * Falls back to container ID if no name is available
  */
 export function getContainerUrlIdentifier(container: ContainerInfo): string {
-  if (container.names && container.names.length > 0) {
-    const name = container.names[0];
-    return name.startsWith("/") ? name.slice(1) : name;
-  }
-  // Fallback to short ID if no name
-  return container.id.substring(0, 12);
+	if (container.names && container.names.length > 0) {
+		const name = container.names[0];
+		return name.startsWith("/") ? name.slice(1) : name;
+	}
+	// Fallback to short ID if no name
+	return container.id.substring(0, 12);
 }
 
 export function isCoolifyManaged(labels?: Record<string, string>): boolean {
-  return labels?.["coolify.managed"] === "true";
+	return labels?.["coolify.managed"] === "true";
 }
 
 export function formatBytes(bytes: number): string {
-  if (!bytes || bytes < 0) return "—";
-  if (bytes === 0) return "0 B";
+	if (!bytes || bytes < 0) return "—";
+	if (bytes === 0) return "0 B";
 
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const value = bytes / 1024 ** index;
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	const index = Math.min(
+		Math.floor(Math.log(bytes) / Math.log(1024)),
+		units.length - 1,
+	);
+	const value = bytes / 1024 ** index;
 
-  return `${value.toFixed(index === 0 ? 0 : 1)}${units[index]}`;
+	return `${value.toFixed(index === 0 ? 0 : 1)}${units[index]}`;
 }
 
 export function formatCPUPercent(percent: number | undefined): string {
-  return percent != null ? `${percent.toFixed(1)}%` : "—";
+	return percent != null ? `${percent.toFixed(1)}%` : "—";
 }
 
 export function formatMemoryStats(stats: ContainerStats | undefined): string {
-  if (!stats?.memory_percent || !stats?.memory_used) return "—";
+	if (!stats?.memory_percent || !stats?.memory_used) return "—";
 
-  const percent = stats.memory_percent.toFixed(1);
-  const usage = formatBytes(stats.memory_used);
-  const limit = stats.memory_limit ? `/${formatBytes(stats.memory_limit)}` : "";
+	const percent = stats.memory_percent.toFixed(1);
+	const usage = formatBytes(stats.memory_used);
+	const limit = stats.memory_limit ? `/${formatBytes(stats.memory_limit)}` : "";
 
-  return `${percent}% - ${usage}${limit}`;
+	return `${percent}% - ${usage}${limit}`;
 }

--- a/frontend/src/features/containers/components/containers-dashboard.tsx
+++ b/frontend/src/features/containers/components/containers-dashboard.tsx
@@ -1,39 +1,45 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
+import type { DateRange } from "react-day-picker";
 import { toast } from "sonner";
-
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Spinner } from "@/components/ui/spinner";
-
 import { ResourceNav } from "@/features/resources/components/resource-nav";
-
+import type { ComposeAction } from "../api/compose-actions";
 import { performComposeAction } from "../api/compose-actions";
 import {
-  removeContainer,
-  restartContainer,
-  startContainer,
-  stopContainer,
+	removeContainer,
+	restartContainer,
+	startContainer,
+	stopContainer,
 } from "../api/container-actions";
-import { useContainersDashboardUrlState } from "../hooks/use-containers-dashboard-url-state";
-import { useLiveContainersQuery } from "../hooks/use-live-containers-query";
+import type { GetContainersResponse } from "../api/get-containers";
 import { useContainerStats } from "../hooks/use-container-stats";
+import { useContainersDashboardUrlState } from "../hooks/use-containers-dashboard-url-state";
 import { useHostsStats } from "../hooks/use-hosts-stats";
+import { useLiveContainersQuery } from "../hooks/use-live-containers-query";
 import { useSystemUsageHistory } from "../hooks/use-stats-history";
 import { useSystemStats } from "../hooks/use-system-stats";
-
+import type { ContainerInfo } from "../types";
+import type {
+	ContainerActionType,
+	GroupByOption,
+	GroupedContainers,
+	SortDirection,
+} from "./container-utils";
 import {
-  formatContainerName,
-  getInitialStateCounts,
-  groupByCompose,
+	formatContainerName,
+	getInitialStateCounts,
+	groupByCompose,
 } from "./container-utils";
 import { ContainersLogsSheet } from "./containers-logs-sheet";
 import { ContainersPagination } from "./containers-pagination";
@@ -42,539 +48,528 @@ import { ContainersSummaryCards } from "./containers-summary-cards";
 import { ContainersTable } from "./containers-table";
 import { ContainersToolbar } from "./containers-toolbar";
 
-import type { DateRange } from "react-day-picker";
-import type { ComposeAction } from "../api/compose-actions";
-import type { GetContainersResponse } from "../api/get-containers";
-import type { ContainerInfo } from "../types";
-import type {
-  ContainerActionType,
-  GroupByOption,
-  GroupedContainers,
-  SortDirection,
-} from "./container-utils";
-
 export function ContainersDashboard() {
-  const queryClient = useQueryClient();
-  const { data, error, isError, isFetching, isLoading, refetch } =
-    useLiveContainersQuery();
-  const { data: systemStats } = useSystemStats();
-  const systemHistory = useSystemUsageHistory(systemStats?.usage);
-  const { statsMap, statsHistory } = useContainerStats();
+	const queryClient = useQueryClient();
+	const { data, error, isError, isFetching, isLoading, refetch } =
+		useLiveContainersQuery();
+	const { data: systemStats } = useSystemStats();
+	const systemHistory = useSystemUsageHistory(systemStats?.usage);
+	const { statsMap, statsHistory } = useContainerStats();
 
-  const containers = data?.containers ?? [];
-  const isReadOnly = data?.readOnly ?? false;
-  const hosts = data?.hosts ?? [];
-  const hostErrors = data?.hostErrors ?? [];
-  const { data: hostsStatsData } = useHostsStats(hosts.length > 1);
+	const containers = data?.containers ?? [];
+	const isReadOnly = data?.readOnly ?? false;
+	const hosts = data?.hosts ?? [];
+	const hostErrors = data?.hostErrors ?? [];
+	const { data: hostsStatsData } = useHostsStats(hosts.length > 1);
 
-  useEffect(() => {
-    for (const he of hostErrors) {
-      toast.warning(`Could not reach host "${he.host}"`, {
-        id: `host-error-${he.host}`,
-        description: "Containers from this host could not be loaded.",
-        duration: 8000,
-      });
-    }
-  }, [hostErrors]);
+	useEffect(() => {
+		for (const he of hostErrors) {
+			toast.warning(`Could not reach host "${he.host}"`, {
+				id: `host-error-${he.host}`,
+				description: "Containers from this host could not be loaded.",
+				duration: 8000,
+			});
+		}
+	}, [hostErrors]);
 
-  const hostInfo = useMemo(
-    () => ({
-      hostname: systemStats?.hostInfo.hostname ?? "Loading...",
-      os: systemStats?.hostInfo.platform ?? "Unknown",
-      kernel: systemStats?.hostInfo.kernelVersion ?? "Unknown",
-    }),
-    [systemStats]
-  );
+	const hostInfo = useMemo(
+		() => ({
+			hostname: systemStats?.hostInfo.hostname ?? "Loading...",
+			os: systemStats?.hostInfo.platform ?? "Unknown",
+			kernel: systemStats?.hostInfo.kernelVersion ?? "Unknown",
+		}),
+		[systemStats],
+	);
 
-  const systemUsage = useMemo(
-    () => ({
-      cpu: Math.round(systemStats?.usage.cpuPercent ?? 0),
-      memory: Math.round(systemStats?.usage.memoryPercent ?? 0),
-    }),
-    [systemStats]
-  );
+	const systemUsage = useMemo(
+		() => ({
+			cpu: Math.round(systemStats?.usage.cpuPercent ?? 0),
+			memory: Math.round(systemStats?.usage.memoryPercent ?? 0),
+		}),
+		[systemStats],
+	);
 
-  const {
-    searchTerm,
-    setSearchTerm,
-    stateFilter,
-    setStateFilter,
-    hostFilter,
-    setHostFilter,
-    sortDirection,
-    setSortDirection,
-    groupBy,
-    setGroupBy,
-    dateRange,
-    setDateRange,
-    clearDateRange,
-    pageSize,
-    setPageSize,
-    page,
-    setPage,
-  } = useContainersDashboardUrlState();
-  const [selectedContainer, setSelectedContainer] =
-    useState<ContainerInfo | null>(null);
-  const [isLogsSheetOpen, setIsLogsSheetOpen] = useState(false);
-  const [pendingAction, setPendingAction] = useState<{
-    id: string;
-    type: ContainerActionType;
-  } | null>(null);
-  const [pendingComposeAction, setPendingComposeAction] = useState<{
-    project: string;
-    type: ComposeAction;
-  } | null>(null);
-  const [confirmAction, setConfirmAction] = useState<{
-    type: Extract<ContainerActionType, "stop" | "remove">;
-    container: ContainerInfo;
-  } | null>(null);
+	const {
+		searchTerm,
+		setSearchTerm,
+		stateFilter,
+		setStateFilter,
+		hostFilter,
+		setHostFilter,
+		sortDirection,
+		setSortDirection,
+		groupBy,
+		setGroupBy,
+		dateRange,
+		setDateRange,
+		clearDateRange,
+		pageSize,
+		setPageSize,
+		page,
+		setPage,
+	} = useContainersDashboardUrlState();
+	const [selectedContainer, setSelectedContainer] =
+		useState<ContainerInfo | null>(null);
+	const [isLogsSheetOpen, setIsLogsSheetOpen] = useState(false);
+	const [pendingAction, setPendingAction] = useState<{
+		id: string;
+		type: ContainerActionType;
+	} | null>(null);
+	const [pendingComposeAction, setPendingComposeAction] = useState<{
+		project: string;
+		type: ComposeAction;
+	} | null>(null);
+	const [confirmAction, setConfirmAction] = useState<{
+		type: Extract<ContainerActionType, "stop" | "remove">;
+		container: ContainerInfo;
+	} | null>(null);
 
-  // Helper function to check if a container matches filters
-  const matchesFilters = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
+	// Helper function to check if a container matches filters
+	const matchesFilters = useMemo(() => {
+		const normalizedSearch = searchTerm.trim().toLowerCase();
 
-    return (
-      container: ContainerInfo,
-      options: { includeStateFilter?: boolean } = {}
-    ) => {
-      const matchesSearch =
-        !normalizedSearch ||
-        container.id.toLowerCase().startsWith(normalizedSearch) ||
-        container.image.toLowerCase().includes(normalizedSearch) ||
-        container.names.some((name) =>
-          name.toLowerCase().includes(normalizedSearch)
-        );
+		return (
+			container: ContainerInfo,
+			options: { includeStateFilter?: boolean } = {},
+		) => {
+			const matchesSearch =
+				!normalizedSearch ||
+				container.id.toLowerCase().startsWith(normalizedSearch) ||
+				container.image.toLowerCase().includes(normalizedSearch) ||
+				container.names.some((name) =>
+					name.toLowerCase().includes(normalizedSearch),
+				);
 
-      const matchesHost = hostFilter === "all" || container.host === hostFilter;
+			const matchesHost = hostFilter === "all" || container.host === hostFilter;
 
-      const containerDate = new Date(container.created * 1000);
-      const matchesDateRange =
-        !dateRange ||
-        (dateRange.from &&
-          dateRange.to &&
-          containerDate >= dateRange.from &&
-          containerDate <= dateRange.to) ||
-        (dateRange.from && !dateRange.to && containerDate >= dateRange.from) ||
-        (!dateRange.from && dateRange.to && containerDate <= dateRange.to);
+			const containerDate = new Date(container.created * 1000);
+			const matchesDateRange =
+				!dateRange ||
+				(dateRange.from &&
+					dateRange.to &&
+					containerDate >= dateRange.from &&
+					containerDate <= dateRange.to) ||
+				(dateRange.from && !dateRange.to && containerDate >= dateRange.from) ||
+				(!dateRange.from && dateRange.to && containerDate <= dateRange.to);
 
-      const matchesState = options.includeStateFilter
-        ? stateFilter === "all" || container.state.toLowerCase() === stateFilter
-        : true;
+			const matchesState = options.includeStateFilter
+				? stateFilter === "all" || container.state.toLowerCase() === stateFilter
+				: true;
 
-      return matchesSearch && matchesHost && matchesDateRange && matchesState;
-    };
-  }, [searchTerm, hostFilter, dateRange, stateFilter]);
+			return matchesSearch && matchesHost && matchesDateRange && matchesState;
+		};
+	}, [searchTerm, hostFilter, dateRange, stateFilter]);
 
-  const availableStates = useMemo(() => {
-    const unique = new Set<string>();
-    containers.forEach((container) => {
-      if (container.state) {
-        unique.add(container.state.toLowerCase());
-      }
-    });
-    return Array.from(unique).sort();
-  }, [containers]);
+	const availableStates = useMemo(() => {
+		const unique = new Set<string>();
+		containers.forEach((container) => {
+			if (container.state) {
+				unique.add(container.state.toLowerCase());
+			}
+		});
+		return Array.from(unique).sort();
+	}, [containers]);
 
-  const filteredContainers = useMemo(() => {
-    const filtered = containers.filter((container) =>
-      matchesFilters(container, { includeStateFilter: true })
-    );
+	const filteredContainers = useMemo(() => {
+		const filtered = containers.filter((container) =>
+			matchesFilters(container, { includeStateFilter: true }),
+		);
 
-    return filtered.sort((a, b) =>
-      sortDirection === "desc" ? b.created - a.created : a.created - b.created
-    );
-  }, [containers, matchesFilters, sortDirection]);
+		return filtered.sort((a, b) =>
+			sortDirection === "desc" ? b.created - a.created : a.created - b.created,
+		);
+	}, [containers, matchesFilters, sortDirection]);
 
-  const totalPages =
-    filteredContainers.length === 0
-      ? 1
-      : Math.ceil(filteredContainers.length / pageSize);
+	const totalPages =
+		filteredContainers.length === 0
+			? 1
+			: Math.ceil(filteredContainers.length / pageSize);
 
-  useEffect(() => {
-    if (page > totalPages) {
-      setPage(totalPages);
-    }
-  }, [page, totalPages, setPage]);
+	useEffect(() => {
+		if (page > totalPages) {
+			setPage(totalPages);
+		}
+	}, [page, totalPages, setPage]);
 
-  const startIndex = filteredContainers.length ? (page - 1) * pageSize + 1 : 0;
-  const endIndex = filteredContainers.length
-    ? Math.min(page * pageSize, filteredContainers.length)
-    : 0;
+	const startIndex = filteredContainers.length ? (page - 1) * pageSize + 1 : 0;
+	const endIndex = filteredContainers.length
+		? Math.min(page * pageSize, filteredContainers.length)
+		: 0;
 
-  const pageItems = useMemo(() => {
-    const offset = (page - 1) * pageSize;
-    return filteredContainers.slice(offset, offset + pageSize);
-  }, [filteredContainers, page, pageSize]);
+	const pageItems = useMemo(() => {
+		const offset = (page - 1) * pageSize;
+		return filteredContainers.slice(offset, offset + pageSize);
+	}, [filteredContainers, page, pageSize]);
 
-  const groupedItems = useMemo(() => {
-    if (groupBy !== "compose") {
-      return null;
-    }
-    return groupByCompose(pageItems);
-  }, [pageItems, groupBy]);
+	const groupedItems = useMemo(() => {
+		if (groupBy !== "compose") {
+			return null;
+		}
+		return groupByCompose(pageItems);
+	}, [pageItems, groupBy]);
 
-  const stateCounts = useMemo(() => {
-    const counts = getInitialStateCounts();
+	const stateCounts = useMemo(() => {
+		const counts = getInitialStateCounts();
 
-    // Filter by host, search, and date - but NOT by state filter
-    // This way state counts reflect the current host selection
-    containers.forEach((container) => {
-      if (matchesFilters(container, { includeStateFilter: false })) {
-        const state = container.state.toLowerCase();
-        if (state === "running") counts.running++;
-        else if (state === "exited") counts.exited++;
-        else if (state === "paused") counts.paused++;
-        else if (state === "restarting") counts.restarting++;
-        else if (state === "dead") counts.dead++;
-        else counts.other++;
-      }
-    });
+		// Filter by host, search, and date - but NOT by state filter
+		// This way state counts reflect the current host selection
+		containers.forEach((container) => {
+			if (matchesFilters(container, { includeStateFilter: false })) {
+				const state = container.state.toLowerCase();
+				if (state === "running") counts.running++;
+				else if (state === "exited") counts.exited++;
+				else if (state === "paused") counts.paused++;
+				else if (state === "restarting") counts.restarting++;
+				else if (state === "dead") counts.dead++;
+				else counts.other++;
+			}
+		});
 
-    return counts;
-  }, [containers, matchesFilters]);
+		return counts;
+	}, [containers, matchesFilters]);
 
-  const executeAction = async (
-    actionType: ContainerActionType,
-    container: ContainerInfo
-  ) => {
-    setPendingAction({ id: container.id, type: actionType });
-    try {
-      let message = "";
-      switch (actionType) {
-        case "start":
-          message = await startContainer(container.id, container.host);
-          break;
-        case "stop":
-          message = await stopContainer(container.id, container.host);
-          break;
-        case "restart":
-          message = await restartContainer(container.id, container.host);
-          break;
-        case "remove":
-          message = await removeContainer(container.id, container.host);
-          break;
-        default:
-          return;
-      }
-      if (message) {
-        toast.success(message);
-      }
-      await refetch();
-    } catch (error) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-      } else {
-        toast.error("Unexpected error while performing container action.");
-      }
-    } finally {
-      setPendingAction(null);
-    }
-  };
+	const executeAction = async (
+		actionType: ContainerActionType,
+		container: ContainerInfo,
+	) => {
+		setPendingAction({ id: container.id, type: actionType });
+		try {
+			let message = "";
+			switch (actionType) {
+				case "start":
+					message = await startContainer(container.id, container.host);
+					break;
+				case "stop":
+					message = await stopContainer(container.id, container.host);
+					break;
+				case "restart":
+					message = await restartContainer(container.id, container.host);
+					break;
+				case "remove":
+					message = await removeContainer(container.id, container.host);
+					break;
+				default:
+					return;
+			}
+			if (message) {
+				toast.success(message);
+			}
+			await refetch();
+		} catch (error) {
+			if (error instanceof Error) {
+				toast.error(error.message);
+			} else {
+				toast.error("Unexpected error while performing container action.");
+			}
+		} finally {
+			setPendingAction(null);
+		}
+	};
 
-  const executeComposeAction = async (
-    actionType: ComposeAction,
-    group: GroupedContainers
-  ) => {
-    // A UI group can theoretically span hosts; act once per distinct host.
-    const groupHosts = Array.from(
-      new Set(group.items.map((container) => container.host))
-    );
-    setPendingComposeAction({ project: group.project, type: actionType });
-    try {
-      const results = await Promise.all(
-        groupHosts.map((host) =>
-          performComposeAction(group.project, actionType, host)
-        )
-      );
-      const succeeded = results.reduce(
-        (sum, result) => sum + result.succeeded,
-        0
-      );
-      const verb =
-        actionType === "start"
-          ? "Started"
-          : actionType === "stop"
-            ? "Stopped"
-            : "Restarted";
-      toast.success(
-        `${verb} ${succeeded} container${succeeded === 1 ? "" : "s"} in ${group.project}`
-      );
-      await refetch();
-    } catch (error) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-      } else {
-        toast.error("Unexpected error while performing compose action.");
-      }
-    } finally {
-      setPendingComposeAction(null);
-    }
-  };
+	const executeComposeAction = async (
+		actionType: ComposeAction,
+		group: GroupedContainers,
+	) => {
+		// A UI group can theoretically span hosts; act once per distinct host.
+		const groupHosts = Array.from(
+			new Set(group.items.map((container) => container.host)),
+		);
+		setPendingComposeAction({ project: group.project, type: actionType });
+		try {
+			const results = await Promise.all(
+				groupHosts.map((host) =>
+					performComposeAction(group.project, actionType, host),
+				),
+			);
+			const succeeded = results.reduce(
+				(sum, result) => sum + result.succeeded,
+				0,
+			);
+			const verb =
+				actionType === "start"
+					? "Started"
+					: actionType === "stop"
+						? "Stopped"
+						: "Restarted";
+			toast.success(
+				`${verb} ${succeeded} container${succeeded === 1 ? "" : "s"} in ${group.project}`,
+			);
+			await refetch();
+		} catch (error) {
+			if (error instanceof Error) {
+				toast.error(error.message);
+			} else {
+				toast.error("Unexpected error while performing compose action.");
+			}
+		} finally {
+			setPendingComposeAction(null);
+		}
+	};
 
-  const handleComposeAction = (
-    action: ComposeAction,
-    group: GroupedContainers
-  ) => {
-    void executeComposeAction(action, group);
-  };
+	const handleComposeAction = (
+		action: ComposeAction,
+		group: GroupedContainers,
+	) => {
+		void executeComposeAction(action, group);
+	};
 
-  const handleConfirmAction = async () => {
-    if (!confirmAction) return;
-    const { type, container } = confirmAction;
-    await executeAction(type, container);
-    setConfirmAction(null);
-  };
+	const handleConfirmAction = async () => {
+		if (!confirmAction) return;
+		const { type, container } = confirmAction;
+		await executeAction(type, container);
+		setConfirmAction(null);
+	};
 
-  const handleConfirmDialogOpenChange = (open: boolean) => {
-    if (!open) {
-      setConfirmAction(null);
-    }
-  };
+	const handleConfirmDialogOpenChange = (open: boolean) => {
+		if (!open) {
+			setConfirmAction(null);
+		}
+	};
 
-  const handleSearchChange = (value: string) => {
-    setSearchTerm(value);
-  };
+	const handleSearchChange = (value: string) => {
+		setSearchTerm(value);
+	};
 
-  const handleStateFilterChange = (value: string) => {
-    setStateFilter(value);
-  };
+	const handleStateFilterChange = (value: string) => {
+		setStateFilter(value);
+	};
 
-  const handleHostFilterChange = (value: string) => {
-    setHostFilter(value);
-  };
+	const handleHostFilterChange = (value: string) => {
+		setHostFilter(value);
+	};
 
-  const handleSortDirectionChange = (direction: SortDirection) => {
-    setSortDirection(direction);
-  };
+	const handleSortDirectionChange = (direction: SortDirection) => {
+		setSortDirection(direction);
+	};
 
-  const handleGroupByChange = (value: GroupByOption) => {
-    setGroupBy(value);
-  };
+	const handleGroupByChange = (value: GroupByOption) => {
+		setGroupBy(value);
+	};
 
-  const handleDateRangeChange = (range: DateRange | undefined) => {
-    setDateRange(range);
-  };
+	const handleDateRangeChange = (range: DateRange | undefined) => {
+		setDateRange(range);
+	};
 
-  const handleDateRangeClear = () => {
-    clearDateRange();
-  };
+	const handleDateRangeClear = () => {
+		clearDateRange();
+	};
 
-  const handlePageSizeChange = (size: number) => {
-    setPageSize(size);
-  };
+	const handlePageSizeChange = (size: number) => {
+		setPageSize(size);
+	};
 
-  const handlePageChange = (nextPage: number) => {
-    setPage(nextPage);
-  };
+	const handlePageChange = (nextPage: number) => {
+		setPage(nextPage);
+	};
 
-  const handleViewLogs = (container: ContainerInfo) => {
-    setSelectedContainer(container);
-    setIsLogsSheetOpen(true);
-  };
+	const handleViewLogs = (container: ContainerInfo) => {
+		setSelectedContainer(container);
+		setIsLogsSheetOpen(true);
+	};
 
-  const handleLogsSheetOpenChange = (open: boolean) => {
-    setIsLogsSheetOpen(open);
-    if (!open) {
-      setSelectedContainer(null);
-    }
-  };
+	const handleLogsSheetOpenChange = (open: boolean) => {
+		setIsLogsSheetOpen(open);
+		if (!open) {
+			setSelectedContainer(null);
+		}
+	};
 
-  const handleContainerRecreated = async (newContainerId: string) => {
-    await queryClient.refetchQueries({
-      queryKey: ["containers"],
-      exact: false,
-    });
+	const handleContainerRecreated = async (newContainerId: string) => {
+		await queryClient.refetchQueries({
+			queryKey: ["containers"],
+			exact: false,
+		});
 
-    const updatedData = queryClient.getQueryData<GetContainersResponse>([
-      "containers",
-    ]);
-    const newContainer = updatedData?.containers?.find(
-      (c) => c.id === newContainerId
-    );
+		const updatedData = queryClient.getQueryData<GetContainersResponse>([
+			"containers",
+		]);
+		const newContainer = updatedData?.containers?.find(
+			(c) => c.id === newContainerId,
+		);
 
-    if (newContainer) {
-      setSelectedContainer(newContainer);
-    }
-  };
+		if (newContainer) {
+			setSelectedContainer(newContainer);
+		}
+	};
 
-  const handleStartContainer = (container: ContainerInfo) => {
-    void executeAction("start", container);
-  };
+	const handleStartContainer = (container: ContainerInfo) => {
+		void executeAction("start", container);
+	};
 
-  const handleStopContainer = (container: ContainerInfo) => {
-    setConfirmAction({ type: "stop", container });
-  };
+	const handleStopContainer = (container: ContainerInfo) => {
+		setConfirmAction({ type: "stop", container });
+	};
 
-  const handleRestartContainer = (container: ContainerInfo) => {
-    void executeAction("restart", container);
-  };
+	const handleRestartContainer = (container: ContainerInfo) => {
+		void executeAction("restart", container);
+	};
 
-  const handleDeleteContainer = (container: ContainerInfo) => {
-    setConfirmAction({ type: "remove", container });
-  };
+	const handleDeleteContainer = (container: ContainerInfo) => {
+		setConfirmAction({ type: "remove", container });
+	};
 
-  const confirmActionTitle =
-    confirmAction?.type === "stop"
-      ? "Stop container?"
-      : confirmAction?.type === "remove"
-        ? "Remove container?"
-        : "";
+	const confirmActionTitle =
+		confirmAction?.type === "stop"
+			? "Stop container?"
+			: confirmAction?.type === "remove"
+				? "Remove container?"
+				: "";
 
-  const confirmActionDescription =
-    confirmAction?.type === "stop"
-      ? "Stopping a container will terminate its running processes."
-      : confirmAction?.type === "remove"
-        ? "Removing a container will permanently delete it and its resources. This action cannot be undone."
-        : "";
+	const confirmActionDescription =
+		confirmAction?.type === "stop"
+			? "Stopping a container will terminate its running processes."
+			: confirmAction?.type === "remove"
+				? "Removing a container will permanently delete it and its resources. This action cannot be undone."
+				: "";
 
-  const confirmActionButtonLabel = confirmAction
-    ? confirmAction.type === "stop"
-      ? "Stop Container"
-      : "Remove Container"
-    : "Confirm";
+	const confirmActionButtonLabel = confirmAction
+		? confirmAction.type === "stop"
+			? "Stop Container"
+			: "Remove Container"
+		: "Confirm";
 
-  const isConfirmActionPending =
-    !!confirmAction &&
-    pendingAction?.id === confirmAction.container.id &&
-    pendingAction?.type === confirmAction.type;
+	const isConfirmActionPending =
+		!!confirmAction &&
+		pendingAction?.id === confirmAction.container.id &&
+		pendingAction?.type === confirmAction.type;
 
-  return (
-    <div className="w-full space-y-8">
-      <ResourceNav />
-      <ContainersSummaryCards
-        totalContainers={containers.length}
-        hostInfo={hostInfo}
-        systemUsage={systemUsage}
-        hostsStats={hostsStatsData?.hosts}
-        systemHistory={systemHistory}
-      />
+	return (
+		<div className="w-full space-y-8">
+			<ResourceNav />
+			<ContainersSummaryCards
+				totalContainers={containers.length}
+				hostInfo={hostInfo}
+				systemUsage={systemUsage}
+				hostsStats={hostsStatsData?.hosts}
+				systemHistory={systemHistory}
+			/>
 
-      <section className="space-y-4">
-        <ContainersToolbar
-          searchTerm={searchTerm}
-          onSearchChange={handleSearchChange}
-          stateFilter={stateFilter}
-          onStateFilterChange={handleStateFilterChange}
-          availableStates={availableStates}
-          hostFilter={hostFilter}
-          onHostFilterChange={handleHostFilterChange}
-          availableHosts={hosts}
-          sortDirection={sortDirection}
-          onSortDirectionChange={handleSortDirectionChange}
-          groupBy={groupBy}
-          onGroupByChange={handleGroupByChange}
-          dateRange={dateRange}
-          onDateRangeChange={handleDateRangeChange}
-          onDateRangeClear={handleDateRangeClear}
-          onRefresh={refetch}
-          isFetching={isFetching}
-        />
+			<section className="space-y-4">
+				<ContainersToolbar
+					searchTerm={searchTerm}
+					onSearchChange={handleSearchChange}
+					stateFilter={stateFilter}
+					onStateFilterChange={handleStateFilterChange}
+					availableStates={availableStates}
+					hostFilter={hostFilter}
+					onHostFilterChange={handleHostFilterChange}
+					availableHosts={hosts}
+					sortDirection={sortDirection}
+					onSortDirectionChange={handleSortDirectionChange}
+					groupBy={groupBy}
+					onGroupByChange={handleGroupByChange}
+					dateRange={dateRange}
+					onDateRangeChange={handleDateRangeChange}
+					onDateRangeClear={handleDateRangeClear}
+					onRefresh={refetch}
+					isFetching={isFetching}
+				/>
 
-        <ContainersStateSummary stateCounts={stateCounts} />
+				<ContainersStateSummary stateCounts={stateCounts} />
 
-        <ContainersTable
-          isLoading={isLoading}
-          isError={isError}
-          error={error}
-          groupBy={groupBy}
-          filteredContainers={filteredContainers}
-          groupedItems={groupedItems}
-          pageItems={pageItems}
-          pendingAction={pendingAction}
-          pendingComposeAction={pendingComposeAction}
-          isReadOnly={isReadOnly}
-          statsMap={statsMap}
-          statsHistory={statsHistory}
-          onStart={handleStartContainer}
-          onStop={handleStopContainer}
-          onRestart={handleRestartContainer}
-          onDelete={handleDeleteContainer}
-          onComposeAction={handleComposeAction}
-          onViewLogs={handleViewLogs}
-          onRetry={() => {
-            void refetch();
-          }}
-        />
+				<ContainersTable
+					isLoading={isLoading}
+					isError={isError}
+					error={error}
+					groupBy={groupBy}
+					filteredContainers={filteredContainers}
+					groupedItems={groupedItems}
+					pageItems={pageItems}
+					pendingAction={pendingAction}
+					pendingComposeAction={pendingComposeAction}
+					isReadOnly={isReadOnly}
+					statsMap={statsMap}
+					statsHistory={statsHistory}
+					onStart={handleStartContainer}
+					onStop={handleStopContainer}
+					onRestart={handleRestartContainer}
+					onDelete={handleDeleteContainer}
+					onComposeAction={handleComposeAction}
+					onViewLogs={handleViewLogs}
+					onRetry={() => {
+						void refetch();
+					}}
+				/>
 
-        <ContainersPagination
-          totalItems={filteredContainers.length}
-          startIndex={startIndex}
-          endIndex={endIndex}
-          page={page}
-          totalPages={totalPages}
-          pageSize={pageSize}
-          onPageChange={handlePageChange}
-          onPageSizeChange={handlePageSizeChange}
-        />
-      </section>
+				<ContainersPagination
+					totalItems={filteredContainers.length}
+					startIndex={startIndex}
+					endIndex={endIndex}
+					page={page}
+					totalPages={totalPages}
+					pageSize={pageSize}
+					onPageChange={handlePageChange}
+					onPageSizeChange={handlePageSizeChange}
+				/>
+			</section>
 
-      <AlertDialog
-        open={Boolean(confirmAction)}
-        onOpenChange={handleConfirmDialogOpenChange}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{confirmActionTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {confirmActionDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {confirmAction && (
-            <div className="space-y-2">
-              <div className="text-sm font-medium text-muted-foreground">
-                Container Details
-              </div>
-              <div className="rounded-md border bg-muted/30 p-3 space-y-2">
-                <div className="flex items-start justify-between gap-4">
-                  <span className="text-xs text-muted-foreground">Name</span>
-                  <span className="text-sm font-medium text-right">
-                    {formatContainerName(confirmAction.container.names)}
-                  </span>
-                </div>
-                <div className="flex items-start justify-between gap-4">
-                  <span className="text-xs text-muted-foreground">Image</span>
-                  <span className="text-sm font-mono text-right break-all">
-                    {confirmAction.container.image}
-                  </span>
-                </div>
-                <div className="flex items-start justify-between gap-4">
-                  <span className="text-xs text-muted-foreground">ID</span>
-                  <span className="text-sm font-mono text-right break-all">
-                    {confirmAction.container.id.slice(0, 12)}
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isConfirmActionPending}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              className={`flex items-center gap-2 ${
-                confirmAction?.type === "remove"
-                  ? "bg-destructive text-white hover:bg-destructive/90"
-                  : ""
-              }`}
-              onClick={() => {
-                void handleConfirmAction();
-              }}
-              disabled={isConfirmActionPending}
-            >
-              {isConfirmActionPending && <Spinner className="size-4" />}
-              {confirmActionButtonLabel}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+			<AlertDialog
+				open={Boolean(confirmAction)}
+				onOpenChange={handleConfirmDialogOpenChange}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>{confirmActionTitle}</AlertDialogTitle>
+						<AlertDialogDescription>
+							{confirmActionDescription}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					{confirmAction && (
+						<div className="space-y-2">
+							<div className="text-sm font-medium text-muted-foreground">
+								Container Details
+							</div>
+							<div className="rounded-md border bg-muted/30 p-3 space-y-2">
+								<div className="flex items-start justify-between gap-4">
+									<span className="text-xs text-muted-foreground">Name</span>
+									<span className="text-sm font-medium text-right">
+										{formatContainerName(confirmAction.container.names)}
+									</span>
+								</div>
+								<div className="flex items-start justify-between gap-4">
+									<span className="text-xs text-muted-foreground">Image</span>
+									<span className="text-sm font-mono text-right break-all">
+										{confirmAction.container.image}
+									</span>
+								</div>
+								<div className="flex items-start justify-between gap-4">
+									<span className="text-xs text-muted-foreground">ID</span>
+									<span className="text-sm font-mono text-right break-all">
+										{confirmAction.container.id.slice(0, 12)}
+									</span>
+								</div>
+							</div>
+						</div>
+					)}
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={isConfirmActionPending}>
+							Cancel
+						</AlertDialogCancel>
+						<AlertDialogAction
+							className={`flex items-center gap-2 ${
+								confirmAction?.type === "remove"
+									? "bg-destructive text-white hover:bg-destructive/90"
+									: ""
+							}`}
+							onClick={() => {
+								void handleConfirmAction();
+							}}
+							disabled={isConfirmActionPending}
+						>
+							{isConfirmActionPending && <Spinner className="size-4" />}
+							{confirmActionButtonLabel}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 
-      <ContainersLogsSheet
-        container={selectedContainer}
-        isOpen={isLogsSheetOpen}
-        isReadOnly={isReadOnly}
-        onOpenChange={handleLogsSheetOpenChange}
-        onContainerRecreated={handleContainerRecreated}
-      />
-    </div>
-  );
+			<ContainersLogsSheet
+				container={selectedContainer}
+				isOpen={isLogsSheetOpen}
+				isReadOnly={isReadOnly}
+				onOpenChange={handleLogsSheetOpenChange}
+				onContainerRecreated={handleContainerRecreated}
+			/>
+		</div>
+	);
 }

--- a/frontend/src/features/containers/components/containers-pagination.tsx
+++ b/frontend/src/features/containers/components/containers-pagination.tsx
@@ -1,204 +1,204 @@
 import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
 } from "@/components/ui/pagination";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 } from "@/components/ui/select";
 
 interface ContainersPaginationProps {
-  totalItems: number;
-  startIndex: number;
-  endIndex: number;
-  page: number;
-  totalPages: number;
-  pageSize: number;
-  onPageChange: (page: number) => void;
-  onPageSizeChange: (size: number) => void;
+	totalItems: number;
+	startIndex: number;
+	endIndex: number;
+	page: number;
+	totalPages: number;
+	pageSize: number;
+	onPageChange: (page: number) => void;
+	onPageSizeChange: (size: number) => void;
 }
 
 export function ContainersPagination({
-  totalItems,
-  startIndex,
-  endIndex,
-  page,
-  totalPages,
-  pageSize,
-  onPageChange,
-  onPageSizeChange,
+	totalItems,
+	startIndex,
+	endIndex,
+	page,
+	totalPages,
+	pageSize,
+	onPageChange,
+	onPageSizeChange,
 }: ContainersPaginationProps) {
-  const handlePageClick = (nextPage: number) => {
-    if (nextPage < 1 || nextPage > totalPages || nextPage === page) {
-      return;
-    }
-    onPageChange(nextPage);
-  };
+	const handlePageClick = (nextPage: number) => {
+		if (nextPage < 1 || nextPage > totalPages || nextPage === page) {
+			return;
+		}
+		onPageChange(nextPage);
+	};
 
-  const renderPaginationNumbers = () => {
-    if (totalPages <= 7) {
-      return Array.from({ length: totalPages }, (_, index) => {
-        const pageNumber = index + 1;
-        return (
-          <PaginationItem key={pageNumber}>
-            <PaginationLink
-              href="#"
-              onClick={(event) => {
-                event.preventDefault();
-                handlePageClick(pageNumber);
-              }}
-              isActive={pageNumber === page}
-            >
-              {pageNumber}
-            </PaginationLink>
-          </PaginationItem>
-        );
-      });
-    }
+	const renderPaginationNumbers = () => {
+		if (totalPages <= 7) {
+			return Array.from({ length: totalPages }, (_, index) => {
+				const pageNumber = index + 1;
+				return (
+					<PaginationItem key={pageNumber}>
+						<PaginationLink
+							href="#"
+							onClick={(event) => {
+								event.preventDefault();
+								handlePageClick(pageNumber);
+							}}
+							isActive={pageNumber === page}
+						>
+							{pageNumber}
+						</PaginationLink>
+					</PaginationItem>
+				);
+			});
+		}
 
-    return (
-      <>
-        <PaginationItem>
-          <PaginationLink
-            href="#"
-            onClick={(event) => {
-              event.preventDefault();
-              handlePageClick(1);
-            }}
-            isActive={page === 1}
-          >
-            1
-          </PaginationLink>
-        </PaginationItem>
-        {page > 3 && (
-          <PaginationItem>
-            <PaginationEllipsis />
-          </PaginationItem>
-        )}
-        {page > 2 && (
-          <PaginationItem>
-            <PaginationLink
-              href="#"
-              onClick={(event) => {
-                event.preventDefault();
-                handlePageClick(page - 1);
-              }}
-            >
-              {page - 1}
-            </PaginationLink>
-          </PaginationItem>
-        )}
-        {page !== 1 && page !== totalPages && (
-          <PaginationItem>
-            <PaginationLink
-              href="#"
-              onClick={(event) => event.preventDefault()}
-              isActive
-            >
-              {page}
-            </PaginationLink>
-          </PaginationItem>
-        )}
-        {page < totalPages - 1 && (
-          <PaginationItem>
-            <PaginationLink
-              href="#"
-              onClick={(event) => {
-                event.preventDefault();
-                handlePageClick(page + 1);
-              }}
-            >
-              {page + 1}
-            </PaginationLink>
-          </PaginationItem>
-        )}
-        {page < totalPages - 2 && (
-          <PaginationItem>
-            <PaginationEllipsis />
-          </PaginationItem>
-        )}
-        <PaginationItem>
-          <PaginationLink
-            href="#"
-            onClick={(event) => {
-              event.preventDefault();
-              handlePageClick(totalPages);
-            }}
-            isActive={page === totalPages}
-          >
-            {totalPages}
-          </PaginationLink>
-        </PaginationItem>
-      </>
-    );
-  };
+		return (
+			<>
+				<PaginationItem>
+					<PaginationLink
+						href="#"
+						onClick={(event) => {
+							event.preventDefault();
+							handlePageClick(1);
+						}}
+						isActive={page === 1}
+					>
+						1
+					</PaginationLink>
+				</PaginationItem>
+				{page > 3 && (
+					<PaginationItem>
+						<PaginationEllipsis />
+					</PaginationItem>
+				)}
+				{page > 2 && (
+					<PaginationItem>
+						<PaginationLink
+							href="#"
+							onClick={(event) => {
+								event.preventDefault();
+								handlePageClick(page - 1);
+							}}
+						>
+							{page - 1}
+						</PaginationLink>
+					</PaginationItem>
+				)}
+				{page !== 1 && page !== totalPages && (
+					<PaginationItem>
+						<PaginationLink
+							href="#"
+							onClick={(event) => event.preventDefault()}
+							isActive
+						>
+							{page}
+						</PaginationLink>
+					</PaginationItem>
+				)}
+				{page < totalPages - 1 && (
+					<PaginationItem>
+						<PaginationLink
+							href="#"
+							onClick={(event) => {
+								event.preventDefault();
+								handlePageClick(page + 1);
+							}}
+						>
+							{page + 1}
+						</PaginationLink>
+					</PaginationItem>
+				)}
+				{page < totalPages - 2 && (
+					<PaginationItem>
+						<PaginationEllipsis />
+					</PaginationItem>
+				)}
+				<PaginationItem>
+					<PaginationLink
+						href="#"
+						onClick={(event) => {
+							event.preventDefault();
+							handlePageClick(totalPages);
+						}}
+						isActive={page === totalPages}
+					>
+						{totalPages}
+					</PaginationLink>
+				</PaginationItem>
+			</>
+		);
+	};
 
-  return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-      <div className="text-sm text-muted-foreground">
-        {totalItems > 0
-          ? `Showing ${startIndex}-${endIndex} of ${totalItems}`
-          : "0 containers"}
-      </div>
-      <div className="flex items-center gap-6">
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">Rows per page</span>
-          <Select
-            value={String(pageSize)}
-            onValueChange={(value) => onPageSizeChange(Number(value))}
-          >
-            <SelectTrigger size="sm" className="w-[70px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="10">10</SelectItem>
-              <SelectItem value="20">20</SelectItem>
-              <SelectItem value="50">50</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <Pagination className="mx-0 w-auto">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationPrevious
-                href="#"
-                onClick={(event) => {
-                  event.preventDefault();
-                  handlePageClick(page - 1);
-                }}
-                className={
-                  page === 1 || totalItems === 0
-                    ? "pointer-events-none opacity-50"
-                    : ""
-                }
-              />
-            </PaginationItem>
-            {renderPaginationNumbers()}
-            <PaginationItem>
-              <PaginationNext
-                href="#"
-                onClick={(event) => {
-                  event.preventDefault();
-                  handlePageClick(page + 1);
-                }}
-                className={
-                  page === totalPages || totalItems === 0
-                    ? "pointer-events-none opacity-50"
-                    : ""
-                }
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
-      </div>
-    </div>
-  );
+	return (
+		<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+			<div className="text-sm text-muted-foreground">
+				{totalItems > 0
+					? `Showing ${startIndex}-${endIndex} of ${totalItems}`
+					: "0 containers"}
+			</div>
+			<div className="flex items-center gap-6">
+				<div className="flex items-center gap-2">
+					<span className="text-sm text-muted-foreground">Rows per page</span>
+					<Select
+						value={String(pageSize)}
+						onValueChange={(value) => onPageSizeChange(Number(value))}
+					>
+						<SelectTrigger size="sm" className="w-[70px]">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="10">10</SelectItem>
+							<SelectItem value="20">20</SelectItem>
+							<SelectItem value="50">50</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+				<Pagination className="mx-0 w-auto">
+					<PaginationContent>
+						<PaginationItem>
+							<PaginationPrevious
+								href="#"
+								onClick={(event) => {
+									event.preventDefault();
+									handlePageClick(page - 1);
+								}}
+								className={
+									page === 1 || totalItems === 0
+										? "pointer-events-none opacity-50"
+										: ""
+								}
+							/>
+						</PaginationItem>
+						{renderPaginationNumbers()}
+						<PaginationItem>
+							<PaginationNext
+								href="#"
+								onClick={(event) => {
+									event.preventDefault();
+									handlePageClick(page + 1);
+								}}
+								className={
+									page === totalPages || totalItems === 0
+										? "pointer-events-none opacity-50"
+										: ""
+								}
+							/>
+						</PaginationItem>
+					</PaginationContent>
+				</Pagination>
+			</div>
+		</div>
+	);
 }

--- a/frontend/src/features/containers/components/containers-state-summary.tsx
+++ b/frontend/src/features/containers/components/containers-state-summary.tsx
@@ -1,49 +1,49 @@
 import type { StateCounts } from "./container-utils";
 
 interface ContainersStateSummaryProps {
-  stateCounts: StateCounts;
+	stateCounts: StateCounts;
 }
 
 export function ContainersStateSummary({
-  stateCounts,
+	stateCounts,
 }: ContainersStateSummaryProps) {
-  return (
-    <div className="flex flex-wrap items-center gap-3 text-sm">
-      {stateCounts.running > 0 && (
-        <div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
-          <div className="size-2 rounded-full bg-emerald-500" />
-          <span className="text-muted-foreground">Running</span>
-          <span className="font-semibold">{stateCounts.running}</span>
-        </div>
-      )}
-      {stateCounts.exited > 0 && (
-        <div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
-          <div className="size-2 rounded-full bg-muted" />
-          <span className="text-muted-foreground">Exited</span>
-          <span className="font-semibold">{stateCounts.exited}</span>
-        </div>
-      )}
-      {stateCounts.paused > 0 && (
-        <div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
-          <div className="size-2 rounded-full bg-amber-500" />
-          <span className="text-muted-foreground">Paused</span>
-          <span className="font-semibold">{stateCounts.paused}</span>
-        </div>
-      )}
-      {stateCounts.restarting > 0 && (
-        <div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
-          <div className="size-2 rounded-full bg-blue-500" />
-          <span className="text-muted-foreground">Restarting</span>
-          <span className="font-semibold">{stateCounts.restarting}</span>
-        </div>
-      )}
-      {stateCounts.dead > 0 && (
-        <div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
-          <div className="size-2 rounded-full bg-rose-500" />
-          <span className="text-muted-foreground">Dead</span>
-          <span className="font-semibold">{stateCounts.dead}</span>
-        </div>
-      )}
-    </div>
-  );
+	return (
+		<div className="flex flex-wrap items-center gap-3 text-sm">
+			{stateCounts.running > 0 && (
+				<div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
+					<div className="size-2 rounded-full bg-emerald-500" />
+					<span className="text-muted-foreground">Running</span>
+					<span className="font-semibold">{stateCounts.running}</span>
+				</div>
+			)}
+			{stateCounts.exited > 0 && (
+				<div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
+					<div className="size-2 rounded-full bg-muted" />
+					<span className="text-muted-foreground">Exited</span>
+					<span className="font-semibold">{stateCounts.exited}</span>
+				</div>
+			)}
+			{stateCounts.paused > 0 && (
+				<div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
+					<div className="size-2 rounded-full bg-amber-500" />
+					<span className="text-muted-foreground">Paused</span>
+					<span className="font-semibold">{stateCounts.paused}</span>
+				</div>
+			)}
+			{stateCounts.restarting > 0 && (
+				<div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
+					<div className="size-2 rounded-full bg-blue-500" />
+					<span className="text-muted-foreground">Restarting</span>
+					<span className="font-semibold">{stateCounts.restarting}</span>
+				</div>
+			)}
+			{stateCounts.dead > 0 && (
+				<div className="flex items-center gap-2 rounded-md border bg-card px-3 py-2">
+					<div className="size-2 rounded-full bg-rose-500" />
+					<span className="text-muted-foreground">Dead</span>
+					<span className="font-semibold">{stateCounts.dead}</span>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/frontend/src/features/containers/components/containers-summary-cards.tsx
+++ b/frontend/src/features/containers/components/containers-summary-cards.tsx
@@ -6,156 +6,158 @@ import { formatBytes } from "./container-utils";
 import { Sparkline } from "./sparkline";
 
 interface HostInfo {
-  hostname: string;
-  os: string;
-  kernel: string;
+	hostname: string;
+	os: string;
+	kernel: string;
 }
 
 interface SystemUsage {
-  cpu: number;
-  memory: number;
+	cpu: number;
+	memory: number;
 }
 
 interface SystemUsageSample {
-  cpuPercent: number;
-  memoryPercent: number;
+	cpuPercent: number;
+	memoryPercent: number;
 }
 
 interface ContainersSummaryCardsProps {
-  totalContainers: number;
-  hostInfo: HostInfo;
-  systemUsage: SystemUsage;
-  hostsStats?: HostStats[];
-  systemHistory: SystemUsageSample[];
+	totalContainers: number;
+	hostInfo: HostInfo;
+	systemUsage: SystemUsage;
+	hostsStats?: HostStats[];
+	systemHistory: SystemUsageSample[];
 }
 
 function HostRow({ host }: { host: HostStats }) {
-  return (
-    <div className="space-y-0.5">
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-sm font-medium truncate" title={host.host}>
-          {host.host}
-        </p>
-        {host.available ? (
-          <span className="text-xs text-muted-foreground shrink-0">
-            v{host.server_version}
-          </span>
-        ) : (
-          <span className="text-xs font-medium text-destructive shrink-0">
-            Unreachable
-          </span>
-        )}
-      </div>
-      {host.available ? (
-        <p className="text-xs text-muted-foreground">
-          {host.ncpu} CPUs • {formatBytes(host.mem_total)} •{" "}
-          {host.containers_running} running / {host.containers_stopped} stopped
-        </p>
-      ) : (
-        <p className="text-xs text-muted-foreground truncate" title={host.error}>
-          {host.error ?? "Host could not be reached"}
-        </p>
-      )}
-    </div>
-  );
+	return (
+		<div className="space-y-0.5">
+			<div className="flex items-center justify-between gap-2">
+				<p className="text-sm font-medium truncate" title={host.host}>
+					{host.host}
+				</p>
+				{host.available ? (
+					<span className="text-xs text-muted-foreground shrink-0">
+						v{host.server_version}
+					</span>
+				) : (
+					<span className="text-xs font-medium text-destructive shrink-0">
+						Unreachable
+					</span>
+				)}
+			</div>
+			{host.available ? (
+				<p className="text-xs text-muted-foreground">
+					{host.ncpu} CPUs • {formatBytes(host.mem_total)} •{" "}
+					{host.containers_running} running / {host.containers_stopped} stopped
+				</p>
+			) : (
+				<p
+					className="text-xs text-muted-foreground truncate"
+					title={host.error}
+				>
+					{host.error ?? "Host could not be reached"}
+				</p>
+			)}
+		</div>
+	);
 }
 
 export function ContainersSummaryCards({
-  totalContainers,
-  hostInfo,
-  systemUsage,
-  hostsStats,
-  systemHistory,
+	totalContainers,
+	hostInfo,
+	systemUsage,
+	hostsStats,
+	systemHistory,
 }: ContainersSummaryCardsProps) {
-  const multiHost = hostsStats && hostsStats.length > 1;
+	const multiHost = hostsStats && hostsStats.length > 1;
 
-  return (
-    <section className="space-y-3">
-      <div className="grid gap-3 md:grid-cols-3">
-        {multiHost ? (
-          <Card className="py-4">
-            <CardContent className="px-6 py-0">
-              <div className="space-y-2">
-                <p className="text-sm text-muted-foreground">Hosts</p>
-                <div className="max-h-24 space-y-2 overflow-y-auto">
-                  {hostsStats.map((host) => (
-                    <HostRow key={host.host} host={host} />
-                  ))}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ) : (
-          <Card className="py-4">
-            <CardContent className="px-6 py-0">
-              <div className="space-y-1">
-                <p className="text-sm text-muted-foreground">Host</p>
-                <p
-                  className="text-2xl font-semibold truncate"
-                  title={hostInfo.hostname}
-                >
-                  {hostInfo.hostname}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {hostInfo.os} • {hostInfo.kernel}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        )}
+	return (
+		<section className="space-y-3">
+			<div className="grid gap-3 md:grid-cols-3">
+				{multiHost ? (
+					<Card className="py-4">
+						<CardContent className="px-6 py-0">
+							<div className="space-y-2">
+								<p className="text-sm text-muted-foreground">Hosts</p>
+								<div className="max-h-24 space-y-2 overflow-y-auto">
+									{hostsStats.map((host) => (
+										<HostRow key={host.host} host={host} />
+									))}
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+				) : (
+					<Card className="py-4">
+						<CardContent className="px-6 py-0">
+							<div className="space-y-1">
+								<p className="text-sm text-muted-foreground">Host</p>
+								<p
+									className="text-2xl font-semibold truncate"
+									title={hostInfo.hostname}
+								>
+									{hostInfo.hostname}
+								</p>
+								<p className="text-xs text-muted-foreground">
+									{hostInfo.os} • {hostInfo.kernel}
+								</p>
+							</div>
+						</CardContent>
+					</Card>
+				)}
 
-        <Card className="py-4">
-          <CardContent className="px-6 py-0">
-            <div className="space-y-1">
-              <p className="text-sm text-muted-foreground">Containers</p>
-              <p className="text-2xl font-semibold">{totalContainers}</p>
-            </div>
-          </CardContent>
-        </Card>
+				<Card className="py-4">
+					<CardContent className="px-6 py-0">
+						<div className="space-y-1">
+							<p className="text-sm text-muted-foreground">Containers</p>
+							<p className="text-2xl font-semibold">{totalContainers}</p>
+						</div>
+					</CardContent>
+				</Card>
 
-        <Card className="py-4">
-          <CardContent className="px-6 py-0">
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">
-                System (LogDeck host)
-              </p>
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between text-xs">
-                  <span className="text-muted-foreground">CPU</span>
-                  <span className="flex items-center gap-2">
-                    <Sparkline
-                      values={systemHistory.map((s) => s.cpuPercent)}
-                    />
-                    <span className="font-medium">{systemUsage.cpu}%</span>
-                  </span>
-                </div>
-                <div className="h-1.5 w-full rounded-full bg-muted">
-                  <div
-                    className="h-1.5 rounded-full bg-foreground"
-                    style={{ width: `${systemUsage.cpu}%` }}
-                  />
-                </div>
-                <div className="flex items-center justify-between text-xs">
-                  <span className="text-muted-foreground">Memory</span>
-                  <span className="flex items-center gap-2">
-                    <Sparkline
-                      values={systemHistory.map((s) => s.memoryPercent)}
-                    />
-                    <span className="font-medium">{systemUsage.memory}%</span>
-                  </span>
-                </div>
-                <div className="h-1.5 w-full rounded-full bg-muted">
-                  <div
-                    className="h-1.5 rounded-full bg-foreground"
-                    style={{ width: `${systemUsage.memory}%` }}
-                  />
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-    </section>
-  );
+				<Card className="py-4">
+					<CardContent className="px-6 py-0">
+						<div className="space-y-2">
+							<p className="text-sm text-muted-foreground">
+								System (LogDeck host)
+							</p>
+							<div className="space-y-1.5">
+								<div className="flex items-center justify-between text-xs">
+									<span className="text-muted-foreground">CPU</span>
+									<span className="flex items-center gap-2">
+										<Sparkline
+											values={systemHistory.map((s) => s.cpuPercent)}
+										/>
+										<span className="font-medium">{systemUsage.cpu}%</span>
+									</span>
+								</div>
+								<div className="h-1.5 w-full rounded-full bg-muted">
+									<div
+										className="h-1.5 rounded-full bg-foreground"
+										style={{ width: `${systemUsage.cpu}%` }}
+									/>
+								</div>
+								<div className="flex items-center justify-between text-xs">
+									<span className="text-muted-foreground">Memory</span>
+									<span className="flex items-center gap-2">
+										<Sparkline
+											values={systemHistory.map((s) => s.memoryPercent)}
+										/>
+										<span className="font-medium">{systemUsage.memory}%</span>
+									</span>
+								</div>
+								<div className="h-1.5 w-full rounded-full bg-muted">
+									<div
+										className="h-1.5 rounded-full bg-foreground"
+										style={{ width: `${systemUsage.memory}%` }}
+									/>
+								</div>
+							</div>
+						</div>
+					</CardContent>
+				</Card>
+			</div>
+		</section>
+	);
 }

--- a/frontend/src/features/containers/components/containers-table.tsx
+++ b/frontend/src/features/containers/components/containers-table.tsx
@@ -1,417 +1,423 @@
 import { Link } from "@tanstack/react-router";
-import { FileTextIcon, PlayIcon, RotateCwIcon, SquareIcon, Trash2Icon } from "lucide-react";
-import { Fragment } from "react";
 import type { LucideIcon } from "lucide-react";
+import {
+	FileTextIcon,
+	PlayIcon,
+	RotateCwIcon,
+	SquareIcon,
+	Trash2Icon,
+} from "lucide-react";
+import { Fragment } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
 } from "@/components/ui/table";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
 } from "@/components/ui/tooltip";
-
-import {
-  formatContainerName,
-  formatCPUPercent,
-  formatCreatedDate,
-  formatMemoryStats,
-  formatUptime,
-  getComposeProject,
-  getStateBadgeClass,
-  isCoolifyManaged,
-  toTitleCase,
-} from "./container-utils";
-
-import { Sparkline } from "./sparkline";
-
 import type { ComposeAction } from "../api/compose-actions";
 import type { StatsHistoryMap } from "../hooks/use-stats-history";
 import type { ContainerInfo, ContainerStatsMap } from "../types";
-
 import type {
-  ContainerActionType,
-  GroupByOption,
-  GroupedContainers,
+	ContainerActionType,
+	GroupByOption,
+	GroupedContainers,
 } from "./container-utils";
+import {
+	formatContainerName,
+	formatCPUPercent,
+	formatCreatedDate,
+	formatMemoryStats,
+	formatUptime,
+	getComposeProject,
+	getStateBadgeClass,
+	isCoolifyManaged,
+	toTitleCase,
+} from "./container-utils";
+import { Sparkline } from "./sparkline";
 
 interface ActionButtonProps {
-  icon: LucideIcon;
-  action: ContainerActionType;
-  containerId: string;
-  onClick: () => void;
-  isPending: (action: ContainerActionType, id: string) => boolean;
-  busy: boolean;
-  isReadOnly: boolean;
-  variant?: "destructive";
+	icon: LucideIcon;
+	action: ContainerActionType;
+	containerId: string;
+	onClick: () => void;
+	isPending: (action: ContainerActionType, id: string) => boolean;
+	busy: boolean;
+	isReadOnly: boolean;
+	variant?: "destructive";
 }
 
 function ActionButton({
-  icon: Icon,
-  action,
-  containerId,
-  onClick,
-  isPending,
-  busy,
-  isReadOnly,
-  variant,
+	icon: Icon,
+	action,
+	containerId,
+	onClick,
+	isPending,
+	busy,
+	isReadOnly,
+	variant,
 }: ActionButtonProps) {
-  const pending = isPending(action, containerId);
-  const label = action.charAt(0).toUpperCase() + action.slice(1);
-  const tooltip = isReadOnly ? `${label} (Read-only mode)` : label;
+	const pending = isPending(action, containerId);
+	const label = action.charAt(0).toUpperCase() + action.slice(1);
+	const tooltip = isReadOnly ? `${label} (Read-only mode)` : label;
 
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="inline-block">
-          <Button
-            variant="outline"
-            size="icon"
-            className={`h-8 w-8 ${variant === "destructive" ? "text-destructive hover:bg-destructive hover:text-white" : ""}`}
-            onClick={onClick}
-            disabled={busy || isReadOnly}
-          >
-            {pending ? <Spinner className="size-4" /> : <Icon className="size-4" />}
-          </Button>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>{tooltip}</TooltipContent>
-    </Tooltip>
-  );
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span className="inline-block">
+					<Button
+						variant="outline"
+						size="icon"
+						className={`h-8 w-8 ${variant === "destructive" ? "text-destructive hover:bg-destructive hover:text-white" : ""}`}
+						onClick={onClick}
+						disabled={busy || isReadOnly}
+					>
+						{pending ? (
+							<Spinner className="size-4" />
+						) : (
+							<Icon className="size-4" />
+						)}
+					</Button>
+				</span>
+			</TooltipTrigger>
+			<TooltipContent>{tooltip}</TooltipContent>
+		</Tooltip>
+	);
 }
 
 interface ContainersTableProps {
-  isLoading: boolean;
-  isError: boolean;
-  error: unknown;
-  groupBy: GroupByOption;
-  filteredContainers: ContainerInfo[];
-  groupedItems: GroupedContainers[] | null;
-  pageItems: ContainerInfo[];
-  pendingAction: { id: string; type: ContainerActionType } | null;
-  pendingComposeAction: { project: string; type: ComposeAction } | null;
-  isReadOnly: boolean;
-  statsMap: ContainerStatsMap;
-  statsHistory: StatsHistoryMap;
-  onStart: (container: ContainerInfo) => void;
-  onStop: (container: ContainerInfo) => void;
-  onRestart: (container: ContainerInfo) => void;
-  onDelete: (container: ContainerInfo) => void;
-  onComposeAction: (action: ComposeAction, group: GroupedContainers) => void;
-  onViewLogs: (container: ContainerInfo) => void;
-  onRetry: () => void;
+	isLoading: boolean;
+	isError: boolean;
+	error: unknown;
+	groupBy: GroupByOption;
+	filteredContainers: ContainerInfo[];
+	groupedItems: GroupedContainers[] | null;
+	pageItems: ContainerInfo[];
+	pendingAction: { id: string; type: ContainerActionType } | null;
+	pendingComposeAction: { project: string; type: ComposeAction } | null;
+	isReadOnly: boolean;
+	statsMap: ContainerStatsMap;
+	statsHistory: StatsHistoryMap;
+	onStart: (container: ContainerInfo) => void;
+	onStop: (container: ContainerInfo) => void;
+	onRestart: (container: ContainerInfo) => void;
+	onDelete: (container: ContainerInfo) => void;
+	onComposeAction: (action: ComposeAction, group: GroupedContainers) => void;
+	onViewLogs: (container: ContainerInfo) => void;
+	onRetry: () => void;
 }
 
 export function ContainersTable({
-  isLoading,
-  isError,
-  error,
-  groupBy,
-  filteredContainers,
-  groupedItems,
-  pageItems,
-  pendingAction,
-  pendingComposeAction,
-  isReadOnly,
-  statsMap,
-  statsHistory,
-  onStart,
-  onStop,
-  onRestart,
-  onDelete,
-  onComposeAction,
-  onViewLogs,
-  onRetry,
+	isLoading,
+	isError,
+	error,
+	groupBy,
+	filteredContainers,
+	groupedItems,
+	pageItems,
+	pendingAction,
+	pendingComposeAction,
+	isReadOnly,
+	statsMap,
+	statsHistory,
+	onStart,
+	onStop,
+	onRestart,
+	onDelete,
+	onComposeAction,
+	onViewLogs,
+	onRetry,
 }: ContainersTableProps) {
-  const isPending = (action: ContainerActionType, id: string) =>
-    pendingAction?.id === id && pendingAction.type === action;
+	const isPending = (action: ContainerActionType, id: string) =>
+		pendingAction?.id === id && pendingAction.type === action;
 
-  const isBusy = (id: string) => pendingAction?.id === id;
+	const isBusy = (id: string) => pendingAction?.id === id;
 
-  const isComposePending = (action: ContainerActionType, project: string) =>
-    pendingComposeAction?.project === project &&
-    pendingComposeAction.type === action;
+	const isComposePending = (action: ContainerActionType, project: string) =>
+		pendingComposeAction?.project === project &&
+		pendingComposeAction.type === action;
 
-  const isComposeBusy = (project: string) =>
-    pendingComposeAction?.project === project;
+	const isComposeBusy = (project: string) =>
+		pendingComposeAction?.project === project;
 
-  // Only real compose groups get stack actions; the "Standalone" fallback
-  // group has no compose project label to act on.
-  const isComposeGroup = (group: GroupedContainers) =>
-    group.items.some(
-      (container) => getComposeProject(container.labels) === group.project
-    );
+	// Only real compose groups get stack actions; the "Standalone" fallback
+	// group has no compose project label to act on.
+	const isComposeGroup = (group: GroupedContainers) =>
+		group.items.some(
+			(container) => getComposeProject(container.labels) === group.project,
+		);
 
-  const renderContainerRow = (container: ContainerInfo) => {
-    const state = container.state.toLowerCase();
-    const busy = isBusy(container.id);
+	const renderContainerRow = (container: ContainerInfo) => {
+		const state = container.state.toLowerCase();
+		const busy = isBusy(container.id);
 
-    return (
-      <TableRow key={container.id} className="hover:bg-muted/50">
-        <TableCell className="h-16 px-4 font-medium">
-          <div className="flex items-center gap-2">
-            {formatContainerName(container.names)}
-            {isCoolifyManaged(container.labels) && (
-              <Badge className="bg-purple-500/10 text-purple-700 dark:text-purple-400 border-0 text-[10px] px-1.5 h-4">
-                Coolify
-              </Badge>
-            )}
-          </div>
-        </TableCell>
-        <TableCell className="h-16 px-4 text-sm text-muted-foreground">
-          {container.image}
-        </TableCell>
-        <TableCell className="h-16 px-4">
-          <Badge
-            className={`${getStateBadgeClass(container.state)} border-0`}
-          >
-            {toTitleCase(container.state)}
-          </Badge>
-        </TableCell>
-        <TableCell className="h-16 px-4 text-sm">
-          {state !== "running" ? (
-            <span className="text-muted-foreground">—</span>
-          ) : (
-            <div className="space-y-0.5 font-mono text-xs">
-              <div className="flex items-center gap-2">
-                <span>
-                  <span className="text-muted-foreground">CPU: </span>
-                  {formatCPUPercent(statsMap[container.id]?.cpu_percent)}
-                </span>
-                <Sparkline
-                  values={(statsHistory[container.id] ?? []).map((s) => s.cpu)}
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <span>
-                  <span className="text-muted-foreground">Mem: </span>
-                  {formatMemoryStats(statsMap[container.id])}
-                </span>
-                <Sparkline
-                  values={(statsHistory[container.id] ?? []).map(
-                    (s) => s.memoryPercent
-                  )}
-                />
-              </div>
-            </div>
-          )}
-        </TableCell>
-        <TableCell className="h-16 px-4 text-sm text-muted-foreground">
-          {formatUptime(container.created)}
-        </TableCell>
-        <TableCell className="h-16 px-4 text-sm text-muted-foreground">
-          {formatCreatedDate(container.created)}
-        </TableCell>
-        <TableCell className="h-16 px-4 max-w-[300px] text-sm text-muted-foreground">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="block cursor-help truncate">
-                  {container.command}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-md">
-                {container.command}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </TableCell>
-        <TableCell className="h-16 px-4">
-          <TooltipProvider>
-            <div className="flex items-center gap-1">
-              {state === "exited" && (
-                <ActionButton
-                  icon={PlayIcon}
-                  action="start"
-                  containerId={container.id}
-                  onClick={() => onStart(container)}
-                  isPending={isPending}
-                  busy={busy}
-                  isReadOnly={isReadOnly}
-                />
-              )}
-              {state === "running" && (
-                <ActionButton
-                  icon={SquareIcon}
-                  action="stop"
-                  containerId={container.id}
-                  onClick={() => onStop(container)}
-                  isPending={isPending}
-                  busy={busy}
-                  isReadOnly={isReadOnly}
-                />
-              )}
-              <ActionButton
-                icon={RotateCwIcon}
-                action="restart"
-                containerId={container.id}
-                onClick={() => onRestart(container)}
-                isPending={isPending}
-                busy={busy}
-                isReadOnly={isReadOnly}
-              />
-              <ActionButton
-                icon={Trash2Icon}
-                action="remove"
-                containerId={container.id}
-                onClick={() => onDelete(container)}
-                isPending={isPending}
-                busy={busy}
-                isReadOnly={isReadOnly}
-                variant="destructive"
-              />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    className="h-8 w-8"
-                    onClick={() => onViewLogs(container)}
-                    disabled={busy}
-                  >
-                    <FileTextIcon className="size-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>View Logs</TooltipContent>
-              </Tooltip>
-            </div>
-          </TooltipProvider>
-        </TableCell>
-      </TableRow>
-    );
-  };
+		return (
+			<TableRow key={container.id} className="hover:bg-muted/50">
+				<TableCell className="h-16 px-4 font-medium">
+					<div className="flex items-center gap-2">
+						{formatContainerName(container.names)}
+						{isCoolifyManaged(container.labels) && (
+							<Badge className="bg-purple-500/10 text-purple-700 dark:text-purple-400 border-0 text-[10px] px-1.5 h-4">
+								Coolify
+							</Badge>
+						)}
+					</div>
+				</TableCell>
+				<TableCell className="h-16 px-4 text-sm text-muted-foreground">
+					{container.image}
+				</TableCell>
+				<TableCell className="h-16 px-4">
+					<Badge className={`${getStateBadgeClass(container.state)} border-0`}>
+						{toTitleCase(container.state)}
+					</Badge>
+				</TableCell>
+				<TableCell className="h-16 px-4 text-sm">
+					{state !== "running" ? (
+						<span className="text-muted-foreground">—</span>
+					) : (
+						<div className="space-y-0.5 font-mono text-xs">
+							<div className="flex items-center gap-2">
+								<span>
+									<span className="text-muted-foreground">CPU: </span>
+									{formatCPUPercent(statsMap[container.id]?.cpu_percent)}
+								</span>
+								<Sparkline
+									values={(statsHistory[container.id] ?? []).map((s) => s.cpu)}
+								/>
+							</div>
+							<div className="flex items-center gap-2">
+								<span>
+									<span className="text-muted-foreground">Mem: </span>
+									{formatMemoryStats(statsMap[container.id])}
+								</span>
+								<Sparkline
+									values={(statsHistory[container.id] ?? []).map(
+										(s) => s.memoryPercent,
+									)}
+								/>
+							</div>
+						</div>
+					)}
+				</TableCell>
+				<TableCell className="h-16 px-4 text-sm text-muted-foreground">
+					{formatUptime(container.created)}
+				</TableCell>
+				<TableCell className="h-16 px-4 text-sm text-muted-foreground">
+					{formatCreatedDate(container.created)}
+				</TableCell>
+				<TableCell className="h-16 px-4 max-w-[300px] text-sm text-muted-foreground">
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span className="block cursor-help truncate">
+									{container.command}
+								</span>
+							</TooltipTrigger>
+							<TooltipContent className="max-w-md">
+								{container.command}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</TableCell>
+				<TableCell className="h-16 px-4">
+					<TooltipProvider>
+						<div className="flex items-center gap-1">
+							{state === "exited" && (
+								<ActionButton
+									icon={PlayIcon}
+									action="start"
+									containerId={container.id}
+									onClick={() => onStart(container)}
+									isPending={isPending}
+									busy={busy}
+									isReadOnly={isReadOnly}
+								/>
+							)}
+							{state === "running" && (
+								<ActionButton
+									icon={SquareIcon}
+									action="stop"
+									containerId={container.id}
+									onClick={() => onStop(container)}
+									isPending={isPending}
+									busy={busy}
+									isReadOnly={isReadOnly}
+								/>
+							)}
+							<ActionButton
+								icon={RotateCwIcon}
+								action="restart"
+								containerId={container.id}
+								onClick={() => onRestart(container)}
+								isPending={isPending}
+								busy={busy}
+								isReadOnly={isReadOnly}
+							/>
+							<ActionButton
+								icon={Trash2Icon}
+								action="remove"
+								containerId={container.id}
+								onClick={() => onDelete(container)}
+								isPending={isPending}
+								busy={busy}
+								isReadOnly={isReadOnly}
+								variant="destructive"
+							/>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="outline"
+										size="icon"
+										className="h-8 w-8"
+										onClick={() => onViewLogs(container)}
+										disabled={busy}
+									>
+										<FileTextIcon className="size-4" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent>View Logs</TooltipContent>
+							</Tooltip>
+						</div>
+					</TooltipProvider>
+				</TableCell>
+			</TableRow>
+		);
+	};
 
-  return (
-    <div className="rounded-lg border bg-card">
-      <Table>
-        <TableHeader>
-          <TableRow className="hover:bg-transparent border-b">
-            <TableHead className="h-12 px-4 font-medium">Name</TableHead>
-            <TableHead className="h-12 px-4 font-medium">Image</TableHead>
-            <TableHead className="h-12 px-4 font-medium w-[120px]">
-              State
-            </TableHead>
-            <TableHead className="h-12 px-4 font-medium w-[160px]">
-              Metrics
-            </TableHead>
-            <TableHead className="h-12 px-4 font-medium">Uptime</TableHead>
-            <TableHead className="h-12 px-4 font-medium">Created</TableHead>
-            <TableHead className="h-12 px-4 font-medium">Command</TableHead>
-            <TableHead className="h-12 px-4 font-medium w-[120px]">
-              Actions
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            <TableRow>
-              <TableCell colSpan={8} className="h-32">
-                <div className="flex items-center justify-center text-sm text-muted-foreground">
-                  <Spinner className="mr-2" />
-                  Loading containers…
-                </div>
-              </TableCell>
-            </TableRow>
-          ) : isError ? (
-            <TableRow>
-              <TableCell colSpan={8} className="h-32">
-                <div className="flex flex-col items-center gap-3 text-center">
-                  <p className="text-sm text-muted-foreground">
-                    {(error as Error)?.message || "Unable to load containers."}
-                  </p>
-                  <Button size="sm" variant="outline" onClick={onRetry}>
-                    Try again
-                  </Button>
-                </div>
-              </TableCell>
-            </TableRow>
-          ) : filteredContainers.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={8} className="h-32">
-                <div className="text-center text-sm text-muted-foreground">
-                  No containers found.
-                </div>
-              </TableCell>
-            </TableRow>
-          ) : groupBy === "compose" && groupedItems ? (
-            groupedItems.map((group) => (
-              <Fragment key={group.project}>
-                <TableRow className="bg-muted/30 hover:bg-muted/30">
-                  <TableCell
-                    colSpan={8}
-                    className="h-10 px-4 text-xs font-medium text-muted-foreground"
-                  >
-                    <div className="flex items-center justify-between">
-                      <span>
-                        {group.project} · {group.items.length} container
-                        {group.items.length === 1 ? "" : "s"}
-                      </span>
-                      <div className="flex items-center gap-3">
-                        {group.project !== "Standalone" && (
-                          <Link
-                            to="/stacks/$project/logs"
-                            params={{ project: group.project }}
-                            className="inline-flex items-center gap-1 text-primary hover:underline"
-                          >
-                            <FileTextIcon className="size-3" />
-                            Stack logs
-                          </Link>
-                        )}
-                        {isComposeGroup(group) && (
-                          <TooltipProvider>
-                            <div className="flex items-center gap-1">
-                              <ActionButton
-                                icon={PlayIcon}
-                                action="start"
-                                containerId={group.project}
-                                onClick={() => onComposeAction("start", group)}
-                                isPending={isComposePending}
-                                busy={isComposeBusy(group.project)}
-                                isReadOnly={isReadOnly}
-                              />
-                              <ActionButton
-                                icon={SquareIcon}
-                                action="stop"
-                                containerId={group.project}
-                                onClick={() => onComposeAction("stop", group)}
-                                isPending={isComposePending}
-                                busy={isComposeBusy(group.project)}
-                                isReadOnly={isReadOnly}
-                              />
-                              <ActionButton
-                                icon={RotateCwIcon}
-                                action="restart"
-                                containerId={group.project}
-                                onClick={() => onComposeAction("restart", group)}
-                                isPending={isComposePending}
-                                busy={isComposeBusy(group.project)}
-                                isReadOnly={isReadOnly}
-                              />
-                            </div>
-                          </TooltipProvider>
-                        )}
-                      </div>
-                    </div>
-                  </TableCell>
-                </TableRow>
-                {group.items.map(renderContainerRow)}
-              </Fragment>
-            ))
-          ) : (
-            pageItems.map(renderContainerRow)
-          )}
-        </TableBody>
-      </Table>
-    </div>
-  );
+	return (
+		<div className="rounded-lg border bg-card">
+			<Table>
+				<TableHeader>
+					<TableRow className="hover:bg-transparent border-b">
+						<TableHead className="h-12 px-4 font-medium">Name</TableHead>
+						<TableHead className="h-12 px-4 font-medium">Image</TableHead>
+						<TableHead className="h-12 px-4 font-medium w-[120px]">
+							State
+						</TableHead>
+						<TableHead className="h-12 px-4 font-medium w-[160px]">
+							Metrics
+						</TableHead>
+						<TableHead className="h-12 px-4 font-medium">Uptime</TableHead>
+						<TableHead className="h-12 px-4 font-medium">Created</TableHead>
+						<TableHead className="h-12 px-4 font-medium">Command</TableHead>
+						<TableHead className="h-12 px-4 font-medium w-[120px]">
+							Actions
+						</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{isLoading ? (
+						<TableRow>
+							<TableCell colSpan={8} className="h-32">
+								<div className="flex items-center justify-center text-sm text-muted-foreground">
+									<Spinner className="mr-2" />
+									Loading containers…
+								</div>
+							</TableCell>
+						</TableRow>
+					) : isError ? (
+						<TableRow>
+							<TableCell colSpan={8} className="h-32">
+								<div className="flex flex-col items-center gap-3 text-center">
+									<p className="text-sm text-muted-foreground">
+										{(error as Error)?.message || "Unable to load containers."}
+									</p>
+									<Button size="sm" variant="outline" onClick={onRetry}>
+										Try again
+									</Button>
+								</div>
+							</TableCell>
+						</TableRow>
+					) : filteredContainers.length === 0 ? (
+						<TableRow>
+							<TableCell colSpan={8} className="h-32">
+								<div className="text-center text-sm text-muted-foreground">
+									No containers found.
+								</div>
+							</TableCell>
+						</TableRow>
+					) : groupBy === "compose" && groupedItems ? (
+						groupedItems.map((group) => (
+							<Fragment key={group.project}>
+								<TableRow className="bg-muted/30 hover:bg-muted/30">
+									<TableCell
+										colSpan={8}
+										className="h-10 px-4 text-xs font-medium text-muted-foreground"
+									>
+										<div className="flex items-center justify-between">
+											<span>
+												{group.project} · {group.items.length} container
+												{group.items.length === 1 ? "" : "s"}
+											</span>
+											<div className="flex items-center gap-3">
+												{group.project !== "Standalone" && (
+													<Link
+														to="/stacks/$project/logs"
+														params={{ project: group.project }}
+														className="inline-flex items-center gap-1 text-primary hover:underline"
+													>
+														<FileTextIcon className="size-3" />
+														Stack logs
+													</Link>
+												)}
+												{isComposeGroup(group) && (
+													<TooltipProvider>
+														<div className="flex items-center gap-1">
+															<ActionButton
+																icon={PlayIcon}
+																action="start"
+																containerId={group.project}
+																onClick={() => onComposeAction("start", group)}
+																isPending={isComposePending}
+																busy={isComposeBusy(group.project)}
+																isReadOnly={isReadOnly}
+															/>
+															<ActionButton
+																icon={SquareIcon}
+																action="stop"
+																containerId={group.project}
+																onClick={() => onComposeAction("stop", group)}
+																isPending={isComposePending}
+																busy={isComposeBusy(group.project)}
+																isReadOnly={isReadOnly}
+															/>
+															<ActionButton
+																icon={RotateCwIcon}
+																action="restart"
+																containerId={group.project}
+																onClick={() =>
+																	onComposeAction("restart", group)
+																}
+																isPending={isComposePending}
+																busy={isComposeBusy(group.project)}
+																isReadOnly={isReadOnly}
+															/>
+														</div>
+													</TooltipProvider>
+												)}
+											</div>
+										</div>
+									</TableCell>
+								</TableRow>
+								{group.items.map(renderContainerRow)}
+							</Fragment>
+						))
+					) : (
+						pageItems.map(renderContainerRow)
+					)}
+				</TableBody>
+			</Table>
+		</div>
+	);
 }

--- a/frontend/src/features/containers/components/environment-variables.test.ts
+++ b/frontend/src/features/containers/components/environment-variables.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { parseEnvFile } from "./environment-variables";
+
+describe("parseEnvFile", () => {
+	it("parses multiple KEY=value lines", () => {
+		expect(parseEnvFile("A=1\nB=two\nC=three")).toEqual({
+			A: "1",
+			B: "two",
+			C: "three",
+		});
+	});
+
+	it("skips comments and blank lines", () => {
+		expect(parseEnvFile("# comment\n\nA=1\n  \n# another\nB=2")).toEqual({
+			A: "1",
+			B: "2",
+		});
+	});
+
+	it("strips surrounding quotes from values", () => {
+		expect(parseEnvFile("A=\"quoted\"\nB='single'")).toEqual({
+			A: "quoted",
+			B: "single",
+		});
+	});
+
+	it("keeps equals signs inside values", () => {
+		expect(parseEnvFile("URL=postgres://u:p@h/db?sslmode=require")).toEqual({
+			URL: "postgres://u:p@h/db?sslmode=require",
+		});
+	});
+
+	it("ignores lines without an equals sign", () => {
+		expect(parseEnvFile("NOTAVAR\nA=1")).toEqual({ A: "1" });
+	});
+});

--- a/frontend/src/features/containers/components/environment-variables.tsx
+++ b/frontend/src/features/containers/components/environment-variables.tsx
@@ -4,719 +4,717 @@ import { useId, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
 } from "@/components/ui/tooltip";
 
 import { getContainerEnvVariables } from "../api/get-container-env-variables";
 import { updateContainerEnvVariables } from "../api/update-container-env-variables";
 
 interface EnvironmentVariablesProps {
-  containerId: string;
-  containerHost: string;
-  isReadOnly?: boolean;
-  isCoolifyManaged?: boolean;
-  onContainerIdChange?: (newContainerId: string) => void;
+	containerId: string;
+	containerHost: string;
+	isReadOnly?: boolean;
+	isCoolifyManaged?: boolean;
+	onContainerIdChange?: (newContainerId: string) => void;
 }
 
 // Parse .env file content into key-value pairs
 function parseEnvFile(content: string): Record<string, string> {
-  const env: Record<string, string> = {};
-  const lines = content.split("\n");
+	const env: Record<string, string> = {};
+	const lines = content.split("\n");
 
-  for (const line of lines) {
-    const trimmed = line.trim();
+	for (const line of lines) {
+		const trimmed = line.trim();
 
-    // Skip empty lines and comments
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
+		// Skip empty lines and comments
+		if (!trimmed || trimmed.startsWith("#")) {
+			continue;
+		}
 
-    // Find the first = sign
-    const equalIndex = trimmed.indexOf("=");
-    if (equalIndex === -1) {
-      continue;
-    }
+		// Find the first = sign
+		const equalIndex = trimmed.indexOf("=");
+		if (equalIndex === -1) {
+			continue;
+		}
 
-    const key = trimmed.substring(0, equalIndex).trim();
-    let value = trimmed.substring(equalIndex + 1).trim();
+		const key = trimmed.substring(0, equalIndex).trim();
+		let value = trimmed.substring(equalIndex + 1).trim();
 
-    // Remove quotes if present
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
+		// Remove quotes if present
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
 
-    if (key) {
-      env[key] = value;
-    }
-  }
+		if (key) {
+			env[key] = value;
+		}
+	}
 
-  return env;
+	return env;
 }
 
 export function EnvironmentVariables({
-  containerId,
-  containerHost,
-  isReadOnly = false,
-  isCoolifyManaged = false,
-  onContainerIdChange,
+	containerId,
+	containerHost,
+	isReadOnly = false,
+	isCoolifyManaged = false,
+	onContainerIdChange,
 }: EnvironmentVariablesProps) {
-  const queryClient = useQueryClient();
-  const [isEditing, setIsEditing] = useState(false);
-  const [editedEnv, setEditedEnv] = useState<Record<string, string>>({});
-  const [deletedKeys, setDeletedKeys] = useState<Set<string>>(new Set());
-  const [newKey, setNewKey] = useState("");
-  const [newValue, setNewValue] = useState("");
-  const [showAddNew, setShowAddNew] = useState(false);
-  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const [modifiedKeys, setModifiedKeys] = useState<Set<string>>(new Set());
-  const [showUploadPreview, setShowUploadPreview] = useState(false);
-  const [parsedEnvFile, setParsedEnvFile] = useState<Record<string, string>>(
-    {}
-  );
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const newValueInputRef = useRef<HTMLInputElement>(null);
-  const newKeyId = useId();
-  const newValueId = useId();
+	const queryClient = useQueryClient();
+	const [isEditing, setIsEditing] = useState(false);
+	const [editedEnv, setEditedEnv] = useState<Record<string, string>>({});
+	const [deletedKeys, setDeletedKeys] = useState<Set<string>>(new Set());
+	const [newKey, setNewKey] = useState("");
+	const [newValue, setNewValue] = useState("");
+	const [showAddNew, setShowAddNew] = useState(false);
+	const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+	const [modifiedKeys, setModifiedKeys] = useState<Set<string>>(new Set());
+	const [showUploadPreview, setShowUploadPreview] = useState(false);
+	const [parsedEnvFile, setParsedEnvFile] = useState<Record<string, string>>(
+		{},
+	);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const newValueInputRef = useRef<HTMLInputElement>(null);
+	const newKeyId = useId();
+	const newValueId = useId();
 
-  const {
-    data: envVariables,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["container-env", containerId, containerHost],
-    queryFn: () => getContainerEnvVariables(containerId, containerHost),
-    enabled: !!containerId && !!containerHost,
-  });
+	const {
+		data: envVariables,
+		isLoading,
+		error,
+	} = useQuery({
+		queryKey: ["container-env", containerId, containerHost],
+		queryFn: () => getContainerEnvVariables(containerId, containerHost),
+		enabled: !!containerId && !!containerHost,
+	});
 
-  const updateMutation = useMutation({
-    mutationFn: (env: Record<string, string>) =>
-      updateContainerEnvVariables(containerId, containerHost, env),
-    onSuccess: (result) => {
-      // Invalidate queries for BOTH old and new container IDs
-      queryClient.invalidateQueries({
-        queryKey: ["container-env", containerId],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["container-env", result.newContainerId],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["containers"],
-      });
+	const updateMutation = useMutation({
+		mutationFn: (env: Record<string, string>) =>
+			updateContainerEnvVariables(containerId, containerHost, env),
+		onSuccess: (result) => {
+			// Invalidate queries for BOTH old and new container IDs
+			queryClient.invalidateQueries({
+				queryKey: ["container-env", containerId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["container-env", result.newContainerId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["containers"],
+			});
 
-      // Notify parent of new container ID
-      onContainerIdChange?.(result.newContainerId);
+			// Notify parent of new container ID
+			onContainerIdChange?.(result.newContainerId);
 
-      setIsEditing(false);
-      setEditedEnv({});
-      setDeletedKeys(new Set());
-      setModifiedKeys(new Set());
+			setIsEditing(false);
+			setEditedEnv({});
+			setDeletedKeys(new Set());
+			setModifiedKeys(new Set());
 
-      if (result.coolifySynced === true) {
-        toast.success("Environment variables updated", {
-          description:
-            "Container recreated and changes synced to Coolify.",
-        });
-      } else if (result.coolifySynced === false) {
-        toast.warning("Updated, but Coolify sync failed", {
-          description:
-            result.coolifyError || "Container recreated, but Coolify was not updated. Changes may be lost on redeployment.",
-        });
-      } else {
-        toast.success("Environment variables updated", {
-          description:
-            "Container recreated with the new environment variables.",
-        });
-      }
-    },
-    onError: (error: Error) => {
-      toast.error("Failed to update environment variables", {
-        description: error.message,
-      });
-    },
-  });
+			if (result.coolifySynced === true) {
+				toast.success("Environment variables updated", {
+					description: "Container recreated and changes synced to Coolify.",
+				});
+			} else if (result.coolifySynced === false) {
+				toast.warning("Updated, but Coolify sync failed", {
+					description:
+						result.coolifyError ||
+						"Container recreated, but Coolify was not updated. Changes may be lost on redeployment.",
+				});
+			} else {
+				toast.success("Environment variables updated", {
+					description:
+						"Container recreated with the new environment variables.",
+				});
+			}
+		},
+		onError: (error: Error) => {
+			toast.error("Failed to update environment variables", {
+				description: error.message,
+			});
+		},
+	});
 
-  const handleEdit = () => {
-    setEditedEnv({ ...envVariables });
-    setDeletedKeys(new Set());
-    setModifiedKeys(new Set());
-    setIsEditing(true);
-  };
+	const handleEdit = () => {
+		setEditedEnv({ ...envVariables });
+		setDeletedKeys(new Set());
+		setModifiedKeys(new Set());
+		setIsEditing(true);
+	};
 
-  const handleCancel = () => {
-    setIsEditing(false);
-    setEditedEnv({});
-    setDeletedKeys(new Set());
-    setModifiedKeys(new Set());
-    setShowAddNew(false);
-    setNewKey("");
-    setNewValue("");
-  };
+	const handleCancel = () => {
+		setIsEditing(false);
+		setEditedEnv({});
+		setDeletedKeys(new Set());
+		setModifiedKeys(new Set());
+		setShowAddNew(false);
+		setNewKey("");
+		setNewValue("");
+	};
 
-  const handleSave = () => {
-    setShowConfirmDialog(true);
-  };
+	const handleSave = () => {
+		setShowConfirmDialog(true);
+	};
 
-  const handleConfirmUpdate = () => {
-    const finalEnv = { ...editedEnv };
-    // Remove deleted keys
-    deletedKeys.forEach((key) => {
-      delete finalEnv[key];
-    });
-    updateMutation.mutate(finalEnv);
-    setShowConfirmDialog(false);
-  };
+	const handleConfirmUpdate = () => {
+		const finalEnv = { ...editedEnv };
+		// Remove deleted keys
+		deletedKeys.forEach((key) => {
+			delete finalEnv[key];
+		});
+		updateMutation.mutate(finalEnv);
+		setShowConfirmDialog(false);
+	};
 
-  const handleDelete = (key: string) => {
-    setDeletedKeys((prev) => new Set(prev).add(key));
-  };
+	const handleDelete = (key: string) => {
+		setDeletedKeys((prev) => new Set(prev).add(key));
+	};
 
-  const handleValueChange = (key: string, value: string) => {
-    setEditedEnv((prev) => ({ ...prev, [key]: value }));
-  };
+	const handleValueChange = (key: string, value: string) => {
+		setEditedEnv((prev) => ({ ...prev, [key]: value }));
+	};
 
-  const handleNewKeyChange = (rawValue: string) => {
-    const equalIndex = rawValue.indexOf("=");
-    if (equalIndex === -1) {
-      setNewKey(rawValue);
-      return;
-    }
+	const handleNewKeyChange = (rawValue: string) => {
+		const equalIndex = rawValue.indexOf("=");
+		if (equalIndex === -1) {
+			setNewKey(rawValue);
+			return;
+		}
 
-    const key = rawValue.substring(0, equalIndex).trim();
-    const rawTail = rawValue.substring(equalIndex + 1);
-    let value = rawTail;
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
+		const key = rawValue.substring(0, equalIndex).trim();
+		const rawTail = rawValue.substring(equalIndex + 1);
+		let value = rawTail;
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
 
-    setNewKey(key);
-    // Only overwrite an existing value when the pasted segment after `=` is
-    // non-empty; otherwise we'd wipe text the user already typed in Value.
-    // Check rawTail (pre-strip) so explicit empty quotes like KEY="" still
-    // clear the value field.
-    if (rawTail.length > 0) {
-      setNewValue(value);
-    }
-    // Move focus to the value field so the user can keep editing if needed.
-    requestAnimationFrame(() => {
-      const input = newValueInputRef.current;
-      if (!input) return;
-      input.focus();
-      const caret = input.value.length;
-      input.setSelectionRange(caret, caret);
-    });
-  };
+		setNewKey(key);
+		// Only overwrite an existing value when the pasted segment after `=` is
+		// non-empty; otherwise we'd wipe text the user already typed in Value.
+		// Check rawTail (pre-strip) so explicit empty quotes like KEY="" still
+		// clear the value field.
+		if (rawTail.length > 0) {
+			setNewValue(value);
+		}
+		// Move focus to the value field so the user can keep editing if needed.
+		requestAnimationFrame(() => {
+			const input = newValueInputRef.current;
+			if (!input) return;
+			input.focus();
+			const caret = input.value.length;
+			input.setSelectionRange(caret, caret);
+		});
+	};
 
-  const handleAddNew = () => {
-    if (newKey.trim() && !editedEnv[newKey]) {
-      setEditedEnv((prev) => ({ ...prev, [newKey]: newValue }));
-      setModifiedKeys((prev) => new Set(prev).add(newKey));
-      setNewKey("");
-      setNewValue("");
-      setShowAddNew(false);
-    } else if (editedEnv[newKey]) {
-      toast.error("Key already exists");
-    } else {
-      toast.error("Key cannot be empty");
-    }
-  };
+	const handleAddNew = () => {
+		if (newKey.trim() && !editedEnv[newKey]) {
+			setEditedEnv((prev) => ({ ...prev, [newKey]: newValue }));
+			setModifiedKeys((prev) => new Set(prev).add(newKey));
+			setNewKey("");
+			setNewValue("");
+			setShowAddNew(false);
+		} else if (editedEnv[newKey]) {
+			toast.error("Key already exists");
+		} else {
+			toast.error("Key cannot be empty");
+		}
+	};
 
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
+	const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		if (!file) return;
 
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const content = e.target?.result as string;
-      try {
-        const parsed = parseEnvFile(content);
-        setParsedEnvFile(parsed);
-        setShowUploadPreview(true);
-      } catch {
-        toast.error("Failed to parse .env file");
-      }
-    };
-    reader.readAsText(file);
+		const reader = new FileReader();
+		reader.onload = (e) => {
+			const content = e.target?.result as string;
+			try {
+				const parsed = parseEnvFile(content);
+				setParsedEnvFile(parsed);
+				setShowUploadPreview(true);
+			} catch {
+				toast.error("Failed to parse .env file");
+			}
+		};
+		reader.readAsText(file);
 
-    // Reset the input so the same file can be selected again
-    event.target.value = "";
-  };
+		// Reset the input so the same file can be selected again
+		event.target.value = "";
+	};
 
-  const handleConfirmUpload = () => {
-    const newKeys = new Set<string>();
+	const handleConfirmUpload = () => {
+		const newKeys = new Set<string>();
 
-    // Merge parsed env file into editedEnv
-    Object.entries(parsedEnvFile).forEach(([key, value]) => {
-      setEditedEnv((prev) => ({ ...prev, [key]: value }));
-      newKeys.add(key);
-    });
+		// Merge parsed env file into editedEnv
+		Object.entries(parsedEnvFile).forEach(([key, value]) => {
+			setEditedEnv((prev) => ({ ...prev, [key]: value }));
+			newKeys.add(key);
+		});
 
-    // Track all uploaded keys as modified
-    setModifiedKeys((prev) => new Set([...prev, ...newKeys]));
+		// Track all uploaded keys as modified
+		setModifiedKeys((prev) => new Set([...prev, ...newKeys]));
 
-    // Close dialog and reset
-    setShowUploadPreview(false);
-    setParsedEnvFile({});
+		// Close dialog and reset
+		setShowUploadPreview(false);
+		setParsedEnvFile({});
 
-    toast.success(
-      `Imported ${Object.keys(parsedEnvFile).length} variables from .env file`
-    );
-  };
+		toast.success(
+			`Imported ${Object.keys(parsedEnvFile).length} variables from .env file`,
+		);
+	};
 
-  const handleCancelUpload = () => {
-    setShowUploadPreview(false);
-    setParsedEnvFile({});
-  };
+	const handleCancelUpload = () => {
+		setShowUploadPreview(false);
+		setParsedEnvFile({});
+	};
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-        Loading environment variables...
-      </div>
-    );
-  }
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+				Loading environment variables...
+			</div>
+		);
+	}
 
-  if (error) {
-    return (
-      <div className="flex items-center justify-center py-4 text-sm text-destructive">
-        Failed to load environment variables
-      </div>
-    );
-  }
+	if (error) {
+		return (
+			<div className="flex items-center justify-center py-4 text-sm text-destructive">
+				Failed to load environment variables
+			</div>
+		);
+	}
 
-  const displayEnv = isEditing ? editedEnv : envVariables || {};
-  const envEntries = Object.entries(displayEnv)
-    .filter(([key]) => !deletedKeys.has(key))
-    .sort(([keyA], [keyB]) => {
-      // When editing, sort by modified status (modified first)
-      if (isEditing) {
-        const aIsModified = modifiedKeys.has(keyA);
-        const bIsModified = modifiedKeys.has(keyB);
+	const displayEnv = isEditing ? editedEnv : envVariables || {};
+	const envEntries = Object.entries(displayEnv)
+		.filter(([key]) => !deletedKeys.has(key))
+		.sort(([keyA], [keyB]) => {
+			// When editing, sort by modified status (modified first)
+			if (isEditing) {
+				const aIsModified = modifiedKeys.has(keyA);
+				const bIsModified = modifiedKeys.has(keyB);
 
-        if (aIsModified && !bIsModified) return -1;
-        if (!aIsModified && bIsModified) return 1;
-      }
+				if (aIsModified && !bIsModified) return -1;
+				if (!aIsModified && bIsModified) return 1;
+			}
 
-      // For items with same modified status (or when not editing), maintain original order
-      return 0;
-    });
+			// For items with same modified status (or when not editing), maintain original order
+			return 0;
+		});
 
-  if (envEntries.length === 0 && !isEditing) {
-    return (
-      <div className="space-y-3">
-        <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-          No environment variables configured
-        </div>
-      </div>
-    );
-  }
+	if (envEntries.length === 0 && !isEditing) {
+		return (
+			<div className="space-y-3">
+				<div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+					No environment variables configured
+				</div>
+			</div>
+		);
+	}
 
-  return (
-    <div className="space-y-3 pt-2">
-      {/* Hidden file input */}
-      <input
-        type="file"
-        ref={fileInputRef}
-        onChange={handleFileUpload}
-        accept=".env"
-        className="hidden"
-      />
+	return (
+		<div className="space-y-3 pt-2">
+			{/* Hidden file input */}
+			<input
+				type="file"
+				ref={fileInputRef}
+				onChange={handleFileUpload}
+				accept=".env"
+				className="hidden"
+			/>
 
-      {/* Edit/Save/Cancel buttons */}
-      <div className="flex items-center gap-2 justify-end border-b pb-2">
-        {!isEditing ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleEdit}
-                  disabled={isReadOnly}
-                  className="h-8"
-                >
-                  <Edit2 className="mr-2 h-3.5 w-3.5" />
-                  Edit
-                </Button>
-              </TooltipTrigger>
-              {isReadOnly && (
-                <TooltipContent>
-                  Cannot edit in read-only mode
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-        ) : (
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => fileInputRef.current?.click()}
-              className="h-8"
-            >
-              <Upload className="mr-2 h-3.5 w-3.5" />
-              Upload .env
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowAddNew(true)}
-              className="h-8"
-            >
-              <Plus className="mr-2 h-3.5 w-3.5" />
-              Add
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleCancel}
-              className="h-8"
-            >
-              <X className="mr-2 h-3.5 w-3.5" />
-              Cancel
-            </Button>
-            <Button
-              variant="default"
-              size="sm"
-              onClick={handleSave}
-              disabled={updateMutation.isPending}
-              className="h-8"
-            >
-              <Save className="mr-2 h-3.5 w-3.5" />
-              {updateMutation.isPending ? "Saving..." : "Save"}
-            </Button>
-          </>
-        )}
-      </div>
+			{/* Edit/Save/Cancel buttons */}
+			<div className="flex items-center gap-2 justify-end border-b pb-2">
+				{!isEditing ? (
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={handleEdit}
+									disabled={isReadOnly}
+									className="h-8"
+								>
+									<Edit2 className="mr-2 h-3.5 w-3.5" />
+									Edit
+								</Button>
+							</TooltipTrigger>
+							{isReadOnly && (
+								<TooltipContent>Cannot edit in read-only mode</TooltipContent>
+							)}
+						</Tooltip>
+					</TooltipProvider>
+				) : (
+					<>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => fileInputRef.current?.click()}
+							className="h-8"
+						>
+							<Upload className="mr-2 h-3.5 w-3.5" />
+							Upload .env
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setShowAddNew(true)}
+							className="h-8"
+						>
+							<Plus className="mr-2 h-3.5 w-3.5" />
+							Add
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleCancel}
+							className="h-8"
+						>
+							<X className="mr-2 h-3.5 w-3.5" />
+							Cancel
+						</Button>
+						<Button
+							variant="default"
+							size="sm"
+							onClick={handleSave}
+							disabled={updateMutation.isPending}
+							className="h-8"
+						>
+							<Save className="mr-2 h-3.5 w-3.5" />
+							{updateMutation.isPending ? "Saving..." : "Save"}
+						</Button>
+					</>
+				)}
+			</div>
 
-      {/* Add new variable form */}
-      {showAddNew && (
-        <div className="rounded-lg border border-primary p-3 transition-colors bg-muted/30">
-          <div className="flex items-end gap-3">
-            <div className="flex-1 space-y-2">
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor={newKeyId} className="text-xs font-medium">
-                    Key
-                  </Label>
-                  <Input
-                    id={newKeyId}
-                    value={newKey}
-                    onChange={(e) => handleNewKeyChange(e.target.value)}
-                    placeholder="VARIABLE_NAME or KEY=value"
-                    className="font-mono text-xs h-8"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor={newValueId} className="text-xs font-medium">
-                    Value
-                  </Label>
-                  <Input
-                    id={newValueId}
-                    ref={newValueInputRef}
-                    value={newValue}
-                    onChange={(e) => setNewValue(e.target.value)}
-                    placeholder="value"
-                    className="font-mono text-xs h-8"
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="flex gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleAddNew}
-                className="mb-0.5 h-8 w-8 text-primary hover:text-primary"
-                title="Add variable"
-              >
-                <Plus className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => {
-                  setShowAddNew(false);
-                  setNewKey("");
-                  setNewValue("");
-                }}
-                className="mb-0.5 h-8 w-8 text-muted-foreground"
-                title="Cancel"
-              >
-                <X className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+			{/* Add new variable form */}
+			{showAddNew && (
+				<div className="rounded-lg border border-primary p-3 transition-colors bg-muted/30">
+					<div className="flex items-end gap-3">
+						<div className="flex-1 space-y-2">
+							<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+								<div className="space-y-1.5">
+									<Label htmlFor={newKeyId} className="text-xs font-medium">
+										Key
+									</Label>
+									<Input
+										id={newKeyId}
+										value={newKey}
+										onChange={(e) => handleNewKeyChange(e.target.value)}
+										placeholder="VARIABLE_NAME or KEY=value"
+										className="font-mono text-xs h-8"
+									/>
+								</div>
+								<div className="space-y-1.5">
+									<Label htmlFor={newValueId} className="text-xs font-medium">
+										Value
+									</Label>
+									<Input
+										id={newValueId}
+										ref={newValueInputRef}
+										value={newValue}
+										onChange={(e) => setNewValue(e.target.value)}
+										placeholder="value"
+										className="font-mono text-xs h-8"
+									/>
+								</div>
+							</div>
+						</div>
+						<div className="flex gap-1">
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={handleAddNew}
+								className="mb-0.5 h-8 w-8 text-primary hover:text-primary"
+								title="Add variable"
+							>
+								<Plus className="h-3.5 w-3.5" />
+							</Button>
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={() => {
+									setShowAddNew(false);
+									setNewKey("");
+									setNewValue("");
+								}}
+								className="mb-0.5 h-8 w-8 text-muted-foreground"
+								title="Cancel"
+							>
+								<X className="h-3.5 w-3.5" />
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
 
-      {/* Existing environment variables */}
-      {envEntries.map(([key, value]) => {
-        const isModified = modifiedKeys.has(key);
-        return (
-          <div
-            key={key}
-            className={`flex items-end gap-3 rounded-lg border p-3 transition-colors ${
-              deletedKeys.has(key)
-                ? "opacity-50 bg-destructive/10"
-                : isModified && isEditing
-                  ? "border-primary/50 bg-primary/5 hover:bg-primary/10"
-                  : "hover:bg-muted/50"
-            }`}
-          >
-            <div className="flex-1 space-y-2">
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <div className="flex items-center gap-2">
-                    <Label
-                      htmlFor={`key-${key}`}
-                      className="text-xs font-medium"
-                    >
-                      Key
-                    </Label>
-                    {isModified && isEditing && (
-                      <Badge
-                        variant="default"
-                        className="h-4 text-[10px] px-1.5"
-                      >
-                        New
-                      </Badge>
-                    )}
-                  </div>
-                  <Input
-                    id={`key-${key}`}
-                    value={key}
-                    disabled
-                    className="font-mono text-xs h-8"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label
-                    htmlFor={`value-${key}`}
-                    className="text-xs font-medium"
-                  >
-                    Value
-                  </Label>
-                  <Input
-                    id={`value-${key}`}
-                    value={value}
-                    onChange={(e) => handleValueChange(key, e.target.value)}
-                    disabled={!isEditing}
-                    className="font-mono text-xs h-8"
-                  />
-                </div>
-              </div>
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => handleDelete(key)}
-              className="mb-0.5 h-8 w-8 text-muted-foreground hover:text-destructive"
-              disabled={!isEditing}
-              title={
-                isEditing ? "Mark for deletion" : "Edit to enable deletion"
-              }
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-        );
-      })}
+			{/* Existing environment variables */}
+			{envEntries.map(([key, value]) => {
+				const isModified = modifiedKeys.has(key);
+				return (
+					<div
+						key={key}
+						className={`flex items-end gap-3 rounded-lg border p-3 transition-colors ${
+							deletedKeys.has(key)
+								? "opacity-50 bg-destructive/10"
+								: isModified && isEditing
+									? "border-primary/50 bg-primary/5 hover:bg-primary/10"
+									: "hover:bg-muted/50"
+						}`}
+					>
+						<div className="flex-1 space-y-2">
+							<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+								<div className="space-y-1.5">
+									<div className="flex items-center gap-2">
+										<Label
+											htmlFor={`key-${key}`}
+											className="text-xs font-medium"
+										>
+											Key
+										</Label>
+										{isModified && isEditing && (
+											<Badge
+												variant="default"
+												className="h-4 text-[10px] px-1.5"
+											>
+												New
+											</Badge>
+										)}
+									</div>
+									<Input
+										id={`key-${key}`}
+										value={key}
+										disabled
+										className="font-mono text-xs h-8"
+									/>
+								</div>
+								<div className="space-y-1.5">
+									<Label
+										htmlFor={`value-${key}`}
+										className="text-xs font-medium"
+									>
+										Value
+									</Label>
+									<Input
+										id={`value-${key}`}
+										value={value}
+										onChange={(e) => handleValueChange(key, e.target.value)}
+										disabled={!isEditing}
+										className="font-mono text-xs h-8"
+									/>
+								</div>
+							</div>
+						</div>
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={() => handleDelete(key)}
+							className="mb-0.5 h-8 w-8 text-muted-foreground hover:text-destructive"
+							disabled={!isEditing}
+							title={
+								isEditing ? "Mark for deletion" : "Edit to enable deletion"
+							}
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+						</Button>
+					</div>
+				);
+			})}
 
-      {envEntries.length === 0 && isEditing && (
-        <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-          No environment variables. Click "Add" to create one.
-        </div>
-      )}
+			{envEntries.length === 0 && isEditing && (
+				<div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+					No environment variables. Click "Add" to create one.
+				</div>
+			)}
 
-      {/* Upload Preview Dialog */}
-      <AlertDialog open={showUploadPreview} onOpenChange={setShowUploadPreview}>
-        <AlertDialogContent className="max-w-3xl max-h-[80vh] overflow-hidden flex flex-col">
-          <AlertDialogHeader className="shrink-0">
-            <AlertDialogTitle>Preview .env File Import</AlertDialogTitle>
-            <AlertDialogDescription>
-              Review the variables that will be imported from the .env file.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+			{/* Upload Preview Dialog */}
+			<AlertDialog open={showUploadPreview} onOpenChange={setShowUploadPreview}>
+				<AlertDialogContent className="max-w-3xl max-h-[80vh] overflow-hidden flex flex-col">
+					<AlertDialogHeader className="shrink-0">
+						<AlertDialogTitle>Preview .env File Import</AlertDialogTitle>
+						<AlertDialogDescription>
+							Review the variables that will be imported from the .env file.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
 
-          <div className="space-y-4 py-4 overflow-y-auto min-h-0">
-            {/* Summary */}
-            <div className="flex gap-4 text-sm">
-              <div className="flex items-center gap-2">
-                <span className="font-medium">Total:</span>
-                <span className="px-2 py-0.5 rounded bg-muted">
-                  {Object.keys(parsedEnvFile).length}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="font-medium">New:</span>
-                <span className="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">
-                  {
-                    Object.keys(parsedEnvFile).filter((key) => !editedEnv[key])
-                      .length
-                  }
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="font-medium">Updated:</span>
-                <span className="px-2 py-0.5 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">
-                  {
-                    Object.keys(parsedEnvFile).filter(
-                      (key) =>
-                        editedEnv[key] && editedEnv[key] !== parsedEnvFile[key]
-                    ).length
-                  }
-                </span>
-              </div>
-            </div>
+					<div className="space-y-4 py-4 overflow-y-auto min-h-0">
+						{/* Summary */}
+						<div className="flex gap-4 text-sm">
+							<div className="flex items-center gap-2">
+								<span className="font-medium">Total:</span>
+								<span className="px-2 py-0.5 rounded bg-muted">
+									{Object.keys(parsedEnvFile).length}
+								</span>
+							</div>
+							<div className="flex items-center gap-2">
+								<span className="font-medium">New:</span>
+								<span className="px-2 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">
+									{
+										Object.keys(parsedEnvFile).filter((key) => !editedEnv[key])
+											.length
+									}
+								</span>
+							</div>
+							<div className="flex items-center gap-2">
+								<span className="font-medium">Updated:</span>
+								<span className="px-2 py-0.5 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">
+									{
+										Object.keys(parsedEnvFile).filter(
+											(key) =>
+												editedEnv[key] && editedEnv[key] !== parsedEnvFile[key],
+										).length
+									}
+								</span>
+							</div>
+						</div>
 
-            {/* New Variables */}
-            {Object.keys(parsedEnvFile).filter((key) => !editedEnv[key])
-              .length > 0 && (
-              <div className="space-y-2">
-                <h4 className="text-sm font-semibold text-green-700 dark:text-green-400">
-                  New Variables
-                </h4>
-                <div className="space-y-2 max-h-48 overflow-y-auto">
-                  {Object.entries(parsedEnvFile)
-                    .filter(([key]) => !editedEnv[key])
-                    .map(([key, value]) => (
-                      <div
-                        key={key}
-                        className="p-2 rounded border border-green-200 dark:border-green-900/30 bg-green-50 dark:bg-green-900/10"
-                      >
-                        <div className="font-mono text-xs break-all overflow-hidden">
-                          <span className="font-semibold break-words">
-                            {key}
-                          </span>
-                          <span className="text-muted-foreground"> = </span>
-                          <span className="break-words">{value}</span>
-                        </div>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            )}
+						{/* New Variables */}
+						{Object.keys(parsedEnvFile).filter((key) => !editedEnv[key])
+							.length > 0 && (
+							<div className="space-y-2">
+								<h4 className="text-sm font-semibold text-green-700 dark:text-green-400">
+									New Variables
+								</h4>
+								<div className="space-y-2 max-h-48 overflow-y-auto">
+									{Object.entries(parsedEnvFile)
+										.filter(([key]) => !editedEnv[key])
+										.map(([key, value]) => (
+											<div
+												key={key}
+												className="p-2 rounded border border-green-200 dark:border-green-900/30 bg-green-50 dark:bg-green-900/10"
+											>
+												<div className="font-mono text-xs break-all overflow-hidden">
+													<span className="font-semibold break-words">
+														{key}
+													</span>
+													<span className="text-muted-foreground"> = </span>
+													<span className="break-words">{value}</span>
+												</div>
+											</div>
+										))}
+								</div>
+							</div>
+						)}
 
-            {/* Updated Variables */}
-            {Object.keys(parsedEnvFile).filter(
-              (key) => editedEnv[key] && editedEnv[key] !== parsedEnvFile[key]
-            ).length > 0 && (
-              <div className="space-y-2">
-                <h4 className="text-sm font-semibold text-blue-700 dark:text-blue-400">
-                  Updated Variables
-                </h4>
-                <div className="space-y-3 max-h-48 overflow-y-auto">
-                  {Object.entries(parsedEnvFile)
-                    .filter(
-                      ([key]) =>
-                        editedEnv[key] && editedEnv[key] !== parsedEnvFile[key]
-                    )
-                    .map(([key, value]) => (
-                      <div
-                        key={key}
-                        className="p-2 rounded border border-blue-200 dark:border-blue-900/30 bg-blue-50 dark:bg-blue-900/10"
-                      >
-                        <div className="font-mono text-xs space-y-1 overflow-hidden">
-                          <div className="font-semibold break-words">{key}</div>
-                          <div className="flex flex-col gap-1">
-                            <div className="flex items-start gap-2">
-                              <span className="text-muted-foreground shrink-0">
-                                Old:
-                              </span>
-                              <span className="text-red-600 dark:text-red-400 line-through break-all">
-                                {editedEnv[key]}
-                              </span>
-                            </div>
-                            <div className="flex items-start gap-2">
-                              <span className="text-muted-foreground shrink-0">
-                                New:
-                              </span>
-                              <span className="text-green-600 dark:text-green-400 break-all">
-                                {value}
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            )}
+						{/* Updated Variables */}
+						{Object.keys(parsedEnvFile).filter(
+							(key) => editedEnv[key] && editedEnv[key] !== parsedEnvFile[key],
+						).length > 0 && (
+							<div className="space-y-2">
+								<h4 className="text-sm font-semibold text-blue-700 dark:text-blue-400">
+									Updated Variables
+								</h4>
+								<div className="space-y-3 max-h-48 overflow-y-auto">
+									{Object.entries(parsedEnvFile)
+										.filter(
+											([key]) =>
+												editedEnv[key] && editedEnv[key] !== parsedEnvFile[key],
+										)
+										.map(([key, value]) => (
+											<div
+												key={key}
+												className="p-2 rounded border border-blue-200 dark:border-blue-900/30 bg-blue-50 dark:bg-blue-900/10"
+											>
+												<div className="font-mono text-xs space-y-1 overflow-hidden">
+													<div className="font-semibold break-words">{key}</div>
+													<div className="flex flex-col gap-1">
+														<div className="flex items-start gap-2">
+															<span className="text-muted-foreground shrink-0">
+																Old:
+															</span>
+															<span className="text-red-600 dark:text-red-400 line-through break-all">
+																{editedEnv[key]}
+															</span>
+														</div>
+														<div className="flex items-start gap-2">
+															<span className="text-muted-foreground shrink-0">
+																New:
+															</span>
+															<span className="text-green-600 dark:text-green-400 break-all">
+																{value}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										))}
+								</div>
+							</div>
+						)}
 
-            {/* Unchanged Variables */}
-            {Object.keys(parsedEnvFile).filter(
-              (key) => editedEnv[key] && editedEnv[key] === parsedEnvFile[key]
-            ).length > 0 && (
-              <div className="space-y-2">
-                <h4 className="text-sm font-semibold text-muted-foreground">
-                  Unchanged Variables (
-                  {
-                    Object.keys(parsedEnvFile).filter(
-                      (key) =>
-                        editedEnv[key] && editedEnv[key] === parsedEnvFile[key]
-                    ).length
-                  }
-                  )
-                </h4>
-              </div>
-            )}
-          </div>
+						{/* Unchanged Variables */}
+						{Object.keys(parsedEnvFile).filter(
+							(key) => editedEnv[key] && editedEnv[key] === parsedEnvFile[key],
+						).length > 0 && (
+							<div className="space-y-2">
+								<h4 className="text-sm font-semibold text-muted-foreground">
+									Unchanged Variables (
+									{
+										Object.keys(parsedEnvFile).filter(
+											(key) =>
+												editedEnv[key] && editedEnv[key] === parsedEnvFile[key],
+										).length
+									}
+									)
+								</h4>
+							</div>
+						)}
+					</div>
 
-          <AlertDialogFooter className="shrink-0">
-            <AlertDialogCancel onClick={handleCancelUpload}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmUpload}>
-              Import Variables
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+					<AlertDialogFooter className="shrink-0">
+						<AlertDialogCancel onClick={handleCancelUpload}>
+							Cancel
+						</AlertDialogCancel>
+						<AlertDialogAction onClick={handleConfirmUpload}>
+							Import Variables
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 
-      {/* Confirmation Dialog */}
-      <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Update environment variables?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Changing environment variables requires recreating the container.
-              This will cause a brief downtime.
-              {isCoolifyManaged
-                ? " Changes will also be synced to Coolify so they persist across redeployments. Are you sure you want to continue?"
-                : " Are you sure you want to continue?"}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmUpdate}>
-              Confirm & Update
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
-  );
+			{/* Confirmation Dialog */}
+			<AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Update environment variables?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Changing environment variables requires recreating the container.
+							This will cause a brief downtime.
+							{isCoolifyManaged
+								? " Changes will also be synced to Coolify so they persist across redeployments. Are you sure you want to continue?"
+								: " Are you sure you want to continue?"}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction onClick={handleConfirmUpdate}>
+							Confirm & Update
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
 }

--- a/frontend/src/features/containers/components/environment-variables.tsx
+++ b/frontend/src/features/containers/components/environment-variables.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Edit2, Plus, Save, Trash2, Upload, X } from "lucide-react";
-import { useId, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -16,7 +16,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
 	Tooltip,
 	TooltipContent,
@@ -36,7 +35,7 @@ interface EnvironmentVariablesProps {
 }
 
 // Parse .env file content into key-value pairs
-function parseEnvFile(content: string): Record<string, string> {
+export function parseEnvFile(content: string): Record<string, string> {
 	const env: Record<string, string> = {};
 	const lines = content.split("\n");
 
@@ -95,8 +94,6 @@ export function EnvironmentVariables({
 	);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const newValueInputRef = useRef<HTMLInputElement>(null);
-	const newKeyId = useId();
-	const newValueId = useId();
 
 	const {
 		data: envVariables,
@@ -227,6 +224,31 @@ export function EnvironmentVariables({
 			const caret = input.value.length;
 			input.setSelectionRange(caret, caret);
 		});
+	};
+
+	// Pasting a whole .env (multiple KEY=value lines) into the key field
+	// imports every pair at once — new keys added, existing keys updated.
+	// Must intercept the paste: text inputs strip newlines before onChange.
+	const handleKeyPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+		const text = event.clipboardData.getData("text");
+		if (!text.includes("\n")) return;
+
+		event.preventDefault();
+		const parsed = parseEnvFile(text);
+		const count = Object.keys(parsed).length;
+		if (count === 0) {
+			toast.error("No KEY=value pairs found in pasted text");
+			return;
+		}
+
+		setEditedEnv((prev) => ({ ...prev, ...parsed }));
+		setModifiedKeys((prev) => new Set([...prev, ...Object.keys(parsed)]));
+		setNewKey("");
+		setNewValue("");
+		setShowAddNew(false);
+		toast.success(
+			`Imported ${count} variable${count === 1 ? "" : "s"} from pasted text`,
+		);
 	};
 
 	const handleAddNew = () => {
@@ -409,141 +431,120 @@ export function EnvironmentVariables({
 				)}
 			</div>
 
-			{/* Add new variable form */}
-			{showAddNew && (
-				<div className="rounded-lg border border-primary p-3 transition-colors bg-muted/30">
-					<div className="flex items-end gap-3">
-						<div className="flex-1 space-y-2">
-							<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-								<div className="space-y-1.5">
-									<Label htmlFor={newKeyId} className="text-xs font-medium">
-										Key
-									</Label>
-									<Input
-										id={newKeyId}
-										value={newKey}
-										onChange={(e) => handleNewKeyChange(e.target.value)}
-										placeholder="VARIABLE_NAME or KEY=value"
-										className="font-mono text-xs h-8"
-									/>
-								</div>
-								<div className="space-y-1.5">
-									<Label htmlFor={newValueId} className="text-xs font-medium">
-										Value
-									</Label>
-									<Input
-										id={newValueId}
-										ref={newValueInputRef}
-										value={newValue}
-										onChange={(e) => setNewValue(e.target.value)}
-										placeholder="value"
-										className="font-mono text-xs h-8"
-									/>
-								</div>
+			{/* Variables list: one header row, then dense key/value rows */}
+			{(envEntries.length > 0 || showAddNew) && (
+				<div>
+					<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_2rem] items-center gap-2 border-b pb-1.5 text-xs font-medium text-muted-foreground">
+						<span>Key</span>
+						<span>Value</span>
+						<span />
+					</div>
+
+					{showAddNew && (
+						<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_2rem] items-center gap-2 border-b py-1.5">
+							<Input
+								value={newKey}
+								onChange={(e) => handleNewKeyChange(e.target.value)}
+								onPaste={handleKeyPaste}
+								placeholder="VARIABLE_NAME, KEY=value, or paste a .env"
+								aria-label="Key"
+								className="h-8 font-mono text-xs"
+							/>
+							<Input
+								ref={newValueInputRef}
+								value={newValue}
+								onChange={(e) => setNewValue(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleAddNew();
+								}}
+								placeholder="value"
+								aria-label="Value"
+								className="h-8 font-mono text-xs"
+							/>
+							<div className="flex gap-0.5">
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={handleAddNew}
+									className="h-8 w-8 text-primary hover:text-primary"
+									title="Add variable"
+								>
+									<Plus className="h-3.5 w-3.5" />
+								</Button>
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={() => {
+										setShowAddNew(false);
+										setNewKey("");
+										setNewValue("");
+									}}
+									className="h-8 w-8 text-muted-foreground"
+									title="Cancel"
+								>
+									<X className="h-3.5 w-3.5" />
+								</Button>
 							</div>
 						</div>
-						<div className="flex gap-1">
-							<Button
-								variant="ghost"
-								size="icon"
-								onClick={handleAddNew}
-								className="mb-0.5 h-8 w-8 text-primary hover:text-primary"
-								title="Add variable"
+					)}
+
+					{envEntries.map(([key, value]) => {
+						const isModified = modifiedKeys.has(key);
+						return (
+							<div
+								key={key}
+								className={`grid grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_2rem] items-center gap-2 border-b py-1.5 transition-colors last:border-b-0 ${
+									isModified && isEditing ? "bg-primary/5" : "hover:bg-muted/30"
+								}`}
 							>
-								<Plus className="h-3.5 w-3.5" />
-							</Button>
-							<Button
-								variant="ghost"
-								size="icon"
-								onClick={() => {
-									setShowAddNew(false);
-									setNewKey("");
-									setNewValue("");
-								}}
-								className="mb-0.5 h-8 w-8 text-muted-foreground"
-								title="Cancel"
-							>
-								<X className="h-3.5 w-3.5" />
-							</Button>
-						</div>
-					</div>
+								<div className="flex min-w-0 items-center gap-2">
+									<span
+										className="truncate font-mono text-xs font-medium"
+										title={key}
+									>
+										{key}
+									</span>
+									{isModified && isEditing && (
+										<Badge variant="default" className="h-4 px-1.5 text-[10px]">
+											New
+										</Badge>
+									)}
+								</div>
+								{isEditing ? (
+									<Input
+										value={value}
+										onChange={(e) => handleValueChange(key, e.target.value)}
+										aria-label={`Value for ${key}`}
+										className="h-8 font-mono text-xs"
+									/>
+								) : (
+									<span
+										className="truncate font-mono text-xs text-muted-foreground"
+										title={value}
+									>
+										{value}
+									</span>
+								)}
+								{isEditing ? (
+									<Button
+										variant="ghost"
+										size="icon"
+										onClick={() => handleDelete(key)}
+										className="h-8 w-8 text-muted-foreground hover:text-destructive"
+										title="Remove variable"
+									>
+										<Trash2 className="h-3.5 w-3.5" />
+									</Button>
+								) : (
+									<span />
+								)}
+							</div>
+						);
+					})}
 				</div>
 			)}
 
-			{/* Existing environment variables */}
-			{envEntries.map(([key, value]) => {
-				const isModified = modifiedKeys.has(key);
-				return (
-					<div
-						key={key}
-						className={`flex items-end gap-3 rounded-lg border p-3 transition-colors ${
-							deletedKeys.has(key)
-								? "opacity-50 bg-destructive/10"
-								: isModified && isEditing
-									? "border-primary/50 bg-primary/5 hover:bg-primary/10"
-									: "hover:bg-muted/50"
-						}`}
-					>
-						<div className="flex-1 space-y-2">
-							<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-								<div className="space-y-1.5">
-									<div className="flex items-center gap-2">
-										<Label
-											htmlFor={`key-${key}`}
-											className="text-xs font-medium"
-										>
-											Key
-										</Label>
-										{isModified && isEditing && (
-											<Badge
-												variant="default"
-												className="h-4 text-[10px] px-1.5"
-											>
-												New
-											</Badge>
-										)}
-									</div>
-									<Input
-										id={`key-${key}`}
-										value={key}
-										disabled
-										className="font-mono text-xs h-8"
-									/>
-								</div>
-								<div className="space-y-1.5">
-									<Label
-										htmlFor={`value-${key}`}
-										className="text-xs font-medium"
-									>
-										Value
-									</Label>
-									<Input
-										id={`value-${key}`}
-										value={value}
-										onChange={(e) => handleValueChange(key, e.target.value)}
-										disabled={!isEditing}
-										className="font-mono text-xs h-8"
-									/>
-								</div>
-							</div>
-						</div>
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={() => handleDelete(key)}
-							className="mb-0.5 h-8 w-8 text-muted-foreground hover:text-destructive"
-							disabled={!isEditing}
-							title={
-								isEditing ? "Mark for deletion" : "Edit to enable deletion"
-							}
-						>
-							<Trash2 className="h-3.5 w-3.5" />
-						</Button>
-					</div>
-				);
-			})}
-
-			{envEntries.length === 0 && isEditing && (
+			{envEntries.length === 0 && isEditing && !showAddNew && (
 				<div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
 					No environment variables. Click "Add" to create one.
 				</div>

--- a/frontend/src/features/containers/components/log-viewer/time-range-control.tsx
+++ b/frontend/src/features/containers/components/log-viewer/time-range-control.tsx
@@ -1,7 +1,10 @@
+import { format } from "date-fns";
 import { ClockIcon } from "lucide-react";
 import { useId, useState } from "react";
+import type { DateRange } from "react-day-picker";
 
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -31,20 +34,27 @@ interface TimeRangeControlProps {
 	disabled?: boolean;
 }
 
-// ISO timestamp <-> datetime-local input value (local time, minute precision).
-function toDateTimeLocalValue(iso: string | null): string {
-	if (!iso) return "";
-	const date = new Date(iso);
-	if (Number.isNaN(date.getTime())) return "";
-	const pad = (value: number) => String(value).padStart(2, "0");
-	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+// Combine a calendar day with an "HH:mm" time-of-day into an ISO timestamp.
+function combineDateAndTime(day: Date, time: string): string {
+	const [hours = 0, minutes = 0] = time.split(":").map(Number);
+	const date = new Date(day);
+	date.setHours(hours, minutes, 0, 0);
+	return date.toISOString();
 }
 
-function fromDateTimeLocalValue(value: string): string | null {
-	if (!value) return null;
-	const date = new Date(value);
-	if (Number.isNaN(date.getTime())) return null;
-	return date.toISOString();
+function toTimeValue(iso: string | null, fallback: string): string {
+	if (!iso) return fallback;
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return fallback;
+	return format(date, "HH:mm");
+}
+
+function customRangeLabel(timeRange: TimeRange): string {
+	if (!timeRange.since && !timeRange.until) return "Pick range";
+	const fmt = (iso: string | null) =>
+		iso ? format(new Date(iso), "MMM d, HH:mm") : "now";
+	if (!timeRange.since) return `Until ${fmt(timeRange.until)}`;
+	return `${fmt(timeRange.since)} – ${fmt(timeRange.until)}`;
 }
 
 export function TimeRangeControl({
@@ -53,14 +63,18 @@ export function TimeRangeControl({
 	disabled = false,
 }: TimeRangeControlProps) {
 	const [isCustomOpen, setIsCustomOpen] = useState(false);
-	const [sinceDraft, setSinceDraft] = useState("");
-	const [untilDraft, setUntilDraft] = useState("");
-	const sinceInputId = useId();
-	const untilInputId = useId();
+	const [draftRange, setDraftRange] = useState<DateRange | undefined>();
+	const [sinceTime, setSinceTime] = useState("00:00");
+	const [untilTime, setUntilTime] = useState("23:59");
+	const sinceTimeId = useId();
+	const untilTimeId = useId();
 
 	const openCustomEditor = () => {
-		setSinceDraft(toDateTimeLocalValue(timeRange.since));
-		setUntilDraft(toDateTimeLocalValue(timeRange.until));
+		const since = timeRange.since ? new Date(timeRange.since) : undefined;
+		const until = timeRange.until ? new Date(timeRange.until) : undefined;
+		setDraftRange(since || until ? { from: since, to: until } : undefined);
+		setSinceTime(toTimeValue(timeRange.since, "00:00"));
+		setUntilTime(toTimeValue(timeRange.until, "23:59"));
 		setIsCustomOpen(true);
 	};
 
@@ -77,8 +91,12 @@ export function TimeRangeControl({
 	const applyCustomRange = () => {
 		setTimeRange({
 			preset: "custom",
-			since: fromDateTimeLocalValue(sinceDraft),
-			until: fromDateTimeLocalValue(untilDraft),
+			since: draftRange?.from
+				? combineDateAndTime(draftRange.from, sinceTime)
+				: null,
+			until: draftRange?.to
+				? combineDateAndTime(draftRange.to, untilTime)
+				: null,
 		});
 		setIsCustomOpen(false);
 	};
@@ -112,35 +130,47 @@ export function TimeRangeControl({
 							onClick={openCustomEditor}
 							className="h-8 text-xs"
 						>
-							Edit
+							{customRangeLabel(timeRange)}
 						</Button>
 					</PopoverTrigger>
-					<PopoverContent align="start" className="w-72 space-y-3">
-						<div className="space-y-1.5">
-							<Label htmlFor={sinceInputId} className="text-xs">
-								From
-							</Label>
-							<Input
-								id={sinceInputId}
-								type="datetime-local"
-								value={sinceDraft}
-								onChange={(e) => setSinceDraft(e.target.value)}
-								className="h-8 text-xs"
-							/>
+					<PopoverContent align="start" className="w-auto p-3">
+						<Calendar
+							mode="range"
+							defaultMonth={draftRange?.from}
+							selected={draftRange}
+							onSelect={setDraftRange}
+						/>
+						<div className="mt-3 grid grid-cols-2 gap-3 border-t pt-3">
+							<div className="space-y-1.5">
+								<Label htmlFor={sinceTimeId} className="text-xs">
+									From time
+								</Label>
+								<Input
+									id={sinceTimeId}
+									type="time"
+									value={sinceTime}
+									onChange={(e) => setSinceTime(e.target.value)}
+									className="h-8 text-xs"
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor={untilTimeId} className="text-xs">
+									To time
+								</Label>
+								<Input
+									id={untilTimeId}
+									type="time"
+									value={untilTime}
+									onChange={(e) => setUntilTime(e.target.value)}
+									className="h-8 text-xs"
+								/>
+							</div>
 						</div>
-						<div className="space-y-1.5">
-							<Label htmlFor={untilInputId} className="text-xs">
-								To
-							</Label>
-							<Input
-								id={untilInputId}
-								type="datetime-local"
-								value={untilDraft}
-								onChange={(e) => setUntilDraft(e.target.value)}
-								className="h-8 text-xs"
-							/>
-						</div>
-						<Button size="sm" onClick={applyCustomRange} className="w-full">
+						<Button
+							size="sm"
+							onClick={applyCustomRange}
+							className="mt-3 w-full"
+						>
 							Apply
 						</Button>
 					</PopoverContent>

--- a/frontend/src/features/containers/components/selection-action-bar.tsx
+++ b/frontend/src/features/containers/components/selection-action-bar.tsx
@@ -5,122 +5,119 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface SelectionActionBarProps {
-  selectedCount: number;
-  onCopy: () => void;
-  onTogglePin: () => void;
-  pinActionLabel: "pin" | "unpin";
-  onClear: () => void;
+	selectedCount: number;
+	onCopy: () => void;
+	onTogglePin: () => void;
+	pinActionLabel: "pin" | "unpin";
+	onClear: () => void;
 }
 
 export function SelectionActionBar({
-  selectedCount,
-  onCopy,
-  onTogglePin,
-  pinActionLabel,
-  onClear,
+	selectedCount,
+	onCopy,
+	onTogglePin,
+	pinActionLabel,
+	onClear,
 }: SelectionActionBarProps) {
-  const [copied, setCopied] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
+	const [copied, setCopied] = useState(false);
+	const [isVisible, setIsVisible] = useState(false);
 
-  // Animate in/out based on selection
-  useEffect(() => {
-    if (selectedCount > 0) {
-      // Small delay for enter animation
-      const timer = setTimeout(() => setIsVisible(true), 10);
-      return () => clearTimeout(timer);
-    } else {
-      setIsVisible(false);
-    }
-  }, [selectedCount]);
+	// Animate in/out based on selection
+	useEffect(() => {
+		if (selectedCount > 0) {
+			// Small delay for enter animation
+			const timer = setTimeout(() => setIsVisible(true), 10);
+			return () => clearTimeout(timer);
+		} else {
+			setIsVisible(false);
+		}
+	}, [selectedCount]);
 
-  const handleCopy = useCallback(() => {
-    onCopy();
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  }, [onCopy]);
+	const handleCopy = useCallback(() => {
+		onCopy();
+		setCopied(true);
+		setTimeout(() => setCopied(false), 1500);
+	}, [onCopy]);
 
-  if (selectedCount === 0) return null;
+	if (selectedCount === 0) return null;
 
-  return (
-    <div
-      className={cn(
-        "sticky top-0 z-20 flex items-center justify-between gap-4 px-4 py-2",
-        "bg-primary/[0.06] border-b border-primary/20 backdrop-blur-sm",
-        "transition-all duration-300 ease-out",
-        isVisible
-          ? "opacity-100 translate-y-0"
-          : "opacity-0 -translate-y-2"
-      )}
-    >
-      {/* Selection indicator with animated dot */}
-      <div className="flex items-center gap-3">
-        <div className="relative flex items-center justify-center">
-          <span className="absolute size-2 rounded-full bg-primary/60 animate-ping" />
-          <span className="relative size-2 rounded-full bg-primary" />
-        </div>
-        <span className="text-sm font-medium text-foreground/90 tabular-nums">
-          <span className="text-primary font-semibold">{selectedCount}</span>
-          {" "}
-          {selectedCount === 1 ? "line" : "lines"} selected
-        </span>
-      </div>
+	return (
+		<div
+			className={cn(
+				"sticky top-0 z-20 flex items-center justify-between gap-4 px-4 py-2",
+				"bg-primary/[0.06] border-b border-primary/20 backdrop-blur-sm",
+				"transition-all duration-300 ease-out",
+				isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
+			)}
+		>
+			{/* Selection indicator with animated dot */}
+			<div className="flex items-center gap-3">
+				<div className="relative flex items-center justify-center">
+					<span className="absolute size-2 rounded-full bg-primary/60 animate-ping" />
+					<span className="relative size-2 rounded-full bg-primary" />
+				</div>
+				<span className="text-sm font-medium text-foreground/90 tabular-nums">
+					<span className="text-primary font-semibold">{selectedCount}</span>{" "}
+					{selectedCount === 1 ? "line" : "lines"} selected
+				</span>
+			</div>
 
-      {/* Action buttons */}
-      <div className="flex items-center gap-2">
-        <Button
-          size="sm"
-          onClick={handleCopy}
-          className={cn(
-            "h-7 px-3 text-xs font-medium gap-1.5",
-            "transition-all duration-200",
-            "shadow-sm hover:shadow",
-            copied && "bg-emerald-600 hover:bg-emerald-600"
-          )}
-        >
-          {copied ? (
-            <>
-              <CheckIcon className="size-3.5" />
-              Copied!
-            </>
-          ) : (
-            <>
-              <CopyIcon className="size-3.5" />
-              Copy
-            </>
-          )}
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={onTogglePin}
-          className="h-7 px-3 text-xs font-medium gap-1.5"
-        >
-          {pinActionLabel === "unpin" ? (
-            <>
-              <PinOffIcon className="size-3.5" />
-              Unpin
-            </>
-          ) : (
-            <>
-              <PinIcon className="size-3.5" />
-              Pin
-            </>
-          )}
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={onClear}
-          className={cn(
-            "h-7 w-7 p-0",
-            "text-muted-foreground hover:text-foreground",
-            "transition-colors duration-150"
-          )}
-          aria-label="Clear selection"
-        >
-          <XIcon className="size-3.5" />
-        </Button>
-      </div>
-    </div>
-  );
+			{/* Action buttons */}
+			<div className="flex items-center gap-2">
+				<Button
+					size="sm"
+					onClick={handleCopy}
+					className={cn(
+						"h-7 px-3 text-xs font-medium gap-1.5",
+						"transition-all duration-200",
+						"shadow-sm hover:shadow",
+						copied && "bg-emerald-600 hover:bg-emerald-600",
+					)}
+				>
+					{copied ? (
+						<>
+							<CheckIcon className="size-3.5" />
+							Copied!
+						</>
+					) : (
+						<>
+							<CopyIcon className="size-3.5" />
+							Copy
+						</>
+					)}
+				</Button>
+				<Button
+					size="sm"
+					variant="outline"
+					onClick={onTogglePin}
+					className="h-7 px-3 text-xs font-medium gap-1.5"
+				>
+					{pinActionLabel === "unpin" ? (
+						<>
+							<PinOffIcon className="size-3.5" />
+							Unpin
+						</>
+					) : (
+						<>
+							<PinIcon className="size-3.5" />
+							Pin
+						</>
+					)}
+				</Button>
+				<Button
+					size="sm"
+					variant="ghost"
+					onClick={onClear}
+					className={cn(
+						"h-7 w-7 p-0",
+						"text-muted-foreground hover:text-foreground",
+						"transition-colors duration-150",
+					)}
+					aria-label="Clear selection"
+				>
+					<XIcon className="size-3.5" />
+				</Button>
+			</div>
+		</div>
+	);
 }

--- a/frontend/src/features/containers/hooks/use-container-events.ts
+++ b/frontend/src/features/containers/hooks/use-container-events.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 import {
-  type ContainerEvent,
-  streamContainerEvents,
+	type ContainerEvent,
+	streamContainerEvents,
 } from "../api/get-container-events";
 
 import { useDocumentVisible } from "./use-document-visible";
@@ -16,51 +16,51 @@ const MAX_RETRY_DELAY_MS = 30_000;
  * paused entirely while the document is hidden and resumed on visibility.
  */
 export function useContainerEvents(onEvent: (event: ContainerEvent) => void) {
-  const [isConnected, setIsConnected] = useState(false);
-  const isVisible = useDocumentVisible();
-  const onEventRef = useRef(onEvent);
+	const [isConnected, setIsConnected] = useState(false);
+	const isVisible = useDocumentVisible();
+	const onEventRef = useRef(onEvent);
 
-  useEffect(() => {
-    onEventRef.current = onEvent;
-  }, [onEvent]);
+	useEffect(() => {
+		onEventRef.current = onEvent;
+	}, [onEvent]);
 
-  useEffect(() => {
-    if (!isVisible) return;
+	useEffect(() => {
+		if (!isVisible) return;
 
-    const abortController = new AbortController();
-    let retryDelay = INITIAL_RETRY_DELAY_MS;
-    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+		const abortController = new AbortController();
+		let retryDelay = INITIAL_RETRY_DELAY_MS;
+		let retryTimeout: ReturnType<typeof setTimeout> | null = null;
 
-    const subscribe = async () => {
-      try {
-        const stream = streamContainerEvents(abortController.signal, () => {
-          setIsConnected(true);
-          retryDelay = INITIAL_RETRY_DELAY_MS;
-        });
-        for await (const event of stream) {
-          onEventRef.current(event);
-        }
-      } catch {}
+		const subscribe = async () => {
+			try {
+				const stream = streamContainerEvents(abortController.signal, () => {
+					setIsConnected(true);
+					retryDelay = INITIAL_RETRY_DELAY_MS;
+				});
+				for await (const event of stream) {
+					onEventRef.current(event);
+				}
+			} catch {}
 
-      setIsConnected(false);
-      if (abortController.signal.aborted) return;
+			setIsConnected(false);
+			if (abortController.signal.aborted) return;
 
-      retryTimeout = setTimeout(() => {
-        void subscribe();
-      }, retryDelay);
-      retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY_MS);
-    };
+			retryTimeout = setTimeout(() => {
+				void subscribe();
+			}, retryDelay);
+			retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY_MS);
+		};
 
-    void subscribe();
+		void subscribe();
 
-    return () => {
-      abortController.abort();
-      if (retryTimeout) {
-        clearTimeout(retryTimeout);
-      }
-      setIsConnected(false);
-    };
-  }, [isVisible]);
+		return () => {
+			abortController.abort();
+			if (retryTimeout) {
+				clearTimeout(retryTimeout);
+			}
+			setIsConnected(false);
+		};
+	}, [isVisible]);
 
-  return { isConnected };
+	return { isConnected };
 }

--- a/frontend/src/features/containers/hooks/use-container-log-stream.test.ts
+++ b/frontend/src/features/containers/hooks/use-container-log-stream.test.ts
@@ -33,7 +33,7 @@ function createControlledStream() {
 	};
 
 	async function* stream(
-		signal?: AbortSignal
+		signal?: AbortSignal,
 	): AsyncGenerator<TestEntry | LogStreamHeartbeat, void, unknown> {
 		while (true) {
 			while (queue.length > 0) {
@@ -65,12 +65,8 @@ function setup(options?: { maxLogLines?: number }) {
 	const scrollToBottom = vi.fn();
 	const renderCount = { current: 0 };
 	const streamLogs = vi.fn(
-		(
-			_id: string,
-			_host: string,
-			_options: unknown,
-			signal: AbortSignal
-		) => controlled.stream(signal)
+		(_id: string, _host: string, _options: unknown, signal: AbortSignal) =>
+			controlled.stream(signal),
 	);
 
 	const hook = renderHook(() => {

--- a/frontend/src/features/containers/hooks/use-container-log-stream.ts
+++ b/frontend/src/features/containers/hooks/use-container-log-stream.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
-  type ContainerLogsOptions,
-  isLogStreamHeartbeat,
-  type LogStreamHeartbeat,
+	type ContainerLogsOptions,
+	isLogStreamHeartbeat,
+	type LogStreamHeartbeat,
 } from "@/features/containers/api/get-container-logs-parsed";
 
 export const DEFAULT_MAX_LOG_LINES = 10000;
@@ -17,489 +17,505 @@ const RECONNECT_MAX_DELAY_MS = 30_000;
 
 // Resolves after ms, or immediately when the signal aborts.
 function waitWithSignal(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(onDone, ms);
-    function onDone() {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", onDone);
-      resolve();
-    }
-    signal.addEventListener("abort", onDone);
-  });
+	return new Promise((resolve) => {
+		const timer = setTimeout(onDone, ms);
+		function onDone() {
+			clearTimeout(timer);
+			signal.removeEventListener("abort", onDone);
+			resolve();
+		}
+		signal.addEventListener("abort", onDone);
+	});
 }
 
 interface UseContainerLogStreamOptions<TLogEntry> {
-  containerId?: string;
-  host?: string;
-  tail: number;
-  search?: string;
-  // Time bounds for historical fetches (RFC3339). Live streaming ignores
-  // them and always follows from now.
-  since?: string;
-  until?: string;
-  maxLogLines?: number;
-  getLogs: (
-    containerId: string,
-    host: string,
-    options: ContainerLogsOptions
-  ) => Promise<TLogEntry[]>;
-  streamLogs: (
-    containerId: string,
-    host: string,
-    options: ContainerLogsOptions,
-    signal: AbortSignal
-  ) => AsyncGenerator<TLogEntry | LogStreamHeartbeat, void, unknown>;
-  scrollToBottom: (behavior?: ScrollBehavior) => void;
-  onResetState?: () => void;
-  onFetchError?: (error: Error) => void;
-  onStreamError?: (error: Error) => void;
+	containerId?: string;
+	host?: string;
+	tail: number;
+	search?: string;
+	// Time bounds for historical fetches (RFC3339). Live streaming ignores
+	// them and always follows from now.
+	since?: string;
+	until?: string;
+	maxLogLines?: number;
+	getLogs: (
+		containerId: string,
+		host: string,
+		options: ContainerLogsOptions,
+	) => Promise<TLogEntry[]>;
+	streamLogs: (
+		containerId: string,
+		host: string,
+		options: ContainerLogsOptions,
+		signal: AbortSignal,
+	) => AsyncGenerator<TLogEntry | LogStreamHeartbeat, void, unknown>;
+	scrollToBottom: (behavior?: ScrollBehavior) => void;
+	onResetState?: () => void;
+	onFetchError?: (error: Error) => void;
+	onStreamError?: (error: Error) => void;
 }
 
 export function useContainerLogStream<TLogEntry>({
-  containerId,
-  host,
-  tail,
-  search,
-  since,
-  until,
-  maxLogLines = DEFAULT_MAX_LOG_LINES,
-  getLogs,
-  streamLogs,
-  scrollToBottom,
-  onResetState,
-  onFetchError,
-  onStreamError,
+	containerId,
+	host,
+	tail,
+	search,
+	since,
+	until,
+	maxLogLines = DEFAULT_MAX_LOG_LINES,
+	getLogs,
+	streamLogs,
+	scrollToBottom,
+	onResetState,
+	onFetchError,
+	onStreamError,
 }: UseContainerLogStreamOptions<TLogEntry>) {
-  const [logs, setLogs] = useState<TLogEntry[]>([]);
-  const [isLoadingLogs, setIsLoadingLogs] = useState(false);
-  const [isStreaming, setIsStreaming] = useState(false);
-  const [isReconnecting, setIsReconnecting] = useState(false);
-  const [isStreamPaused, setIsStreamPaused] = useState(false);
-  const [bufferedCount, setBufferedCount] = useState(0);
-  const [droppedCount, setDroppedCount] = useState(0);
-  const [bufferedDroppedCount, setBufferedDroppedCount] = useState(0);
-  const [animatedRange, setAnimatedRange] = useState<{
-    start: number;
-    end: number;
-  } | null>(null);
+	const [logs, setLogs] = useState<TLogEntry[]>([]);
+	const [isLoadingLogs, setIsLoadingLogs] = useState(false);
+	const [isStreaming, setIsStreaming] = useState(false);
+	const [isReconnecting, setIsReconnecting] = useState(false);
+	const [isStreamPaused, setIsStreamPaused] = useState(false);
+	const [bufferedCount, setBufferedCount] = useState(0);
+	const [droppedCount, setDroppedCount] = useState(0);
+	const [bufferedDroppedCount, setBufferedDroppedCount] = useState(0);
+	const [animatedRange, setAnimatedRange] = useState<{
+		start: number;
+		end: number;
+	} | null>(null);
 
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const stopRequestedRef = useRef(false);
-  const lastActivityRef = useRef(0);
-  const isStreamPausedRef = useRef(false);
-  const bufferedLogsRef = useRef<TLogEntry[]>([]);
-  const pendingLogsRef = useRef<TLogEntry[]>([]);
-  const logsLengthRef = useRef(0);
-  const droppedCountRef = useRef(0);
-  const bufferedDroppedCountRef = useRef(0);
-  const maxLogLinesRef = useRef(maxLogLines);
-  const flushIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const getLogsRef = useRef(getLogs);
-  const streamLogsRef = useRef(streamLogs);
-  const scrollToBottomRef = useRef(scrollToBottom);
-  const onResetStateRef = useRef(onResetState);
-  const onFetchErrorRef = useRef(onFetchError);
-  const onStreamErrorRef = useRef(onStreamError);
+	const abortControllerRef = useRef<AbortController | null>(null);
+	const stopRequestedRef = useRef(false);
+	const lastActivityRef = useRef(0);
+	const isStreamPausedRef = useRef(false);
+	const bufferedLogsRef = useRef<TLogEntry[]>([]);
+	const pendingLogsRef = useRef<TLogEntry[]>([]);
+	const logsLengthRef = useRef(0);
+	const droppedCountRef = useRef(0);
+	const bufferedDroppedCountRef = useRef(0);
+	const maxLogLinesRef = useRef(maxLogLines);
+	const flushIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const getLogsRef = useRef(getLogs);
+	const streamLogsRef = useRef(streamLogs);
+	const scrollToBottomRef = useRef(scrollToBottom);
+	const onResetStateRef = useRef(onResetState);
+	const onFetchErrorRef = useRef(onFetchError);
+	const onStreamErrorRef = useRef(onStreamError);
 
-  useEffect(() => {
-    isStreamPausedRef.current = isStreamPaused;
-  }, [isStreamPaused]);
+	useEffect(() => {
+		isStreamPausedRef.current = isStreamPaused;
+	}, [isStreamPaused]);
 
-  useEffect(() => {
-    maxLogLinesRef.current = maxLogLines;
-  }, [maxLogLines]);
+	useEffect(() => {
+		maxLogLinesRef.current = maxLogLines;
+	}, [maxLogLines]);
 
-  useEffect(() => {
-    getLogsRef.current = getLogs;
-  }, [getLogs]);
+	useEffect(() => {
+		getLogsRef.current = getLogs;
+	}, [getLogs]);
 
-  useEffect(() => {
-    streamLogsRef.current = streamLogs;
-  }, [streamLogs]);
+	useEffect(() => {
+		streamLogsRef.current = streamLogs;
+	}, [streamLogs]);
 
-  useEffect(() => {
-    scrollToBottomRef.current = scrollToBottom;
-  }, [scrollToBottom]);
+	useEffect(() => {
+		scrollToBottomRef.current = scrollToBottom;
+	}, [scrollToBottom]);
 
-  useEffect(() => {
-    onResetStateRef.current = onResetState;
-  }, [onResetState]);
+	useEffect(() => {
+		onResetStateRef.current = onResetState;
+	}, [onResetState]);
 
-  useEffect(() => {
-    onFetchErrorRef.current = onFetchError;
-  }, [onFetchError]);
+	useEffect(() => {
+		onFetchErrorRef.current = onFetchError;
+	}, [onFetchError]);
 
-  useEffect(() => {
-    onStreamErrorRef.current = onStreamError;
-  }, [onStreamError]);
+	useEffect(() => {
+		onStreamErrorRef.current = onStreamError;
+	}, [onStreamError]);
 
-  const resetPauseAndBuffer = useCallback(() => {
-    setIsStreamPaused(false);
-    setBufferedCount(0);
-    isStreamPausedRef.current = false;
-    bufferedLogsRef.current = [];
-  }, []);
+	const resetPauseAndBuffer = useCallback(() => {
+		setIsStreamPaused(false);
+		setBufferedCount(0);
+		isStreamPausedRef.current = false;
+		bufferedLogsRef.current = [];
+	}, []);
 
-  const resetDroppedCount = useCallback(() => {
-    droppedCountRef.current = 0;
-    setDroppedCount(0);
-    bufferedDroppedCountRef.current = 0;
-    setBufferedDroppedCount(0);
-  }, []);
+	const resetDroppedCount = useCallback(() => {
+		droppedCountRef.current = 0;
+		setDroppedCount(0);
+		bufferedDroppedCountRef.current = 0;
+		setBufferedDroppedCount(0);
+	}, []);
 
-  // Entries dropped from the front of the displayed `logs` array. Consumers
-  // shift index-based bookkeeping (pins) by this value, so it must never
-  // include entries that were dropped before they were displayed.
-  const recordDroppedLines = useCallback((count: number) => {
-    if (count <= 0) return;
-    droppedCountRef.current += count;
-    setDroppedCount(droppedCountRef.current);
-  }, []);
+	// Entries dropped from the front of the displayed `logs` array. Consumers
+	// shift index-based bookkeeping (pins) by this value, so it must never
+	// include entries that were dropped before they were displayed.
+	const recordDroppedLines = useCallback((count: number) => {
+		if (count <= 0) return;
+		droppedCountRef.current += count;
+		setDroppedCount(droppedCountRef.current);
+	}, []);
 
-  // Entries dropped before ever reaching the displayed array (paused-backlog
-  // trims, pending overflow within a single flush window).
-  const recordBufferedDroppedLines = useCallback((count: number) => {
-    if (count <= 0) return;
-    bufferedDroppedCountRef.current += count;
-    setBufferedDroppedCount(bufferedDroppedCountRef.current);
-  }, []);
+	// Entries dropped before ever reaching the displayed array (paused-backlog
+	// trims, pending overflow within a single flush window).
+	const recordBufferedDroppedLines = useCallback((count: number) => {
+		if (count <= 0) return;
+		bufferedDroppedCountRef.current += count;
+		setBufferedDroppedCount(bufferedDroppedCountRef.current);
+	}, []);
 
-  const scheduleScrollToBottom = useCallback(
-    (delay: number, behavior?: ScrollBehavior) => {
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      scrollTimeoutRef.current = setTimeout(() => {
-        scrollTimeoutRef.current = null;
-        scrollToBottomRef.current(behavior);
-      }, delay);
-    },
-    []
-  );
+	const scheduleScrollToBottom = useCallback(
+		(delay: number, behavior?: ScrollBehavior) => {
+			if (scrollTimeoutRef.current) {
+				clearTimeout(scrollTimeoutRef.current);
+			}
+			scrollTimeoutRef.current = setTimeout(() => {
+				scrollTimeoutRef.current = null;
+				scrollToBottomRef.current(behavior);
+			}, delay);
+		},
+		[],
+	);
 
-  const triggerRowAnimation = useCallback((start: number, end: number) => {
-    if (animationTimeoutRef.current) {
-      clearTimeout(animationTimeoutRef.current);
-    }
-    setAnimatedRange({ start, end });
-    animationTimeoutRef.current = setTimeout(() => {
-      setAnimatedRange(null);
-    }, 260);
-  }, []);
+	const triggerRowAnimation = useCallback((start: number, end: number) => {
+		if (animationTimeoutRef.current) {
+			clearTimeout(animationTimeoutRef.current);
+		}
+		setAnimatedRange({ start, end });
+		animationTimeoutRef.current = setTimeout(() => {
+			setAnimatedRange(null);
+		}, 260);
+	}, []);
 
-  // Flush accumulated entries into state: one setLogs (with the ring-buffer
-  // cap applied) and one scheduled scroll per flush.
-  const flushPendingLogs = useCallback(
-    (scrollBehavior?: ScrollBehavior) => {
-      const pending = pendingLogsRef.current;
-      if (pending.length === 0) return;
-      pendingLogsRef.current = [];
+	// Flush accumulated entries into state: one setLogs (with the ring-buffer
+	// cap applied) and one scheduled scroll per flush.
+	const flushPendingLogs = useCallback(
+		(scrollBehavior?: ScrollBehavior) => {
+			const pending = pendingLogsRef.current;
+			if (pending.length === 0) return;
+			pendingLogsRef.current = [];
 
-      const max = maxLogLinesRef.current;
-      const prevLength = logsLengthRef.current;
-      const total = prevLength + pending.length;
-      const dropped = Math.max(0, total - max);
-      // Drops come off the front of concat(displayed, pending), so at most
-      // prevLength of them shift the displayed indices.
-      const droppedFromDisplayed = Math.min(prevLength, dropped);
-      const nextLength = total - dropped;
+			const max = maxLogLinesRef.current;
+			const prevLength = logsLengthRef.current;
+			const total = prevLength + pending.length;
+			const dropped = Math.max(0, total - max);
+			// Drops come off the front of concat(displayed, pending), so at most
+			// prevLength of them shift the displayed indices.
+			const droppedFromDisplayed = Math.min(prevLength, dropped);
+			const nextLength = total - dropped;
 
-      setLogs((prev) => {
-        const next = prev.concat(pending);
-        return next.length > max ? next.slice(next.length - max) : next;
-      });
-      logsLengthRef.current = nextLength;
-      recordDroppedLines(droppedFromDisplayed);
-      recordBufferedDroppedLines(dropped - droppedFromDisplayed);
-      triggerRowAnimation(Math.max(0, nextLength - pending.length), nextLength - 1);
-      scheduleScrollToBottom(scrollBehavior === "smooth" ? 40 : 100, scrollBehavior);
-    },
-    [
-      recordBufferedDroppedLines,
-      recordDroppedLines,
-      scheduleScrollToBottom,
-      triggerRowAnimation,
-    ]
-  );
+			setLogs((prev) => {
+				const next = prev.concat(pending);
+				return next.length > max ? next.slice(next.length - max) : next;
+			});
+			logsLengthRef.current = nextLength;
+			recordDroppedLines(droppedFromDisplayed);
+			recordBufferedDroppedLines(dropped - droppedFromDisplayed);
+			triggerRowAnimation(
+				Math.max(0, nextLength - pending.length),
+				nextLength - 1,
+			);
+			scheduleScrollToBottom(
+				scrollBehavior === "smooth" ? 40 : 100,
+				scrollBehavior,
+			);
+		},
+		[
+			recordBufferedDroppedLines,
+			recordDroppedLines,
+			scheduleScrollToBottom,
+			triggerRowAnimation,
+		],
+	);
 
-  // While paused, keep the buffered backlog capped and sync its count on the
-  // flush cadence instead of per line. Backlog trims never touch the
-  // displayed array, so they must not feed the pin-shift counter.
-  const syncBufferedLogs = useCallback(() => {
-    const buffered = bufferedLogsRef.current;
-    const max = maxLogLinesRef.current;
-    if (buffered.length > max) {
-      recordBufferedDroppedLines(buffered.length - max);
-      buffered.splice(0, buffered.length - max);
-    }
-    setBufferedCount(buffered.length);
-  }, [recordBufferedDroppedLines]);
+	// While paused, keep the buffered backlog capped and sync its count on the
+	// flush cadence instead of per line. Backlog trims never touch the
+	// displayed array, so they must not feed the pin-shift counter.
+	const syncBufferedLogs = useCallback(() => {
+		const buffered = bufferedLogsRef.current;
+		const max = maxLogLinesRef.current;
+		if (buffered.length > max) {
+			recordBufferedDroppedLines(buffered.length - max);
+			buffered.splice(0, buffered.length - max);
+		}
+		setBufferedCount(buffered.length);
+	}, [recordBufferedDroppedLines]);
 
-  const handleFlushTick = useCallback(() => {
-    // Idle watchdog: abort a stream that has gone silent past the timeout so
-    // the loop in startStreaming reconnects. Aborting an already-aborted
-    // controller is a no-op.
-    if (
-      abortControllerRef.current &&
-      Date.now() - lastActivityRef.current > STREAM_IDLE_TIMEOUT_MS
-    ) {
-      abortControllerRef.current.abort();
-    }
-    if (isStreamPausedRef.current) {
-      syncBufferedLogs();
-      return;
-    }
-    flushPendingLogs();
-  }, [flushPendingLogs, syncBufferedLogs]);
+	const handleFlushTick = useCallback(() => {
+		// Idle watchdog: abort a stream that has gone silent past the timeout so
+		// the loop in startStreaming reconnects. Aborting an already-aborted
+		// controller is a no-op.
+		if (
+			abortControllerRef.current &&
+			Date.now() - lastActivityRef.current > STREAM_IDLE_TIMEOUT_MS
+		) {
+			abortControllerRef.current.abort();
+		}
+		if (isStreamPausedRef.current) {
+			syncBufferedLogs();
+			return;
+		}
+		flushPendingLogs();
+	}, [flushPendingLogs, syncBufferedLogs]);
 
-  const stopFlushInterval = useCallback(() => {
-    if (flushIntervalRef.current) {
-      clearInterval(flushIntervalRef.current);
-      flushIntervalRef.current = null;
-    }
-  }, []);
+	const stopFlushInterval = useCallback(() => {
+		if (flushIntervalRef.current) {
+			clearInterval(flushIntervalRef.current);
+			flushIntervalRef.current = null;
+		}
+	}, []);
 
-  useEffect(() => {
-    return () => {
-      if (animationTimeoutRef.current) {
-        clearTimeout(animationTimeoutRef.current);
-      }
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      if (flushIntervalRef.current) {
-        clearInterval(flushIntervalRef.current);
-      }
-    };
-  }, []);
+	useEffect(() => {
+		return () => {
+			if (animationTimeoutRef.current) {
+				clearTimeout(animationTimeoutRef.current);
+			}
+			if (scrollTimeoutRef.current) {
+				clearTimeout(scrollTimeoutRef.current);
+			}
+			if (flushIntervalRef.current) {
+				clearInterval(flushIntervalRef.current);
+			}
+		};
+	}, []);
 
-  const fetchLogs = useCallback(async () => {
-    if (!containerId || !host) return;
+	const fetchLogs = useCallback(async () => {
+		if (!containerId || !host) return;
 
-    setIsLoadingLogs(true);
-    resetPauseAndBuffer();
-    resetDroppedCount();
-    onResetStateRef.current?.();
-    try {
-      const logEntries = await getLogsRef.current(containerId, host, {
-        tail,
-        search,
-        since,
-        until,
-      });
-      const max = maxLogLinesRef.current;
-      const capped =
-        logEntries.length > max ? logEntries.slice(logEntries.length - max) : logEntries;
-      setLogs(capped);
-      logsLengthRef.current = capped.length;
-      recordDroppedLines(logEntries.length - capped.length);
-      scheduleScrollToBottom(100);
-    } catch (error) {
-      if (error instanceof Error) {
-        onFetchErrorRef.current?.(error);
-      }
-      setLogs([]);
-      logsLengthRef.current = 0;
-    } finally {
-      setIsLoadingLogs(false);
-    }
-  }, [
-    containerId,
-    host,
-    recordDroppedLines,
-    resetDroppedCount,
-    resetPauseAndBuffer,
-    scheduleScrollToBottom,
-    tail,
-    search,
-    since,
-    until,
-  ]);
+		setIsLoadingLogs(true);
+		resetPauseAndBuffer();
+		resetDroppedCount();
+		onResetStateRef.current?.();
+		try {
+			const logEntries = await getLogsRef.current(containerId, host, {
+				tail,
+				search,
+				since,
+				until,
+			});
+			const max = maxLogLinesRef.current;
+			const capped =
+				logEntries.length > max
+					? logEntries.slice(logEntries.length - max)
+					: logEntries;
+			setLogs(capped);
+			logsLengthRef.current = capped.length;
+			recordDroppedLines(logEntries.length - capped.length);
+			scheduleScrollToBottom(100);
+		} catch (error) {
+			if (error instanceof Error) {
+				onFetchErrorRef.current?.(error);
+			}
+			setLogs([]);
+			logsLengthRef.current = 0;
+		} finally {
+			setIsLoadingLogs(false);
+		}
+	}, [
+		containerId,
+		host,
+		recordDroppedLines,
+		resetDroppedCount,
+		resetPauseAndBuffer,
+		scheduleScrollToBottom,
+		tail,
+		search,
+		since,
+		until,
+	]);
 
-  const stopStreaming = useCallback(() => {
-    stopRequestedRef.current = true;
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-      abortControllerRef.current = null;
-    }
-    resetPauseAndBuffer();
-    setIsStreaming(false);
-    setIsReconnecting(false);
-  }, [resetPauseAndBuffer]);
+	const stopStreaming = useCallback(() => {
+		stopRequestedRef.current = true;
+		if (abortControllerRef.current) {
+			abortControllerRef.current.abort();
+			abortControllerRef.current = null;
+		}
+		resetPauseAndBuffer();
+		setIsStreaming(false);
+		setIsReconnecting(false);
+	}, [resetPauseAndBuffer]);
 
-  const startStreaming = useCallback(async () => {
-    if (!containerId || !host) return;
+	const startStreaming = useCallback(async () => {
+		if (!containerId || !host) return;
 
-    setIsStreaming(true);
-    setIsLoadingLogs(true);
-    resetPauseAndBuffer();
-    resetDroppedCount();
-    onResetStateRef.current?.();
-    setLogs([]);
-    logsLengthRef.current = 0;
-    pendingLogsRef.current = [];
+		setIsStreaming(true);
+		setIsLoadingLogs(true);
+		resetPauseAndBuffer();
+		resetDroppedCount();
+		onResetStateRef.current?.();
+		setLogs([]);
+		logsLengthRef.current = 0;
+		pendingLogsRef.current = [];
 
-    stopRequestedRef.current = false;
-    let abortController: AbortController | null = null;
-    let hasReceivedFirstEntry = false;
+		stopRequestedRef.current = false;
+		let abortController: AbortController | null = null;
+		let hasReceivedFirstEntry = false;
 
-    stopFlushInterval();
-    flushIntervalRef.current = setInterval(handleFlushTick, STREAM_FLUSH_INTERVAL_MS);
+		stopFlushInterval();
+		flushIntervalRef.current = setInterval(
+			handleFlushTick,
+			STREAM_FLUSH_INTERVAL_MS,
+		);
 
-    try {
-      // One iteration per connection. A session that ends or errors without
-      // the user stopping it is retried with capped exponential backoff;
-      // receiving anything (entry or heartbeat) resets the backoff.
-      for (let attempt = 0; ; attempt++) {
-        abortController = new AbortController();
-        abortControllerRef.current = abortController;
-        lastActivityRef.current = Date.now();
+		try {
+			// One iteration per connection. A session that ends or errors without
+			// the user stopping it is retried with capped exponential backoff;
+			// receiving anything (entry or heartbeat) resets the backoff.
+			for (let attempt = 0; ; attempt++) {
+				abortController = new AbortController();
+				abortControllerRef.current = abortController;
+				lastActivityRef.current = Date.now();
 
-        if (attempt > 0) {
-          setIsReconnecting(true);
-          await waitWithSignal(
-            Math.min(RECONNECT_MIN_DELAY_MS * 2 ** (attempt - 1), RECONNECT_MAX_DELAY_MS),
-            abortController.signal
-          );
-          if (stopRequestedRef.current || abortController.signal.aborted) {
-            break;
-          }
-        }
+				if (attempt > 0) {
+					setIsReconnecting(true);
+					await waitWithSignal(
+						Math.min(
+							RECONNECT_MIN_DELAY_MS * 2 ** (attempt - 1),
+							RECONNECT_MAX_DELAY_MS,
+						),
+						abortController.signal,
+					);
+					if (stopRequestedRef.current || abortController.signal.aborted) {
+						break;
+					}
+				}
 
-        try {
-          const stream = streamLogsRef.current(
-            containerId,
-            host,
-            // Reconnects follow from "now" so lines already on screen are
-            // not re-fetched and duplicated.
-            { tail: attempt === 0 ? tail : 0, search },
-            abortController.signal
-          );
+				try {
+					const stream = streamLogsRef.current(
+						containerId,
+						host,
+						// Reconnects follow from "now" so lines already on screen are
+						// not re-fetched and duplicated.
+						{ tail: attempt === 0 ? tail : 0, search },
+						abortController.signal,
+					);
 
-          for await (const item of stream) {
-            if (abortController.signal.aborted) {
-              break;
-            }
+					for await (const item of stream) {
+						if (abortController.signal.aborted) {
+							break;
+						}
 
-            lastActivityRef.current = Date.now();
-            attempt = 0;
-            setIsReconnecting(false);
+						lastActivityRef.current = Date.now();
+						attempt = 0;
+						setIsReconnecting(false);
 
-            if (!hasReceivedFirstEntry) {
-              hasReceivedFirstEntry = true;
-              setIsLoadingLogs(false);
-            }
+						if (!hasReceivedFirstEntry) {
+							hasReceivedFirstEntry = true;
+							setIsLoadingLogs(false);
+						}
 
-            if (isLogStreamHeartbeat(item)) {
-              continue;
-            }
-            const entry = item as TLogEntry;
+						if (isLogStreamHeartbeat(item)) {
+							continue;
+						}
+						const entry = item as TLogEntry;
 
-            if (isStreamPausedRef.current) {
-              bufferedLogsRef.current.push(entry);
-              continue;
-            }
+						if (isStreamPausedRef.current) {
+							bufferedLogsRef.current.push(entry);
+							continue;
+						}
 
-            pendingLogsRef.current.push(entry);
-          }
-        } catch (error) {
-          if (error instanceof Error) {
-            const message = error.message.toLowerCase();
-            const isAbort =
-              error.name === "AbortError" || message.includes("aborted");
-            // Reconnect attempts fail quietly; isReconnecting is the signal.
-            if (!isAbort && attempt === 0) {
-              onStreamErrorRef.current?.(error);
-            }
-          }
-        }
+						pendingLogsRef.current.push(entry);
+					}
+				} catch (error) {
+					if (error instanceof Error) {
+						const message = error.message.toLowerCase();
+						const isAbort =
+							error.name === "AbortError" || message.includes("aborted");
+						// Reconnect attempts fail quietly; isReconnecting is the signal.
+						if (!isAbort && attempt === 0) {
+							onStreamErrorRef.current?.(error);
+						}
+					}
+				}
 
-        if (
-          stopRequestedRef.current ||
-          abortControllerRef.current !== abortController
-        ) {
-          break;
-        }
-      }
-    } finally {
-      stopFlushInterval();
-      flushPendingLogs();
-      setIsLoadingLogs(false);
-      setIsStreaming(false);
-      setIsReconnecting(false);
-      if (abortControllerRef.current === abortController) {
-        abortControllerRef.current = null;
-      }
-    }
-  }, [
-    containerId,
-    host,
-    flushPendingLogs,
-    handleFlushTick,
-    resetDroppedCount,
-    resetPauseAndBuffer,
-    stopFlushInterval,
-    tail,
-    search,
-  ]);
+				if (
+					stopRequestedRef.current ||
+					abortControllerRef.current !== abortController
+				) {
+					break;
+				}
+			}
+		} finally {
+			stopFlushInterval();
+			flushPendingLogs();
+			setIsLoadingLogs(false);
+			setIsStreaming(false);
+			setIsReconnecting(false);
+			if (abortControllerRef.current === abortController) {
+				abortControllerRef.current = null;
+			}
+		}
+	}, [
+		containerId,
+		host,
+		flushPendingLogs,
+		handleFlushTick,
+		resetDroppedCount,
+		resetPauseAndBuffer,
+		stopFlushInterval,
+		tail,
+		search,
+	]);
 
-  const toggleStreaming = useCallback(() => {
-    if (isStreaming) {
-      stopStreaming();
-      return;
-    }
-    void startStreaming();
-  }, [isStreaming, startStreaming, stopStreaming]);
+	const toggleStreaming = useCallback(() => {
+		if (isStreaming) {
+			stopStreaming();
+			return;
+		}
+		void startStreaming();
+	}, [isStreaming, startStreaming, stopStreaming]);
 
-  const togglePauseStreaming = useCallback(() => {
-    if (!isStreaming) return;
+	const togglePauseStreaming = useCallback(() => {
+		if (!isStreaming) return;
 
-    if (isStreamPaused) {
-      isStreamPausedRef.current = false;
-      setIsStreamPaused(false);
-      setBufferedCount(0);
-      if (bufferedLogsRef.current.length > 0) {
-        pendingLogsRef.current = pendingLogsRef.current.concat(
-          bufferedLogsRef.current
-        );
-        bufferedLogsRef.current = [];
-        flushPendingLogs("smooth");
-      }
-      return;
-    }
+		if (isStreamPaused) {
+			isStreamPausedRef.current = false;
+			setIsStreamPaused(false);
+			setBufferedCount(0);
+			if (bufferedLogsRef.current.length > 0) {
+				pendingLogsRef.current = pendingLogsRef.current.concat(
+					bufferedLogsRef.current,
+				);
+				bufferedLogsRef.current = [];
+				flushPendingLogs("smooth");
+			}
+			return;
+		}
 
-    // Land any entries that arrived before pausing so the view is current.
-    flushPendingLogs();
-    isStreamPausedRef.current = true;
-    setIsStreamPaused(true);
-  }, [flushPendingLogs, isStreamPaused, isStreaming]);
+		// Land any entries that arrived before pausing so the view is current.
+		flushPendingLogs();
+		isStreamPausedRef.current = true;
+		setIsStreamPaused(true);
+	}, [flushPendingLogs, isStreamPaused, isStreaming]);
 
-  const clearLogs = useCallback(() => {
-    pendingLogsRef.current = [];
-    setLogs([]);
-    logsLengthRef.current = 0;
-    resetDroppedCount();
-  }, [resetDroppedCount]);
+	const clearLogs = useCallback(() => {
+		pendingLogsRef.current = [];
+		setLogs([]);
+		logsLengthRef.current = 0;
+		resetDroppedCount();
+	}, [resetDroppedCount]);
 
-  return {
-    bufferedCount,
-    animatedRange,
-    bufferedDroppedCount,
-    clearLogs,
-    droppedCount,
-    fetchLogs,
-    isLoadingLogs,
-    isReconnecting,
-    isStreamPaused,
-    isStreaming,
-    logs,
-    maxLogLines,
-    setLogs,
-    startStreaming,
-    stopStreaming,
-    togglePauseStreaming,
-    toggleStreaming,
-  };
+	return {
+		bufferedCount,
+		animatedRange,
+		bufferedDroppedCount,
+		clearLogs,
+		droppedCount,
+		fetchLogs,
+		isLoadingLogs,
+		isReconnecting,
+		isStreamPaused,
+		isStreaming,
+		logs,
+		maxLogLines,
+		setLogs,
+		startStreaming,
+		stopStreaming,
+		togglePauseStreaming,
+		toggleStreaming,
+	};
 }

--- a/frontend/src/features/containers/hooks/use-container-stats.ts
+++ b/frontend/src/features/containers/hooks/use-container-stats.ts
@@ -8,29 +8,29 @@ import { useDocumentVisible } from "./use-document-visible";
 import { useContainerStatsHistory } from "./use-stats-history";
 
 export function useContainerStats() {
-  const isVisible = useDocumentVisible();
-  const query = useQuery({
-    queryKey: ["containers", "stats"],
-    queryFn: getContainerStats,
-    refetchInterval: isVisible ? 5000 : false, // Refresh every 5 seconds while the page is visible
-    staleTime: 4000, // Consider stale after 4 seconds
-  });
+	const isVisible = useDocumentVisible();
+	const query = useQuery({
+		queryKey: ["containers", "stats"],
+		queryFn: getContainerStats,
+		refetchInterval: isVisible ? 5000 : false, // Refresh every 5 seconds while the page is visible
+		staleTime: 4000, // Consider stale after 4 seconds
+	});
 
-  // Convert array to map for O(1) lookup by container ID
-  const statsMap = useMemo<ContainerStatsMap>(() => {
-    if (!query.data?.stats) return {};
+	// Convert array to map for O(1) lookup by container ID
+	const statsMap = useMemo<ContainerStatsMap>(() => {
+		if (!query.data?.stats) return {};
 
-    return query.data.stats.reduce((acc, stat) => {
-      acc[stat.id] = stat;
-      return acc;
-    }, {} as ContainerStatsMap);
-  }, [query.data?.stats]);
+		return query.data.stats.reduce((acc, stat) => {
+			acc[stat.id] = stat;
+			return acc;
+		}, {} as ContainerStatsMap);
+	}, [query.data?.stats]);
 
-  const statsHistory = useContainerStatsHistory(query.data?.stats);
+	const statsHistory = useContainerStatsHistory(query.data?.stats);
 
-  return {
-    ...query,
-    statsMap,
-    statsHistory,
-  };
+	return {
+		...query,
+		statsMap,
+		statsHistory,
+	};
 }

--- a/frontend/src/features/containers/hooks/use-containers-dashboard-url-state.ts
+++ b/frontend/src/features/containers/hooks/use-containers-dashboard-url-state.ts
@@ -1,186 +1,186 @@
 import {
-  createParser,
-  parseAsInteger,
-  parseAsIsoDateTime,
-  parseAsString,
-  useQueryStates
+	createParser,
+	parseAsInteger,
+	parseAsIsoDateTime,
+	parseAsString,
+	useQueryStates,
 } from "nuqs";
 import { useCallback, useMemo } from "react";
 
 import type { DateRange } from "react-day-picker";
 import type {
-  GroupByOption,
-  SortDirection,
+	GroupByOption,
+	SortDirection,
 } from "../components/container-utils";
 
 // Custom parser for SortDirection
 const parseAsSortDirection = createParser({
-  parse: (value): SortDirection | null => {
-    if (value === "asc" || value === "desc") {
-      return value;
-    }
-    return null;
-  },
-  serialize: (value: SortDirection) => value,
+	parse: (value): SortDirection | null => {
+		if (value === "asc" || value === "desc") {
+			return value;
+		}
+		return null;
+	},
+	serialize: (value: SortDirection) => value,
 });
 
 // Custom parser for GroupByOption
 const parseAsGroupBy = createParser({
-  parse: (value): GroupByOption | null => {
-    if (value === "none" || value === "compose") {
-      return value;
-    }
-    return null;
-  },
-  serialize: (value: GroupByOption) => value,
+	parse: (value): GroupByOption | null => {
+		if (value === "none" || value === "compose") {
+			return value;
+		}
+		return null;
+	},
+	serialize: (value: GroupByOption) => value,
 });
 
 // Search params configuration with defaults
 const searchParamsConfig = {
-  search: parseAsString.withDefault(""),
-  state: parseAsString.withDefault("all"),
-  host: parseAsString.withDefault("all"),
-  sort: parseAsSortDirection.withDefault("desc" as SortDirection),
-  group: parseAsGroupBy.withDefault("none" as GroupByOption),
-  page: parseAsInteger.withDefault(1),
-  pageSize: parseAsInteger.withDefault(10),
-  from: parseAsIsoDateTime,
-  to: parseAsIsoDateTime,
+	search: parseAsString.withDefault(""),
+	state: parseAsString.withDefault("all"),
+	host: parseAsString.withDefault("all"),
+	sort: parseAsSortDirection.withDefault("desc" as SortDirection),
+	group: parseAsGroupBy.withDefault("none" as GroupByOption),
+	page: parseAsInteger.withDefault(1),
+	pageSize: parseAsInteger.withDefault(10),
+	from: parseAsIsoDateTime,
+	to: parseAsIsoDateTime,
 };
 
 export function useContainersDashboardUrlState() {
-  const [params, setParams] = useQueryStates(searchParamsConfig, {
-    history: "replace",
-  });
+	const [params, setParams] = useQueryStates(searchParamsConfig, {
+		history: "replace",
+	});
 
-  const {
-    search: searchTerm,
-    state: stateFilter,
-    host: hostFilter,
-    sort: sortDirection,
-    group: groupBy,
-    page,
-    pageSize,
-    from,
-    to,
-  } = params;
+	const {
+		search: searchTerm,
+		state: stateFilter,
+		host: hostFilter,
+		sort: sortDirection,
+		group: groupBy,
+		page,
+		pageSize,
+		from,
+		to,
+	} = params;
 
-  // Convert from/to into DateRange format
-  // Supports open-ended ranges: from without to, to without from, or both
-  const dateRange = useMemo((): DateRange | undefined => {
-    if (!from && !to) {
-      return undefined;
-    }
+	// Convert from/to into DateRange format
+	// Supports open-ended ranges: from without to, to without from, or both
+	const dateRange = useMemo((): DateRange | undefined => {
+		if (!from && !to) {
+			return undefined;
+		}
 
-    return { from: from ?? undefined, to: to ?? undefined };
-  }, [from, to]);
+		return { from: from ?? undefined, to: to ?? undefined };
+	}, [from, to]);
 
-  const setSearchTerm = useCallback(
-    (value: string) => {
-      setParams({
-        search: value,
-        page: 1,
-      });
-    },
-    [setParams]
-  );
+	const setSearchTerm = useCallback(
+		(value: string) => {
+			setParams({
+				search: value,
+				page: 1,
+			});
+		},
+		[setParams],
+	);
 
-  const setStateFilter = useCallback(
-    (value: string) => {
-      const normalized = value || "all";
-      setParams({
-        state: normalized,
-        page: 1,
-      });
-    },
-    [setParams]
-  );
+	const setStateFilter = useCallback(
+		(value: string) => {
+			const normalized = value || "all";
+			setParams({
+				state: normalized,
+				page: 1,
+			});
+		},
+		[setParams],
+	);
 
-  const setHostFilter = useCallback(
-    (value: string) => {
-      const normalized = value || "all";
-      setParams({
-        host: normalized,
-        page: 1,
-      });
-    },
-    [setParams]
-  );
+	const setHostFilter = useCallback(
+		(value: string) => {
+			const normalized = value || "all";
+			setParams({
+				host: normalized,
+				page: 1,
+			});
+		},
+		[setParams],
+	);
 
-  const setSortDirection = useCallback(
-    (value: SortDirection) => {
-      setParams({
-        sort: value,
-      });
-    },
-    [setParams]
-  );
+	const setSortDirection = useCallback(
+		(value: SortDirection) => {
+			setParams({
+				sort: value,
+			});
+		},
+		[setParams],
+	);
 
-  const setGroupBy = useCallback(
-    (value: GroupByOption) => {
-      setParams({
-        group: value,
-        page: 1,
-      });
-    },
-    [setParams]
-  );
+	const setGroupBy = useCallback(
+		(value: GroupByOption) => {
+			setParams({
+				group: value,
+				page: 1,
+			});
+		},
+		[setParams],
+	);
 
-  const setDateRange = useCallback(
-    (range: DateRange | undefined) => {
-      setParams({
-        from: range?.from ?? null,
-        to: range?.to ?? null,
-        page: 1,
-      });
-    },
-    [setParams]
-  );
+	const setDateRange = useCallback(
+		(range: DateRange | undefined) => {
+			setParams({
+				from: range?.from ?? null,
+				to: range?.to ?? null,
+				page: 1,
+			});
+		},
+		[setParams],
+	);
 
-  const clearDateRange = useCallback(() => {
-    setParams({
-      from: null,
-      to: null,
-      page: 1,
-    });
-  }, [setParams]);
+	const clearDateRange = useCallback(() => {
+		setParams({
+			from: null,
+			to: null,
+			page: 1,
+		});
+	}, [setParams]);
 
-  const setPage = useCallback(
-    (value: number) => {
-      setParams({
-        page: Math.max(1, Math.floor(value)),
-      });
-    },
-    [setParams]
-  );
+	const setPage = useCallback(
+		(value: number) => {
+			setParams({
+				page: Math.max(1, Math.floor(value)),
+			});
+		},
+		[setParams],
+	);
 
-  const setPageSize = useCallback(
-    (value: number) => {
-      setParams({
-        pageSize: Math.max(1, Math.floor(value)),
-        page: 1,
-      });
-    },
-    [setParams]
-  );
+	const setPageSize = useCallback(
+		(value: number) => {
+			setParams({
+				pageSize: Math.max(1, Math.floor(value)),
+				page: 1,
+			});
+		},
+		[setParams],
+	);
 
-  return {
-    searchTerm,
-    setSearchTerm,
-    stateFilter,
-    setStateFilter,
-    hostFilter,
-    setHostFilter,
-    sortDirection,
-    setSortDirection,
-    groupBy,
-    setGroupBy,
-    dateRange,
-    setDateRange,
-    clearDateRange,
-    page,
-    setPage,
-    pageSize,
-    setPageSize,
-  };
+	return {
+		searchTerm,
+		setSearchTerm,
+		stateFilter,
+		setStateFilter,
+		hostFilter,
+		setHostFilter,
+		sortDirection,
+		setSortDirection,
+		groupBy,
+		setGroupBy,
+		dateRange,
+		setDateRange,
+		clearDateRange,
+		page,
+		setPage,
+		pageSize,
+		setPageSize,
+	};
 }

--- a/frontend/src/features/containers/hooks/use-containers-query.ts
+++ b/frontend/src/features/containers/hooks/use-containers-query.ts
@@ -3,18 +3,18 @@ import { useQuery } from "@tanstack/react-query";
 import { getContainers } from "../api/get-containers";
 
 interface UseContainersQueryOptions {
-  eventsConnected?: boolean;
+	eventsConnected?: boolean;
 }
 
 export function useContainersQuery({
-  eventsConnected = false,
+	eventsConnected = false,
 }: UseContainersQueryOptions = {}) {
-  return useQuery({
-    queryKey: ["containers"],
-    queryFn: getContainers,
-    staleTime: 30_000,
-    // With the event stream connected, updates are pushed and polling is only
-    // a slow safety net; when disconnected, polling carries the updates.
-    refetchInterval: eventsConnected ? 60_000 : 30_000,
-  });
+	return useQuery({
+		queryKey: ["containers"],
+		queryFn: getContainers,
+		staleTime: 30_000,
+		// With the event stream connected, updates are pushed and polling is only
+		// a slow safety net; when disconnected, polling carries the updates.
+		refetchInterval: eventsConnected ? 60_000 : 30_000,
+	});
 }

--- a/frontend/src/features/containers/hooks/use-document-visible.ts
+++ b/frontend/src/features/containers/hooks/use-document-visible.ts
@@ -1,17 +1,17 @@
 import { useSyncExternalStore } from "react";
 
 function subscribe(onStoreChange: () => void) {
-  document.addEventListener("visibilitychange", onStoreChange);
-  return () => document.removeEventListener("visibilitychange", onStoreChange);
+	document.addEventListener("visibilitychange", onStoreChange);
+	return () => document.removeEventListener("visibilitychange", onStoreChange);
 }
 
 /**
  * Tracks whether the document is currently visible (tab in the foreground).
  */
 export function useDocumentVisible(): boolean {
-  return useSyncExternalStore(
-    subscribe,
-    () => !document.hidden,
-    () => true
-  );
+	return useSyncExternalStore(
+		subscribe,
+		() => !document.hidden,
+		() => true,
+	);
 }

--- a/frontend/src/features/containers/hooks/use-live-containers-query.ts
+++ b/frontend/src/features/containers/hooks/use-live-containers-query.ts
@@ -12,31 +12,31 @@ const EVENT_INVALIDATE_DEBOUNCE_MS = 300;
  * refetches), with polling as fallback while the stream is disconnected.
  */
 export function useLiveContainersQuery() {
-  const queryClient = useQueryClient();
-  const invalidateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
+	const queryClient = useQueryClient();
+	const invalidateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
 
-  const handleContainerEvent = useCallback(() => {
-    if (invalidateTimeoutRef.current !== null) return;
-    invalidateTimeoutRef.current = setTimeout(() => {
-      invalidateTimeoutRef.current = null;
-      void queryClient.invalidateQueries({
-        queryKey: ["containers"],
-        exact: true,
-      });
-    }, EVENT_INVALIDATE_DEBOUNCE_MS);
-  }, [queryClient]);
+	const handleContainerEvent = useCallback(() => {
+		if (invalidateTimeoutRef.current !== null) return;
+		invalidateTimeoutRef.current = setTimeout(() => {
+			invalidateTimeoutRef.current = null;
+			void queryClient.invalidateQueries({
+				queryKey: ["containers"],
+				exact: true,
+			});
+		}, EVENT_INVALIDATE_DEBOUNCE_MS);
+	}, [queryClient]);
 
-  useEffect(() => {
-    return () => {
-      if (invalidateTimeoutRef.current !== null) {
-        clearTimeout(invalidateTimeoutRef.current);
-      }
-    };
-  }, []);
+	useEffect(() => {
+		return () => {
+			if (invalidateTimeoutRef.current !== null) {
+				clearTimeout(invalidateTimeoutRef.current);
+			}
+		};
+	}, []);
 
-  const { isConnected } = useContainerEvents(handleContainerEvent);
+	const { isConnected } = useContainerEvents(handleContainerEvent);
 
-  return useContainersQuery({ eventsConnected: isConnected });
+	return useContainersQuery({ eventsConnected: isConnected });
 }

--- a/frontend/src/features/settings/api/get-settings.ts
+++ b/frontend/src/features/settings/api/get-settings.ts
@@ -6,12 +6,12 @@ import type { SettingsResponse } from "../types";
 const SETTINGS_ENDPOINT = `${API_BASE_URL}/api/v1/settings`;
 
 export async function getSettings(): Promise<SettingsResponse> {
-  const response = await authenticatedFetch(SETTINGS_ENDPOINT);
+	const response = await authenticatedFetch(SETTINGS_ENDPOINT);
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed with status ${response.status}`);
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || `Request failed with status ${response.status}`);
+	}
 
-  return (await response.json()) as SettingsResponse;
+	return (await response.json()) as SettingsResponse;
 }

--- a/frontend/src/features/settings/api/test-coolify-host.ts
+++ b/frontend/src/features/settings/api/test-coolify-host.ts
@@ -6,20 +6,20 @@ import type { TestConnectionResult } from "../types";
 const ENDPOINT = `${API_BASE_URL}/api/v1/settings/test/coolify-host`;
 
 export async function testCoolifyHost(
-  hostName: string,
-  apiURL: string,
-  apiToken: string,
+	hostName: string,
+	apiURL: string,
+	apiToken: string,
 ): Promise<TestConnectionResult> {
-  const response = await authenticatedFetch(ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ hostName, apiURL, apiToken }),
-  });
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ hostName, apiURL, apiToken }),
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || "Failed to test Coolify host");
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to test Coolify host");
+	}
 
-  return (await response.json()) as TestConnectionResult;
+	return (await response.json()) as TestConnectionResult;
 }

--- a/frontend/src/features/settings/api/test-docker-host.ts
+++ b/frontend/src/features/settings/api/test-docker-host.ts
@@ -6,19 +6,19 @@ import type { TestConnectionResult } from "../types";
 const ENDPOINT = `${API_BASE_URL}/api/v1/settings/test/docker-host`;
 
 export async function testDockerHost(
-  name: string,
-  host: string,
+	name: string,
+	host: string,
 ): Promise<TestConnectionResult> {
-  const response = await authenticatedFetch(ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, host }),
-  });
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ name, host }),
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || "Failed to test Docker host");
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to test Docker host");
+	}
 
-  return (await response.json()) as TestConnectionResult;
+	return (await response.json()) as TestConnectionResult;
 }

--- a/frontend/src/features/settings/api/update-auth.ts
+++ b/frontend/src/features/settings/api/update-auth.ts
@@ -4,23 +4,23 @@ import { API_BASE_URL } from "@/types/api";
 const ENDPOINT = `${API_BASE_URL}/api/v1/settings/auth`;
 
 export interface UpdateAuthPayload {
-  enabled: boolean;
-  adminUsername: string;
-  newPassword?: string;
+	enabled: boolean;
+	adminUsername: string;
+	newPassword?: string;
 }
 
 export async function updateAuth(payload: UpdateAuthPayload): Promise<string> {
-  const response = await authenticatedFetch(ENDPOINT, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || "Failed to update auth settings");
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to update auth settings");
+	}
 
-  const data = (await response.json()) as { message?: string };
-  return data.message ?? "Auth settings updated";
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "Auth settings updated";
 }

--- a/frontend/src/features/settings/api/update-coolify-hosts.ts
+++ b/frontend/src/features/settings/api/update-coolify-hosts.ts
@@ -4,19 +4,19 @@ import { API_BASE_URL } from "@/types/api";
 const ENDPOINT = `${API_BASE_URL}/api/v1/settings/coolify-hosts`;
 
 export async function updateCoolifyHosts(
-  hosts: { hostName: string; apiURL: string; apiToken: string }[],
+	hosts: { hostName: string; apiURL: string; apiToken: string }[],
 ): Promise<string> {
-  const response = await authenticatedFetch(ENDPOINT, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ hosts }),
-  });
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ hosts }),
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || "Failed to update Coolify hosts");
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to update Coolify hosts");
+	}
 
-  const data = (await response.json()) as { message?: string };
-  return data.message ?? "Coolify hosts updated";
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "Coolify hosts updated";
 }

--- a/frontend/src/features/settings/api/update-docker-hosts.ts
+++ b/frontend/src/features/settings/api/update-docker-hosts.ts
@@ -3,18 +3,20 @@ import { API_BASE_URL } from "@/types/api";
 
 const ENDPOINT = `${API_BASE_URL}/api/v1/settings/docker-hosts`;
 
-export async function updateDockerHosts(hosts: { name: string; host: string }[]): Promise<string> {
-  const response = await authenticatedFetch(ENDPOINT, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ hosts }),
-  });
+export async function updateDockerHosts(
+	hosts: { name: string; host: string }[],
+): Promise<string> {
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ hosts }),
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || "Failed to update Docker hosts");
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to update Docker hosts");
+	}
 
-  const data = (await response.json()) as { message?: string };
-  return data.message ?? "Docker hosts updated";
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "Docker hosts updated";
 }

--- a/frontend/src/features/settings/api/update-read-only.ts
+++ b/frontend/src/features/settings/api/update-read-only.ts
@@ -4,17 +4,17 @@ import { API_BASE_URL } from "@/types/api";
 const ENDPOINT = `${API_BASE_URL}/api/v1/settings/read-only`;
 
 export async function updateReadOnly(value: boolean): Promise<string> {
-  const response = await authenticatedFetch(ENDPOINT, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ value }),
-  });
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ value }),
+	});
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || "Failed to update read-only mode");
-  }
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to update read-only mode");
+	}
 
-  const data = (await response.json()) as { message?: string };
-  return data.message ?? "Read-only mode updated";
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "Read-only mode updated";
 }

--- a/frontend/src/features/settings/components/auth-section.tsx
+++ b/frontend/src/features/settings/components/auth-section.tsx
@@ -3,11 +3,11 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -19,120 +19,122 @@ import type { AuthConfig } from "../types";
 import { EnvBadge } from "./env-badge";
 
 interface AuthSectionProps {
-  config: AuthConfig;
+	config: AuthConfig;
 }
 
 export function AuthSection({ config }: AuthSectionProps) {
-  const isEnv = config.source === "env";
-  const [enabled, setEnabled] = useState(config.enabled);
-  const [username, setUsername] = useState(config.adminUsername ?? "");
-  const [password, setPassword] = useState("");
+	const isEnv = config.source === "env";
+	const [enabled, setEnabled] = useState(config.enabled);
+	const [username, setUsername] = useState(config.adminUsername ?? "");
+	const [password, setPassword] = useState("");
 
-  const mutation = useUpdateAuth();
+	const mutation = useUpdateAuth();
 
-  const hasChanges =
-    enabled !== config.enabled ||
-    username !== (config.adminUsername ?? "") ||
-    password.length > 0;
+	const hasChanges =
+		enabled !== config.enabled ||
+		username !== (config.adminUsername ?? "") ||
+		password.length > 0;
 
-  function handleSave() {
-    if (enabled && !username.trim()) {
-      toast.error("Username is required when enabling auth");
-      return;
-    }
-    if (enabled && !config.enabled && !password) {
-      toast.error("Password is required when first enabling auth");
-      return;
-    }
+	function handleSave() {
+		if (enabled && !username.trim()) {
+			toast.error("Username is required when enabling auth");
+			return;
+		}
+		if (enabled && !config.enabled && !password) {
+			toast.error("Password is required when first enabling auth");
+			return;
+		}
 
-    mutation.mutate(
-      {
-        enabled,
-        adminUsername: username,
-        ...(password ? { newPassword: password } : {}),
-      },
-      {
-        onSuccess: (msg) => {
-          toast.success(msg);
-          setPassword("");
-        },
-        onError: (err) => toast.error(err.message),
-      },
-    );
-  }
+		mutation.mutate(
+			{
+				enabled,
+				adminUsername: username,
+				...(password ? { newPassword: password } : {}),
+			},
+			{
+				onSuccess: (msg) => {
+					toast.success(msg);
+					setPassword("");
+				},
+				onError: (err) => toast.error(err.message),
+			},
+		);
+	}
 
-  return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-3">
-          <CardTitle>Authentication</CardTitle>
-          {isEnv && <EnvBadge />}
-        </div>
-        <CardDescription>
-          Protect the dashboard with username and password authentication.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="flex items-center gap-3">
-          <Switch
-            id="auth-enabled"
-            checked={enabled}
-            onCheckedChange={(checked) => {
-              setEnabled(checked);
-              if (!checked) setPassword("");
-            }}
-            disabled={isEnv}
-          />
-          <Label htmlFor="auth-enabled" className="cursor-pointer">
-            {enabled ? "Enabled" : "Disabled"}
-          </Label>
-        </div>
+	return (
+		<Card>
+			<CardHeader>
+				<div className="flex items-center gap-3">
+					<CardTitle>Authentication</CardTitle>
+					{isEnv && <EnvBadge />}
+				</div>
+				<CardDescription>
+					Protect the dashboard with username and password authentication.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="flex items-center gap-3">
+					<Switch
+						id="auth-enabled"
+						checked={enabled}
+						onCheckedChange={(checked) => {
+							setEnabled(checked);
+							if (!checked) setPassword("");
+						}}
+						disabled={isEnv}
+					/>
+					<Label htmlFor="auth-enabled" className="cursor-pointer">
+						{enabled ? "Enabled" : "Disabled"}
+					</Label>
+				</div>
 
-        {enabled && (
-          <div className="space-y-3 max-w-sm">
-            <div className="space-y-1.5">
-              <Label htmlFor="admin-username">Admin username</Label>
-              <Input
-                id="admin-username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                disabled={isEnv}
-                placeholder="admin"
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="admin-password">
-                {config.enabled ? "New password (leave blank to keep current)" : "Password"}
-              </Label>
-              <Input
-                id="admin-password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                disabled={isEnv}
-                placeholder={config.enabled ? "Leave blank to keep current" : "Enter password"}
-              />
-            </div>
-          </div>
-        )}
+				{enabled && (
+					<div className="space-y-3 max-w-sm">
+						<div className="space-y-1.5">
+							<Label htmlFor="admin-username">Admin username</Label>
+							<Input
+								id="admin-username"
+								value={username}
+								onChange={(e) => setUsername(e.target.value)}
+								disabled={isEnv}
+								placeholder="admin"
+							/>
+						</div>
+						<div className="space-y-1.5">
+							<Label htmlFor="admin-password">
+								{config.enabled
+									? "New password (leave blank to keep current)"
+									: "Password"}
+							</Label>
+							<Input
+								id="admin-password"
+								type="password"
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								disabled={isEnv}
+								placeholder={
+									config.enabled
+										? "Leave blank to keep current"
+										: "Enter password"
+								}
+							/>
+						</div>
+					</div>
+				)}
 
-        {hasChanges && !isEnv && (
-          <Button
-            size="sm"
-            disabled={mutation.isPending}
-            onClick={handleSave}
-          >
-            {mutation.isPending ? (
-              <>
-                <Spinner className="size-3" />
-                Saving...
-              </>
-            ) : (
-              "Save changes"
-            )}
-          </Button>
-        )}
-      </CardContent>
-    </Card>
-  );
+				{hasChanges && !isEnv && (
+					<Button size="sm" disabled={mutation.isPending} onClick={handleSave}>
+						{mutation.isPending ? (
+							<>
+								<Spinner className="size-3" />
+								Saving...
+							</>
+						) : (
+							"Save changes"
+						)}
+					</Button>
+				)}
+			</CardContent>
+		</Card>
+	);
 }

--- a/frontend/src/features/settings/components/coolify-hosts-section.tsx
+++ b/frontend/src/features/settings/components/coolify-hosts-section.tsx
@@ -3,352 +3,455 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
 } from "@/components/ui/table";
 
 import {
-  useTestCoolifyHost,
-  useUpdateCoolifyHosts,
+	useTestCoolifyHost,
+	useUpdateCoolifyHosts,
 } from "../hooks/use-settings";
 import type { CoolifyHostsConfig } from "../types";
 import { EnvBadge } from "./env-badge";
 
 interface CoolifyHostsSectionProps {
-  config: CoolifyHostsConfig;
+	config: CoolifyHostsConfig;
 }
 
 interface EditingHost {
-  hostName: string;
-  apiURL: string;
-  apiToken: string;
+	hostName: string;
+	apiURL: string;
+	apiToken: string;
 }
 
 const EMPTY_HOST: EditingHost = { hostName: "", apiURL: "", apiToken: "" };
 
 export function CoolifyHostsSection({ config }: CoolifyHostsSectionProps) {
-  const envHosts = config.hosts.filter((h) => h.source === "env");
-  const [fileHosts, setFileHosts] = useState<EditingHost[]>(
-    config.hosts
-      .filter((h) => h.source !== "env")
-      .map(({ hostName, apiURL, apiToken }) => ({ hostName, apiURL, apiToken })),
-  );
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [editingHost, setEditingHost] = useState<EditingHost>(EMPTY_HOST);
-  const [isAdding, setIsAdding] = useState(false);
-  const [newHost, setNewHost] = useState<EditingHost>(EMPTY_HOST);
-  const [testResults, setTestResults] = useState<
-    Record<string, { success: boolean; message: string }>
-  >({});
-  const [testingKey, setTestingKey] = useState<string | null>(null);
+	const envHosts = config.hosts.filter((h) => h.source === "env");
+	const [fileHosts, setFileHosts] = useState<EditingHost[]>(
+		config.hosts
+			.filter((h) => h.source !== "env")
+			.map(({ hostName, apiURL, apiToken }) => ({
+				hostName,
+				apiURL,
+				apiToken,
+			})),
+	);
+	const [editingIndex, setEditingIndex] = useState<number | null>(null);
+	const [editingHost, setEditingHost] = useState<EditingHost>(EMPTY_HOST);
+	const [isAdding, setIsAdding] = useState(false);
+	const [newHost, setNewHost] = useState<EditingHost>(EMPTY_HOST);
+	const [testResults, setTestResults] = useState<
+		Record<string, { success: boolean; message: string }>
+	>({});
+	const [testingKey, setTestingKey] = useState<string | null>(null);
 
-  const updateMutation = useUpdateCoolifyHosts();
-  const testMutation = useTestCoolifyHost();
+	const updateMutation = useUpdateCoolifyHosts();
+	const testMutation = useTestCoolifyHost();
 
-  const originalFileHosts = useMemo(
-    () => config.hosts.filter((h) => h.source !== "env").map(({ hostName, apiURL, apiToken }) => ({ hostName, apiURL, apiToken })),
-    [config.hosts],
-  );
-  const hasChanges = fileHosts.length !== originalFileHosts.length ||
-    fileHosts.some((h, i) => h.hostName !== originalFileHosts[i]?.hostName || h.apiURL !== originalFileHosts[i]?.apiURL || h.apiToken !== originalFileHosts[i]?.apiToken);
+	const originalFileHosts = useMemo(
+		() =>
+			config.hosts
+				.filter((h) => h.source !== "env")
+				.map(({ hostName, apiURL, apiToken }) => ({
+					hostName,
+					apiURL,
+					apiToken,
+				})),
+		[config.hosts],
+	);
+	const hasChanges =
+		fileHosts.length !== originalFileHosts.length ||
+		fileHosts.some(
+			(h, i) =>
+				h.hostName !== originalFileHosts[i]?.hostName ||
+				h.apiURL !== originalFileHosts[i]?.apiURL ||
+				h.apiToken !== originalFileHosts[i]?.apiToken,
+		);
 
-  function handleSave() {
-    updateMutation.mutate(fileHosts, {
-      onSuccess: (msg) => toast.success(msg),
-      onError: (err) => toast.error(err.message),
-    });
-  }
+	function handleSave() {
+		updateMutation.mutate(fileHosts, {
+			onSuccess: (msg) => toast.success(msg),
+			onError: (err) => toast.error(err.message),
+		});
+	}
 
-  function handleRemove(index: number) {
-    setFileHosts((prev) => prev.filter((_, i) => i !== index));
-    setTestResults({});
-  }
+	function handleRemove(index: number) {
+		setFileHosts((prev) => prev.filter((_, i) => i !== index));
+		setTestResults({});
+	}
 
-  function handleStartEdit(index: number) {
-    setEditingIndex(index);
-    setEditingHost({ ...fileHosts[index] });
-  }
+	function handleStartEdit(index: number) {
+		setEditingIndex(index);
+		setEditingHost({ ...fileHosts[index] });
+	}
 
-  function handleCancelEdit() {
-    setEditingIndex(null);
-    setEditingHost(EMPTY_HOST);
-  }
+	function handleCancelEdit() {
+		setEditingIndex(null);
+		setEditingHost(EMPTY_HOST);
+	}
 
-  function handleSaveEdit() {
-    if (editingIndex === null) return;
-    if (!editingHost.hostName.trim() || !editingHost.apiURL.trim() || !editingHost.apiToken.trim()) {
-      toast.error("Host name, API URL, and API token are all required");
-      return;
-    }
-    const trimmedName = editingHost.hostName.trim();
-    if (envHosts.some((h) => h.hostName === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" is defined via environment variable`);
-      return;
-    }
-    if (fileHosts.some((h, i) => i !== editingIndex && h.hostName === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" already exists`);
-      return;
-    }
-    const next = [...fileHosts];
-    next[editingIndex] = { ...editingHost };
-    setFileHosts(next);
-    setEditingIndex(null);
-    setEditingHost(EMPTY_HOST);
-    setTestResults({});
-  }
+	function handleSaveEdit() {
+		if (editingIndex === null) return;
+		if (
+			!editingHost.hostName.trim() ||
+			!editingHost.apiURL.trim() ||
+			!editingHost.apiToken.trim()
+		) {
+			toast.error("Host name, API URL, and API token are all required");
+			return;
+		}
+		const trimmedName = editingHost.hostName.trim();
+		if (envHosts.some((h) => h.hostName === trimmedName)) {
+			toast.error(
+				`Host name "${trimmedName}" is defined via environment variable`,
+			);
+			return;
+		}
+		if (
+			fileHosts.some((h, i) => i !== editingIndex && h.hostName === trimmedName)
+		) {
+			toast.error(`Host name "${trimmedName}" already exists`);
+			return;
+		}
+		const next = [...fileHosts];
+		next[editingIndex] = { ...editingHost };
+		setFileHosts(next);
+		setEditingIndex(null);
+		setEditingHost(EMPTY_HOST);
+		setTestResults({});
+	}
 
-  function handleAddHost() {
-    if (!newHost.hostName.trim() || !newHost.apiURL.trim() || !newHost.apiToken.trim()) {
-      toast.error("Host name, API URL, and API token are all required");
-      return;
-    }
-    const trimmedName = newHost.hostName.trim();
-    if (envHosts.some((h) => h.hostName === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" is already defined via environment variable`);
-      return;
-    }
-    if (fileHosts.some((h) => h.hostName === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" already exists`);
-      return;
-    }
-    setFileHosts([...fileHosts, { hostName: trimmedName, apiURL: newHost.apiURL.trim(), apiToken: newHost.apiToken.trim() }]);
-    setNewHost(EMPTY_HOST);
-    setIsAdding(false);
-    setTestResults({});
-  }
+	function handleAddHost() {
+		if (
+			!newHost.hostName.trim() ||
+			!newHost.apiURL.trim() ||
+			!newHost.apiToken.trim()
+		) {
+			toast.error("Host name, API URL, and API token are all required");
+			return;
+		}
+		const trimmedName = newHost.hostName.trim();
+		if (envHosts.some((h) => h.hostName === trimmedName)) {
+			toast.error(
+				`Host name "${trimmedName}" is already defined via environment variable`,
+			);
+			return;
+		}
+		if (fileHosts.some((h) => h.hostName === trimmedName)) {
+			toast.error(`Host name "${trimmedName}" already exists`);
+			return;
+		}
+		setFileHosts([
+			...fileHosts,
+			{
+				hostName: trimmedName,
+				apiURL: newHost.apiURL.trim(),
+				apiToken: newHost.apiToken.trim(),
+			},
+		]);
+		setNewHost(EMPTY_HOST);
+		setIsAdding(false);
+		setTestResults({});
+	}
 
-  function handleTest(key: string, h: { hostName: string; apiURL: string; apiToken: string }) {
-    setTestingKey(key);
-    testMutation.mutate(
-      { hostName: h.hostName, apiURL: h.apiURL, apiToken: h.apiToken },
-      {
-        onSuccess: (result) => {
-          setTestResults((prev) => ({
-            ...prev,
-            [key]: { success: result.success, message: result.message },
-          }));
-          setTestingKey(null);
-        },
-        onError: (err) => {
-          setTestResults((prev) => ({
-            ...prev,
-            [key]: { success: false, message: err.message },
-          }));
-          setTestingKey(null);
-        },
-      },
-    );
-  }
+	function handleTest(
+		key: string,
+		h: { hostName: string; apiURL: string; apiToken: string },
+	) {
+		setTestingKey(key);
+		testMutation.mutate(
+			{ hostName: h.hostName, apiURL: h.apiURL, apiToken: h.apiToken },
+			{
+				onSuccess: (result) => {
+					setTestResults((prev) => ({
+						...prev,
+						[key]: { success: result.success, message: result.message },
+					}));
+					setTestingKey(null);
+				},
+				onError: (err) => {
+					setTestResults((prev) => ({
+						...prev,
+						[key]: { success: false, message: err.message },
+					}));
+					setTestingKey(null);
+				},
+			},
+		);
+	}
 
-  function renderRow(
-    h: { hostName: string; apiURL: string; apiToken: string },
-    isEnvRow: boolean,
-    fileIndex?: number,
-  ) {
-    const testKey = `${isEnvRow ? "env" : "file"}-${h.hostName}`;
-    const isEditing = !isEnvRow && editingIndex === fileIndex;
+	function renderRow(
+		h: { hostName: string; apiURL: string; apiToken: string },
+		isEnvRow: boolean,
+		fileIndex?: number,
+	) {
+		const testKey = `${isEnvRow ? "env" : "file"}-${h.hostName}`;
+		const isEditing = !isEnvRow && editingIndex === fileIndex;
 
-    if (isEditing && fileIndex !== undefined) {
-      return (
-        <TableRow key={testKey}>
-          <TableCell>
-            <Input
-              value={editingHost.hostName}
-              onChange={(e) => setEditingHost((prev) => ({ ...prev, hostName: e.target.value }))}
-              className="h-8"
-            />
-          </TableCell>
-          <TableCell>
-            <Input
-              value={editingHost.apiURL}
-              onChange={(e) => setEditingHost((prev) => ({ ...prev, apiURL: e.target.value }))}
-              className="h-8"
-              placeholder="https://coolify.example.com"
-            />
-          </TableCell>
-          <TableCell>
-            <Input
-              value={editingHost.apiToken}
-              onChange={(e) => setEditingHost((prev) => ({ ...prev, apiToken: e.target.value }))}
-              className="h-8"
-              placeholder="Leave masked to keep existing"
-              type="password"
-            />
-          </TableCell>
-          <TableCell />
-          <TableCell className="text-right">
-            <div className="flex items-center justify-end gap-1">
-              <Button variant="ghost" size="sm" onClick={handleSaveEdit}>Done</Button>
-              <Button variant="ghost" size="sm" onClick={handleCancelEdit}>Cancel</Button>
-            </div>
-          </TableCell>
-        </TableRow>
-      );
-    }
+		if (isEditing && fileIndex !== undefined) {
+			return (
+				<TableRow key={testKey}>
+					<TableCell>
+						<Input
+							value={editingHost.hostName}
+							onChange={(e) =>
+								setEditingHost((prev) => ({
+									...prev,
+									hostName: e.target.value,
+								}))
+							}
+							className="h-8"
+						/>
+					</TableCell>
+					<TableCell>
+						<Input
+							value={editingHost.apiURL}
+							onChange={(e) =>
+								setEditingHost((prev) => ({ ...prev, apiURL: e.target.value }))
+							}
+							className="h-8"
+							placeholder="https://coolify.example.com"
+						/>
+					</TableCell>
+					<TableCell>
+						<Input
+							value={editingHost.apiToken}
+							onChange={(e) =>
+								setEditingHost((prev) => ({
+									...prev,
+									apiToken: e.target.value,
+								}))
+							}
+							className="h-8"
+							placeholder="Leave masked to keep existing"
+							type="password"
+						/>
+					</TableCell>
+					<TableCell />
+					<TableCell className="text-right">
+						<div className="flex items-center justify-end gap-1">
+							<Button variant="ghost" size="sm" onClick={handleSaveEdit}>
+								Done
+							</Button>
+							<Button variant="ghost" size="sm" onClick={handleCancelEdit}>
+								Cancel
+							</Button>
+						</div>
+					</TableCell>
+				</TableRow>
+			);
+		}
 
-    return (
-      <TableRow key={testKey}>
-        <TableCell className="font-medium">
-          <div className="flex items-center gap-2">
-            {h.hostName}
-            {isEnvRow && <EnvBadge />}
-          </div>
-        </TableCell>
-        <TableCell className="font-mono text-xs text-muted-foreground">{h.apiURL}</TableCell>
-        <TableCell className="text-muted-foreground">{h.apiToken}</TableCell>
-        <TableCell>
-          {testResults[testKey] && (
-            <span
-              className={`text-xs ${testResults[testKey].success ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
-            >
-              {testResults[testKey].message}
-            </span>
-          )}
-        </TableCell>
-        <TableCell className="text-right">
-          <div className="flex items-center justify-end gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={testingKey === testKey}
-              onClick={() => handleTest(testKey, h)}
-            >
-              {testingKey === testKey ? <Spinner className="size-3" /> : "Test"}
-            </Button>
-            {!isEnvRow && fileIndex !== undefined && (
-              <>
-                <Button variant="ghost" size="sm" disabled={editingIndex !== null} onClick={() => handleStartEdit(fileIndex)}>Edit</Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={editingIndex !== null}
-                  onClick={() => handleRemove(fileIndex)}
-                  className="text-destructive hover:text-destructive"
-                >
-                  Remove
-                </Button>
-              </>
-            )}
-          </div>
-        </TableCell>
-      </TableRow>
-    );
-  }
+		return (
+			<TableRow key={testKey}>
+				<TableCell className="font-medium">
+					<div className="flex items-center gap-2">
+						{h.hostName}
+						{isEnvRow && <EnvBadge />}
+					</div>
+				</TableCell>
+				<TableCell className="font-mono text-xs text-muted-foreground">
+					{h.apiURL}
+				</TableCell>
+				<TableCell className="text-muted-foreground">{h.apiToken}</TableCell>
+				<TableCell>
+					{testResults[testKey] && (
+						<span
+							className={`text-xs ${testResults[testKey].success ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
+						>
+							{testResults[testKey].message}
+						</span>
+					)}
+				</TableCell>
+				<TableCell className="text-right">
+					<div className="flex items-center justify-end gap-1">
+						<Button
+							variant="ghost"
+							size="sm"
+							disabled={testingKey === testKey}
+							onClick={() => handleTest(testKey, h)}
+						>
+							{testingKey === testKey ? <Spinner className="size-3" /> : "Test"}
+						</Button>
+						{!isEnvRow && fileIndex !== undefined && (
+							<>
+								<Button
+									variant="ghost"
+									size="sm"
+									disabled={editingIndex !== null}
+									onClick={() => handleStartEdit(fileIndex)}
+								>
+									Edit
+								</Button>
+								<Button
+									variant="ghost"
+									size="sm"
+									disabled={editingIndex !== null}
+									onClick={() => handleRemove(fileIndex)}
+									className="text-destructive hover:text-destructive"
+								>
+									Remove
+								</Button>
+							</>
+						)}
+					</div>
+				</TableCell>
+			</TableRow>
+		);
+	}
 
-  const allHosts = [
-    ...envHosts.map((h) => ({ ...h, isEnv: true as const })),
-    ...fileHosts.map((h, i) => ({ ...h, source: "file" as const, isEnv: false as const, fileIndex: i })),
-  ];
+	const allHosts = [
+		...envHosts.map((h) => ({ ...h, isEnv: true as const })),
+		...fileHosts.map((h, i) => ({
+			...h,
+			source: "file" as const,
+			isEnv: false as const,
+			fileIndex: i,
+		})),
+	];
 
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Coolify Hosts</CardTitle>
-        <CardDescription>
-          Connect to Coolify instances to persist environment variable changes across redeployments.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {allHosts.length > 0 && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>API URL</TableHead>
-                <TableHead>Token</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {allHosts.map((h) =>
-                renderRow(
-                  { hostName: h.hostName, apiURL: h.apiURL, apiToken: h.apiToken },
-                  h.isEnv,
-                  h.isEnv ? undefined : h.fileIndex,
-                ),
-              )}
-            </TableBody>
-          </Table>
-        )}
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Coolify Hosts</CardTitle>
+				<CardDescription>
+					Connect to Coolify instances to persist environment variable changes
+					across redeployments.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{allHosts.length > 0 && (
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead>API URL</TableHead>
+								<TableHead>Token</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead className="text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{allHosts.map((h) =>
+								renderRow(
+									{
+										hostName: h.hostName,
+										apiURL: h.apiURL,
+										apiToken: h.apiToken,
+									},
+									h.isEnv,
+									h.isEnv ? undefined : h.fileIndex,
+								),
+							)}
+						</TableBody>
+					</Table>
+				)}
 
-        {allHosts.length === 0 && !isAdding && (
-          <p className="text-sm text-muted-foreground">No Coolify hosts configured.</p>
-        )}
+				{allHosts.length === 0 && !isAdding && (
+					<p className="text-sm text-muted-foreground">
+						No Coolify hosts configured.
+					</p>
+				)}
 
-        {isAdding && (
-          <div className="flex items-end gap-3 border rounded-md p-3">
-            <div className="space-y-1.5 flex-1">
-              <Label htmlFor="new-coolify-name">Name</Label>
-              <Input
-                id="new-coolify-name"
-                value={newHost.hostName}
-                onChange={(e) => setNewHost((prev) => ({ ...prev, hostName: e.target.value }))}
-                placeholder="production"
-                className="h-8"
-              />
-            </div>
-            <div className="space-y-1.5 flex-1">
-              <Label htmlFor="new-coolify-url">API URL</Label>
-              <Input
-                id="new-coolify-url"
-                value={newHost.apiURL}
-                onChange={(e) => setNewHost((prev) => ({ ...prev, apiURL: e.target.value }))}
-                placeholder="https://coolify.example.com"
-                className="h-8"
-              />
-            </div>
-            <div className="space-y-1.5 flex-1">
-              <Label htmlFor="new-coolify-token">API Token</Label>
-              <Input
-                id="new-coolify-token"
-                value={newHost.apiToken}
-                onChange={(e) => setNewHost((prev) => ({ ...prev, apiToken: e.target.value }))}
-                placeholder="Token"
-                type="password"
-                className="h-8"
-              />
-            </div>
-            <div className="flex gap-1">
-              <Button size="sm" onClick={handleAddHost}>Add</Button>
-              <Button size="sm" variant="ghost" onClick={() => { setIsAdding(false); setNewHost(EMPTY_HOST); }}>
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
+				{isAdding && (
+					<div className="flex items-end gap-3 border rounded-md p-3">
+						<div className="space-y-1.5 flex-1">
+							<Label htmlFor="new-coolify-name">Name</Label>
+							<Input
+								id="new-coolify-name"
+								value={newHost.hostName}
+								onChange={(e) =>
+									setNewHost((prev) => ({ ...prev, hostName: e.target.value }))
+								}
+								placeholder="production"
+								className="h-8"
+							/>
+						</div>
+						<div className="space-y-1.5 flex-1">
+							<Label htmlFor="new-coolify-url">API URL</Label>
+							<Input
+								id="new-coolify-url"
+								value={newHost.apiURL}
+								onChange={(e) =>
+									setNewHost((prev) => ({ ...prev, apiURL: e.target.value }))
+								}
+								placeholder="https://coolify.example.com"
+								className="h-8"
+							/>
+						</div>
+						<div className="space-y-1.5 flex-1">
+							<Label htmlFor="new-coolify-token">API Token</Label>
+							<Input
+								id="new-coolify-token"
+								value={newHost.apiToken}
+								onChange={(e) =>
+									setNewHost((prev) => ({ ...prev, apiToken: e.target.value }))
+								}
+								placeholder="Token"
+								type="password"
+								className="h-8"
+							/>
+						</div>
+						<div className="flex gap-1">
+							<Button size="sm" onClick={handleAddHost}>
+								Add
+							</Button>
+							<Button
+								size="sm"
+								variant="ghost"
+								onClick={() => {
+									setIsAdding(false);
+									setNewHost(EMPTY_HOST);
+								}}
+							>
+								Cancel
+							</Button>
+						</div>
+					</div>
+				)}
 
-        <div className="flex items-center gap-2">
-          {!isAdding && (
-            <Button variant="outline" size="sm" onClick={() => setIsAdding(true)}>
-              Add host
-            </Button>
-          )}
-          {hasChanges && (
-            <Button size="sm" disabled={updateMutation.isPending} onClick={handleSave}>
-              {updateMutation.isPending ? (
-                <><Spinner className="size-3" /> Saving...</>
-              ) : (
-                "Save changes"
-              )}
-            </Button>
-          )}
-        </div>
-      </CardContent>
-    </Card>
-  );
+				<div className="flex items-center gap-2">
+					{!isAdding && (
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setIsAdding(true)}
+						>
+							Add host
+						</Button>
+					)}
+					{hasChanges && (
+						<Button
+							size="sm"
+							disabled={updateMutation.isPending}
+							onClick={handleSave}
+						>
+							{updateMutation.isPending ? (
+								<>
+									<Spinner className="size-3" /> Saving...
+								</>
+							) : (
+								"Save changes"
+							)}
+						</Button>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
 }

--- a/frontend/src/features/settings/components/docker-hosts-section.tsx
+++ b/frontend/src/features/settings/components/docker-hosts-section.tsx
@@ -3,22 +3,22 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
 } from "@/components/ui/table";
 
 import { useTestDockerHost, useUpdateDockerHosts } from "../hooks/use-settings";
@@ -26,366 +26,390 @@ import type { DockerHostsConfig } from "../types";
 import { EnvBadge } from "./env-badge";
 
 interface DockerHostsSectionProps {
-  config: DockerHostsConfig;
+	config: DockerHostsConfig;
 }
 
 interface EditingHost {
-  name: string;
-  host: string;
+	name: string;
+	host: string;
 }
 
 export function DockerHostsSection({ config }: DockerHostsSectionProps) {
-  const envHosts = config.hosts.filter((h) => h.source === "env");
-  const [fileHosts, setFileHosts] = useState<EditingHost[]>(
-    config.hosts.filter((h) => h.source !== "env").map(({ name, host }) => ({ name, host })),
-  );
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [editingHost, setEditingHost] = useState<EditingHost>({
-    name: "",
-    host: "",
-  });
-  const [isAdding, setIsAdding] = useState(false);
-  const [newHost, setNewHost] = useState<EditingHost>({
-    name: "",
-    host: "",
-  });
-  const [testResults, setTestResults] = useState<
-    Record<string, { success: boolean; message: string }>
-  >({});
-  const [testingKey, setTestingKey] = useState<string | null>(null);
+	const envHosts = config.hosts.filter((h) => h.source === "env");
+	const [fileHosts, setFileHosts] = useState<EditingHost[]>(
+		config.hosts
+			.filter((h) => h.source !== "env")
+			.map(({ name, host }) => ({ name, host })),
+	);
+	const [editingIndex, setEditingIndex] = useState<number | null>(null);
+	const [editingHost, setEditingHost] = useState<EditingHost>({
+		name: "",
+		host: "",
+	});
+	const [isAdding, setIsAdding] = useState(false);
+	const [newHost, setNewHost] = useState<EditingHost>({
+		name: "",
+		host: "",
+	});
+	const [testResults, setTestResults] = useState<
+		Record<string, { success: boolean; message: string }>
+	>({});
+	const [testingKey, setTestingKey] = useState<string | null>(null);
 
-  const updateMutation = useUpdateDockerHosts();
-  const testMutation = useTestDockerHost();
+	const updateMutation = useUpdateDockerHosts();
+	const testMutation = useTestDockerHost();
 
-  const originalFileHosts = useMemo(
-    () => config.hosts.filter((h) => h.source !== "env").map(({ name, host }) => ({ name, host })),
-    [config.hosts],
-  );
-  const hasChanges = fileHosts.length !== originalFileHosts.length ||
-    fileHosts.some((h, i) => h.name !== originalFileHosts[i]?.name || h.host !== originalFileHosts[i]?.host);
+	const originalFileHosts = useMemo(
+		() =>
+			config.hosts
+				.filter((h) => h.source !== "env")
+				.map(({ name, host }) => ({ name, host })),
+		[config.hosts],
+	);
+	const hasChanges =
+		fileHosts.length !== originalFileHosts.length ||
+		fileHosts.some(
+			(h, i) =>
+				h.name !== originalFileHosts[i]?.name ||
+				h.host !== originalFileHosts[i]?.host,
+		);
 
-  function handleSave() {
-    updateMutation.mutate(
-      fileHosts.map(({ name, host }) => ({ name, host })),
-      {
-        onSuccess: (msg) => toast.success(msg),
-        onError: (err) => toast.error(err.message),
-      },
-    );
-  }
+	function handleSave() {
+		updateMutation.mutate(
+			fileHosts.map(({ name, host }) => ({ name, host })),
+			{
+				onSuccess: (msg) => toast.success(msg),
+				onError: (err) => toast.error(err.message),
+			},
+		);
+	}
 
-  function handleRemove(index: number) {
-    setFileHosts((prev) => prev.filter((_, i) => i !== index));
-    setTestResults({});
-  }
+	function handleRemove(index: number) {
+		setFileHosts((prev) => prev.filter((_, i) => i !== index));
+		setTestResults({});
+	}
 
-  function handleStartEdit(index: number) {
-    setEditingIndex(index);
-    setEditingHost({ ...fileHosts[index] });
-  }
+	function handleStartEdit(index: number) {
+		setEditingIndex(index);
+		setEditingHost({ ...fileHosts[index] });
+	}
 
-  function handleCancelEdit() {
-    setEditingIndex(null);
-    setEditingHost({ name: "", host: "" });
-  }
+	function handleCancelEdit() {
+		setEditingIndex(null);
+		setEditingHost({ name: "", host: "" });
+	}
 
-  function handleSaveEdit() {
-    if (editingIndex === null) return;
-    if (!editingHost.name.trim() || !editingHost.host.trim()) {
-      toast.error("Name and host are required");
-      return;
-    }
-    const trimmedName = editingHost.name.trim();
-    if (envHosts.some((h) => h.name === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" is defined via environment variable`);
-      return;
-    }
-    if (fileHosts.some((h, i) => i !== editingIndex && h.name === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" already exists`);
-      return;
-    }
-    const next = [...fileHosts];
-    next[editingIndex] = { ...editingHost };
-    setFileHosts(next);
-    setEditingIndex(null);
-    setEditingHost({ name: "", host: "" });
-    setTestResults({});
-  }
+	function handleSaveEdit() {
+		if (editingIndex === null) return;
+		if (!editingHost.name.trim() || !editingHost.host.trim()) {
+			toast.error("Name and host are required");
+			return;
+		}
+		const trimmedName = editingHost.name.trim();
+		if (envHosts.some((h) => h.name === trimmedName)) {
+			toast.error(
+				`Host name "${trimmedName}" is defined via environment variable`,
+			);
+			return;
+		}
+		if (
+			fileHosts.some((h, i) => i !== editingIndex && h.name === trimmedName)
+		) {
+			toast.error(`Host name "${trimmedName}" already exists`);
+			return;
+		}
+		const next = [...fileHosts];
+		next[editingIndex] = { ...editingHost };
+		setFileHosts(next);
+		setEditingIndex(null);
+		setEditingHost({ name: "", host: "" });
+		setTestResults({});
+	}
 
-  function handleAddHost() {
-    if (!newHost.name.trim() || !newHost.host.trim()) {
-      toast.error("Name and host are required");
-      return;
-    }
-    const trimmedName = newHost.name.trim();
-    if (envHosts.some((h) => h.name === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" is already defined via environment variable`);
-      return;
-    }
-    if (fileHosts.some((h) => h.name === trimmedName)) {
-      toast.error(`Host name "${trimmedName}" already exists`);
-      return;
-    }
-    setFileHosts([...fileHosts, { name: trimmedName, host: newHost.host.trim() }]);
-    setNewHost({ name: "", host: "" });
-    setIsAdding(false);
-    setTestResults({});
-  }
+	function handleAddHost() {
+		if (!newHost.name.trim() || !newHost.host.trim()) {
+			toast.error("Name and host are required");
+			return;
+		}
+		const trimmedName = newHost.name.trim();
+		if (envHosts.some((h) => h.name === trimmedName)) {
+			toast.error(
+				`Host name "${trimmedName}" is already defined via environment variable`,
+			);
+			return;
+		}
+		if (fileHosts.some((h) => h.name === trimmedName)) {
+			toast.error(`Host name "${trimmedName}" already exists`);
+			return;
+		}
+		setFileHosts([
+			...fileHosts,
+			{ name: trimmedName, host: newHost.host.trim() },
+		]);
+		setNewHost({ name: "", host: "" });
+		setIsAdding(false);
+		setTestResults({});
+	}
 
-  function handleTest(key: string, hostUrl: string) {
-    setTestingKey(key);
-    setTestResults((prev) => {
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-    testMutation.mutate(
-      { name: key, host: hostUrl },
-      {
-        onSuccess: (result) => {
-          const engineLabel =
-            result.engine && result.engineVersion
-              ? `${result.engine} ${result.engineVersion}`
-              : `Docker ${result.dockerVersion ?? ""}`;
-          setTestResults((prev) => ({
-            ...prev,
-            [key]: {
-              success: result.success,
-              message: result.success
-                ? `Connected (${engineLabel})`
-                : result.message,
-            },
-          }));
-          setTestingKey(null);
-        },
-        onError: (err) => {
-          setTestResults((prev) => ({
-            ...prev,
-            [key]: { success: false, message: err.message },
-          }));
-          setTestingKey(null);
-        },
-      },
-    );
-  }
+	function handleTest(key: string, hostUrl: string) {
+		setTestingKey(key);
+		setTestResults((prev) => {
+			const next = { ...prev };
+			delete next[key];
+			return next;
+		});
+		testMutation.mutate(
+			{ name: key, host: hostUrl },
+			{
+				onSuccess: (result) => {
+					const engineLabel =
+						result.engine && result.engineVersion
+							? `${result.engine} ${result.engineVersion}`
+							: `Docker ${result.dockerVersion ?? ""}`;
+					setTestResults((prev) => ({
+						...prev,
+						[key]: {
+							success: result.success,
+							message: result.success
+								? `Connected (${engineLabel})`
+								: result.message,
+						},
+					}));
+					setTestingKey(null);
+				},
+				onError: (err) => {
+					setTestResults((prev) => ({
+						...prev,
+						[key]: { success: false, message: err.message },
+					}));
+					setTestingKey(null);
+				},
+			},
+		);
+	}
 
-  function renderRow(
-    h: { name: string; host: string },
-    isEnvRow: boolean,
-    fileIndex?: number,
-  ) {
-    const testKey = `${isEnvRow ? "env" : "file"}-${h.name}`;
-    const isEditing = !isEnvRow && editingIndex === fileIndex;
+	function renderRow(
+		h: { name: string; host: string },
+		isEnvRow: boolean,
+		fileIndex?: number,
+	) {
+		const testKey = `${isEnvRow ? "env" : "file"}-${h.name}`;
+		const isEditing = !isEnvRow && editingIndex === fileIndex;
 
-    if (isEditing && fileIndex !== undefined) {
-      return (
-        <TableRow key={testKey}>
-          <TableCell>
-            <Input
-              value={editingHost.name}
-              onChange={(e) =>
-                setEditingHost((prev) => ({ ...prev, name: e.target.value }))
-              }
-              className="h-8"
-            />
-          </TableCell>
-          <TableCell>
-            <Input
-              value={editingHost.host}
-              onChange={(e) =>
-                setEditingHost((prev) => ({ ...prev, host: e.target.value }))
-              }
-              className="h-8"
-              placeholder="unix:///var/run/docker.sock"
-            />
-          </TableCell>
-          <TableCell />
-          <TableCell className="text-right">
-            <div className="flex items-center justify-end gap-1">
-              <Button variant="ghost" size="sm" onClick={handleSaveEdit}>
-                Done
-              </Button>
-              <Button variant="ghost" size="sm" onClick={handleCancelEdit}>
-                Cancel
-              </Button>
-            </div>
-          </TableCell>
-        </TableRow>
-      );
-    }
+		if (isEditing && fileIndex !== undefined) {
+			return (
+				<TableRow key={testKey}>
+					<TableCell>
+						<Input
+							value={editingHost.name}
+							onChange={(e) =>
+								setEditingHost((prev) => ({ ...prev, name: e.target.value }))
+							}
+							className="h-8"
+						/>
+					</TableCell>
+					<TableCell>
+						<Input
+							value={editingHost.host}
+							onChange={(e) =>
+								setEditingHost((prev) => ({ ...prev, host: e.target.value }))
+							}
+							className="h-8"
+							placeholder="unix:///var/run/docker.sock"
+						/>
+					</TableCell>
+					<TableCell />
+					<TableCell className="text-right">
+						<div className="flex items-center justify-end gap-1">
+							<Button variant="ghost" size="sm" onClick={handleSaveEdit}>
+								Done
+							</Button>
+							<Button variant="ghost" size="sm" onClick={handleCancelEdit}>
+								Cancel
+							</Button>
+						</div>
+					</TableCell>
+				</TableRow>
+			);
+		}
 
-    return (
-      <TableRow key={testKey}>
-        <TableCell className="font-medium">
-          <div className="flex items-center gap-2">
-            {h.name}
-            {isEnvRow && <EnvBadge />}
-          </div>
-        </TableCell>
-        <TableCell className="font-mono text-xs text-muted-foreground">
-          {h.host}
-        </TableCell>
-        <TableCell>
-          {testResults[testKey] && (
-            <span
-              className={`text-xs ${testResults[testKey].success ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
-            >
-              {testResults[testKey].message}
-            </span>
-          )}
-        </TableCell>
-        <TableCell className="text-right">
-          <div className="flex items-center justify-end gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={testingKey === testKey}
-              onClick={() => handleTest(testKey, h.host)}
-            >
-              {testingKey === testKey ? <Spinner className="size-3" /> : "Test"}
-            </Button>
-            {!isEnvRow && fileIndex !== undefined && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={editingIndex !== null}
-                  onClick={() => handleStartEdit(fileIndex)}
-                >
-                  Edit
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={editingIndex !== null}
-                  onClick={() => handleRemove(fileIndex)}
-                  className="text-destructive hover:text-destructive"
-                >
-                  Remove
-                </Button>
-              </>
-            )}
-          </div>
-        </TableCell>
-      </TableRow>
-    );
-  }
+		return (
+			<TableRow key={testKey}>
+				<TableCell className="font-medium">
+					<div className="flex items-center gap-2">
+						{h.name}
+						{isEnvRow && <EnvBadge />}
+					</div>
+				</TableCell>
+				<TableCell className="font-mono text-xs text-muted-foreground">
+					{h.host}
+				</TableCell>
+				<TableCell>
+					{testResults[testKey] && (
+						<span
+							className={`text-xs ${testResults[testKey].success ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
+						>
+							{testResults[testKey].message}
+						</span>
+					)}
+				</TableCell>
+				<TableCell className="text-right">
+					<div className="flex items-center justify-end gap-1">
+						<Button
+							variant="ghost"
+							size="sm"
+							disabled={testingKey === testKey}
+							onClick={() => handleTest(testKey, h.host)}
+						>
+							{testingKey === testKey ? <Spinner className="size-3" /> : "Test"}
+						</Button>
+						{!isEnvRow && fileIndex !== undefined && (
+							<>
+								<Button
+									variant="ghost"
+									size="sm"
+									disabled={editingIndex !== null}
+									onClick={() => handleStartEdit(fileIndex)}
+								>
+									Edit
+								</Button>
+								<Button
+									variant="ghost"
+									size="sm"
+									disabled={editingIndex !== null}
+									onClick={() => handleRemove(fileIndex)}
+									className="text-destructive hover:text-destructive"
+								>
+									Remove
+								</Button>
+							</>
+						)}
+					</div>
+				</TableCell>
+			</TableRow>
+		);
+	}
 
-  const allHosts = [
-    ...envHosts.map((h) => ({ ...h, isEnv: true as const })),
-    ...fileHosts.map((h, i) => ({ ...h, source: "file" as const, isEnv: false as const, fileIndex: i })),
-  ];
+	const allHosts = [
+		...envHosts.map((h) => ({ ...h, isEnv: true as const })),
+		...fileHosts.map((h, i) => ({
+			...h,
+			source: "file" as const,
+			isEnv: false as const,
+			fileIndex: i,
+		})),
+	];
 
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Docker Hosts</CardTitle>
-        <CardDescription>
-          Configure which Docker or Podman sockets and remote hosts to connect
-          to.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {allHosts.length > 0 && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Host</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {allHosts.map((h) =>
-                renderRow(
-                  { name: h.name, host: h.host },
-                  h.isEnv,
-                  h.isEnv ? undefined : h.fileIndex,
-                ),
-              )}
-            </TableBody>
-          </Table>
-        )}
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Docker Hosts</CardTitle>
+				<CardDescription>
+					Configure which Docker or Podman sockets and remote hosts to connect
+					to.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{allHosts.length > 0 && (
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead>Host</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead className="text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{allHosts.map((h) =>
+								renderRow(
+									{ name: h.name, host: h.host },
+									h.isEnv,
+									h.isEnv ? undefined : h.fileIndex,
+								),
+							)}
+						</TableBody>
+					</Table>
+				)}
 
-        {allHosts.length === 0 && !isAdding && (
-          <p className="text-sm text-muted-foreground">
-            No Docker hosts configured.
-          </p>
-        )}
+				{allHosts.length === 0 && !isAdding && (
+					<p className="text-sm text-muted-foreground">
+						No Docker hosts configured.
+					</p>
+				)}
 
-        {isAdding && (
-          <div className="flex items-end gap-3 border rounded-md p-3">
-            <div className="space-y-1.5 flex-1">
-              <Label htmlFor="new-docker-name">Name</Label>
-              <Input
-                id="new-docker-name"
-                value={newHost.name}
-                onChange={(e) =>
-                  setNewHost((prev) => ({ ...prev, name: e.target.value }))
-                }
-                placeholder="my-server"
-                className="h-8"
-              />
-            </div>
-            <div className="space-y-1.5 flex-[2]">
-              <Label htmlFor="new-docker-host">Host</Label>
-              <Input
-                id="new-docker-host"
-                value={newHost.host}
-                onChange={(e) =>
-                  setNewHost((prev) => ({ ...prev, host: e.target.value }))
-                }
-                placeholder="ssh://root@10.0.0.1"
-                className="h-8"
-              />
-            </div>
-            <div className="flex gap-1">
-              <Button size="sm" onClick={handleAddHost}>
-                Add
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => {
-                  setIsAdding(false);
-                  setNewHost({ name: "", host: "" });
-                }}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
+				{isAdding && (
+					<div className="flex items-end gap-3 border rounded-md p-3">
+						<div className="space-y-1.5 flex-1">
+							<Label htmlFor="new-docker-name">Name</Label>
+							<Input
+								id="new-docker-name"
+								value={newHost.name}
+								onChange={(e) =>
+									setNewHost((prev) => ({ ...prev, name: e.target.value }))
+								}
+								placeholder="my-server"
+								className="h-8"
+							/>
+						</div>
+						<div className="space-y-1.5 flex-[2]">
+							<Label htmlFor="new-docker-host">Host</Label>
+							<Input
+								id="new-docker-host"
+								value={newHost.host}
+								onChange={(e) =>
+									setNewHost((prev) => ({ ...prev, host: e.target.value }))
+								}
+								placeholder="ssh://root@10.0.0.1"
+								className="h-8"
+							/>
+						</div>
+						<div className="flex gap-1">
+							<Button size="sm" onClick={handleAddHost}>
+								Add
+							</Button>
+							<Button
+								size="sm"
+								variant="ghost"
+								onClick={() => {
+									setIsAdding(false);
+									setNewHost({ name: "", host: "" });
+								}}
+							>
+								Cancel
+							</Button>
+						</div>
+					</div>
+				)}
 
-        <div className="flex items-center gap-2">
-          {!isAdding && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsAdding(true)}
-            >
-              Add host
-            </Button>
-          )}
-          {hasChanges && (
-            <Button
-              size="sm"
-              disabled={updateMutation.isPending}
-              onClick={handleSave}
-            >
-              {updateMutation.isPending ? (
-                <>
-                  <Spinner className="size-3" />
-                  Saving...
-                </>
-              ) : (
-                "Save changes"
-              )}
-            </Button>
-          )}
-        </div>
-      </CardContent>
-    </Card>
-  );
+				<div className="flex items-center gap-2">
+					{!isAdding && (
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setIsAdding(true)}
+						>
+							Add host
+						</Button>
+					)}
+					{hasChanges && (
+						<Button
+							size="sm"
+							disabled={updateMutation.isPending}
+							onClick={handleSave}
+						>
+							{updateMutation.isPending ? (
+								<>
+									<Spinner className="size-3" />
+									Saving...
+								</>
+							) : (
+								"Save changes"
+							)}
+						</Button>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
 }

--- a/frontend/src/features/settings/components/env-badge.tsx
+++ b/frontend/src/features/settings/components/env-badge.tsx
@@ -1,9 +1,9 @@
 import { Badge } from "@/components/ui/badge";
 
 export function EnvBadge() {
-  return (
-    <Badge variant="secondary" className="text-xs font-normal">
-      Set via environment variable
-    </Badge>
-  );
+	return (
+		<Badge variant="secondary" className="text-xs font-normal">
+			Set via environment variable
+		</Badge>
+	);
 }

--- a/frontend/src/features/settings/components/read-only-section.tsx
+++ b/frontend/src/features/settings/components/read-only-section.tsx
@@ -1,11 +1,11 @@
 import { toast } from "sonner";
 
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -15,45 +15,45 @@ import type { ReadOnlyConfig } from "../types";
 import { EnvBadge } from "./env-badge";
 
 interface ReadOnlySectionProps {
-  config: ReadOnlyConfig;
+	config: ReadOnlyConfig;
 }
 
 export function ReadOnlySection({ config }: ReadOnlySectionProps) {
-  const isEnv = config.source === "env";
-  const mutation = useUpdateReadOnly();
+	const isEnv = config.source === "env";
+	const mutation = useUpdateReadOnly();
 
-  function handleToggle(checked: boolean) {
-    mutation.mutate(checked, {
-      onSuccess: (msg) => toast.success(msg),
-      onError: (err) => toast.error(err.message),
-    });
-  }
+	function handleToggle(checked: boolean) {
+		mutation.mutate(checked, {
+			onSuccess: (msg) => toast.success(msg),
+			onError: (err) => toast.error(err.message),
+		});
+	}
 
-  return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-3">
-          <CardTitle>Read-Only Mode</CardTitle>
-          {isEnv && <EnvBadge />}
-        </div>
-        <CardDescription>
-          When enabled, container actions (start, stop, restart, remove) are
-          disabled. Log viewing is unaffected.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-center gap-3">
-          <Switch
-            id="read-only"
-            checked={config.value}
-            onCheckedChange={handleToggle}
-            disabled={isEnv || mutation.isPending}
-          />
-          <Label htmlFor="read-only" className="cursor-pointer">
-            {config.value ? "Enabled" : "Disabled"}
-          </Label>
-        </div>
-      </CardContent>
-    </Card>
-  );
+	return (
+		<Card>
+			<CardHeader>
+				<div className="flex items-center gap-3">
+					<CardTitle>Read-Only Mode</CardTitle>
+					{isEnv && <EnvBadge />}
+				</div>
+				<CardDescription>
+					When enabled, container actions (start, stop, restart, remove) are
+					disabled. Log viewing is unaffected.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="flex items-center gap-3">
+					<Switch
+						id="read-only"
+						checked={config.value}
+						onCheckedChange={handleToggle}
+						disabled={isEnv || mutation.isPending}
+					/>
+					<Label htmlFor="read-only" className="cursor-pointer">
+						{config.value ? "Enabled" : "Disabled"}
+					</Label>
+				</div>
+			</CardContent>
+		</Card>
+	);
 }

--- a/frontend/src/features/settings/components/settings-page.tsx
+++ b/frontend/src/features/settings/components/settings-page.tsx
@@ -7,42 +7,51 @@ import { DockerHostsSection } from "./docker-hosts-section";
 import { ReadOnlySection } from "./read-only-section";
 
 export function SettingsPage() {
-  const { data, isLoading, error } = useSettings();
+	const { data, isLoading, error } = useSettings();
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <Spinner className="size-6" />
-      </div>
-    );
-  }
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center py-20">
+				<Spinner className="size-6" />
+			</div>
+		);
+	}
 
-  if (error) {
-    return (
-      <div className="container mx-auto max-w-3xl px-4 py-8">
-        <p className="text-sm text-destructive">
-          Failed to load settings: {error.message}
-        </p>
-      </div>
-    );
-  }
+	if (error) {
+		return (
+			<div className="container mx-auto max-w-3xl px-4 py-8">
+				<p className="text-sm text-destructive">
+					Failed to load settings: {error.message}
+				</p>
+			</div>
+		);
+	}
 
-  if (!data) return null;
+	if (!data) return null;
 
-  return (
-    <div className="container mx-auto max-w-3xl px-4 py-8 space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Manage LogDeck configuration. Sections marked as set via environment
-          variable can only be changed by updating the environment and
-          restarting.
-        </p>
-      </div>
-      <DockerHostsSection key={JSON.stringify(data.dockerHosts)} config={data.dockerHosts} />
-      <CoolifyHostsSection key={JSON.stringify(data.coolifyHosts)} config={data.coolifyHosts} />
-      <ReadOnlySection config={data.readOnly} />
-      <AuthSection key={`${data.auth.enabled}-${data.auth.adminUsername}`} config={data.auth} />
-    </div>
-  );
+	return (
+		<div className="container mx-auto max-w-3xl px-4 py-8 space-y-6">
+			<div>
+				<h1 className="text-2xl font-bold tracking-tight">Settings</h1>
+				<p className="text-sm text-muted-foreground mt-1">
+					Manage LogDeck configuration. Sections marked as set via environment
+					variable can only be changed by updating the environment and
+					restarting.
+				</p>
+			</div>
+			<DockerHostsSection
+				key={JSON.stringify(data.dockerHosts)}
+				config={data.dockerHosts}
+			/>
+			<CoolifyHostsSection
+				key={JSON.stringify(data.coolifyHosts)}
+				config={data.coolifyHosts}
+			/>
+			<ReadOnlySection config={data.readOnly} />
+			<AuthSection
+				key={`${data.auth.enabled}-${data.auth.adminUsername}`}
+				config={data.auth}
+			/>
+		</div>
+	);
 }

--- a/frontend/src/features/settings/hooks/use-settings.ts
+++ b/frontend/src/features/settings/hooks/use-settings.ts
@@ -3,78 +3,81 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getSettings } from "../api/get-settings";
 import { testCoolifyHost } from "../api/test-coolify-host";
 import { testDockerHost } from "../api/test-docker-host";
-import { updateAuth, type UpdateAuthPayload } from "../api/update-auth";
+import { type UpdateAuthPayload, updateAuth } from "../api/update-auth";
 import { updateCoolifyHosts } from "../api/update-coolify-hosts";
 import { updateDockerHosts } from "../api/update-docker-hosts";
 import { updateReadOnly } from "../api/update-read-only";
+
 const SETTINGS_KEY = ["settings"] as const;
 
 export function useSettings() {
-  return useQuery({
-    queryKey: SETTINGS_KEY,
-    queryFn: getSettings,
-    staleTime: 30_000,
-  });
+	return useQuery({
+		queryKey: SETTINGS_KEY,
+		queryFn: getSettings,
+		staleTime: 30_000,
+	});
 }
 
 export function useUpdateDockerHosts() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (hosts: { name: string; host: string }[]) => updateDockerHosts(hosts),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
-    },
-  });
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (hosts: { name: string; host: string }[]) =>
+			updateDockerHosts(hosts),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
+		},
+	});
 }
 
 export function useUpdateCoolifyHosts() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (hosts: { hostName: string; apiURL: string; apiToken: string }[]) =>
-      updateCoolifyHosts(hosts),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
-    },
-  });
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (
+			hosts: { hostName: string; apiURL: string; apiToken: string }[],
+		) => updateCoolifyHosts(hosts),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
+		},
+	});
 }
 
 export function useUpdateReadOnly() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (value: boolean) => updateReadOnly(value),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
-    },
-  });
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (value: boolean) => updateReadOnly(value),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
+		},
+	});
 }
 
 export function useUpdateAuth() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (payload: UpdateAuthPayload) => updateAuth(payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
-    },
-  });
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (payload: UpdateAuthPayload) => updateAuth(payload),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
+		},
+	});
 }
 
 export function useTestDockerHost() {
-  return useMutation({
-    mutationFn: ({ name, host }: { name: string; host: string }) =>
-      testDockerHost(name, host),
-  });
+	return useMutation({
+		mutationFn: ({ name, host }: { name: string; host: string }) =>
+			testDockerHost(name, host),
+	});
 }
 
 export function useTestCoolifyHost() {
-  return useMutation({
-    mutationFn: ({
-      hostName,
-      apiURL,
-      apiToken,
-    }: {
-      hostName: string;
-      apiURL: string;
-      apiToken: string;
-    }) => testCoolifyHost(hostName, apiURL, apiToken),
-  });
+	return useMutation({
+		mutationFn: ({
+			hostName,
+			apiURL,
+			apiToken,
+		}: {
+			hostName: string;
+			apiURL: string;
+			apiToken: string;
+		}) => testCoolifyHost(hostName, apiURL, apiToken),
+	});
 }

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -1,51 +1,51 @@
 export type ConfigSource = "file" | "env" | "default" | "mixed";
 
 export interface DockerHost {
-  name: string;
-  host: string;
-  source: ConfigSource;
+	name: string;
+	host: string;
+	source: ConfigSource;
 }
 
 export interface CoolifyHost {
-  hostName: string;
-  apiURL: string;
-  apiToken: string;
-  source: ConfigSource;
+	hostName: string;
+	apiURL: string;
+	apiToken: string;
+	source: ConfigSource;
 }
 
 export interface DockerHostsConfig {
-  source: ConfigSource;
-  hosts: DockerHost[];
+	source: ConfigSource;
+	hosts: DockerHost[];
 }
 
 export interface CoolifyHostsConfig {
-  source: ConfigSource;
-  hosts: CoolifyHost[];
+	source: ConfigSource;
+	hosts: CoolifyHost[];
 }
 
 export interface ReadOnlyConfig {
-  source: ConfigSource;
-  value: boolean;
+	source: ConfigSource;
+	value: boolean;
 }
 
 export interface AuthConfig {
-  source: ConfigSource;
-  enabled: boolean;
-  adminUsername?: string;
+	source: ConfigSource;
+	enabled: boolean;
+	adminUsername?: string;
 }
 
 export interface SettingsResponse {
-  dockerHosts: DockerHostsConfig;
-  coolifyHosts: CoolifyHostsConfig;
-  readOnly: ReadOnlyConfig;
-  auth: AuthConfig;
+	dockerHosts: DockerHostsConfig;
+	coolifyHosts: CoolifyHostsConfig;
+	readOnly: ReadOnlyConfig;
+	auth: AuthConfig;
 }
 
 export interface TestConnectionResult {
-  success: boolean;
-  message: string;
-  dockerVersion?: string;
-  /** "Docker" or "Podman", when the server could identify the engine. */
-  engine?: string;
-  engineVersion?: string;
+	success: boolean;
+	message: string;
+	dockerVersion?: string;
+	/** "Docker" or "Podman", when the server could identify the engine. */
+	engine?: string;
+	engineVersion?: string;
 }

--- a/frontend/src/integrations/tanstack-query/devtools.tsx
+++ b/frontend/src/integrations/tanstack-query/devtools.tsx
@@ -1,6 +1,6 @@
-import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools'
+import { ReactQueryDevtoolsPanel } from "@tanstack/react-query-devtools";
 
 export default {
-  name: 'Tanstack Query',
-  render: <ReactQueryDevtoolsPanel />,
-}
+	name: "Tanstack Query",
+	render: <ReactQueryDevtoolsPanel />,
+};

--- a/frontend/src/integrations/tanstack-query/root-provider.tsx
+++ b/frontend/src/integrations/tanstack-query/root-provider.tsx
@@ -1,20 +1,20 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 export function getContext() {
-  const queryClient = new QueryClient()
-  return {
-    queryClient,
-  }
+	const queryClient = new QueryClient();
+	return {
+		queryClient,
+	};
 }
 
 export function Provider({
-  children,
-  queryClient,
+	children,
+	queryClient,
 }: {
-  children: React.ReactNode
-  queryClient: QueryClient
+	children: React.ReactNode;
+	queryClient: QueryClient;
 }) {
-  return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  )
+	return (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
 }

--- a/frontend/src/lib/json-format.ts
+++ b/frontend/src/lib/json-format.ts
@@ -1,14 +1,20 @@
 const JSON_CACHE_LIMIT = 1000;
-const jsonFormatCache = new Map<string, { formatted: string; isJson: boolean }>();
+const jsonFormatCache = new Map<
+	string,
+	{ formatted: string; isJson: boolean }
+>();
 
-function setCachedValue(text: string, value: { formatted: string; isJson: boolean }) {
-  if (jsonFormatCache.size >= JSON_CACHE_LIMIT) {
-    const oldestKey = jsonFormatCache.keys().next().value;
-    if (oldestKey) {
-      jsonFormatCache.delete(oldestKey);
-    }
-  }
-  jsonFormatCache.set(text, value);
+function setCachedValue(
+	text: string,
+	value: { formatted: string; isJson: boolean },
+) {
+	if (jsonFormatCache.size >= JSON_CACHE_LIMIT) {
+		const oldestKey = jsonFormatCache.keys().next().value;
+		if (oldestKey) {
+			jsonFormatCache.delete(oldestKey);
+		}
+	}
+	jsonFormatCache.set(text, value);
 }
 
 /**
@@ -16,33 +22,37 @@ function setCachedValue(text: string, value: { formatted: string; isJson: boolea
  * Returns formatted JSON with isJson flag on success.
  * Returns original text with isJson: false on failure.
  */
-export function formatJson(
-  text: string
-): { formatted: string; isJson: boolean } {
-  const cached = jsonFormatCache.get(text);
-  if (cached) return cached;
+export function formatJson(text: string): {
+	formatted: string;
+	isJson: boolean;
+} {
+	const cached = jsonFormatCache.get(text);
+	if (cached) return cached;
 
-  const trimmed = text.trim();
-  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
-    const result = { formatted: text, isJson: false };
-    setCachedValue(text, result);
-    return result;
-  }
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+		const result = { formatted: text, isJson: false };
+		setCachedValue(text, result);
+		return result;
+	}
 
-  try {
-    const parsed = JSON.parse(trimmed);
-    if (typeof parsed === "object" && parsed !== null) {
-      const result = { formatted: JSON.stringify(parsed, null, 2), isJson: true };
-      setCachedValue(text, result);
-      return result;
-    }
-  } catch {
-    // fall through to non-JSON result
-  }
+	try {
+		const parsed = JSON.parse(trimmed);
+		if (typeof parsed === "object" && parsed !== null) {
+			const result = {
+				formatted: JSON.stringify(parsed, null, 2),
+				isJson: true,
+			};
+			setCachedValue(text, result);
+			return result;
+		}
+	} catch {
+		// fall through to non-JSON result
+	}
 
-  const result = { formatted: text, isJson: false };
-  setCachedValue(text, result);
-  return result;
+	const result = { formatted: text, isJson: false };
+	setCachedValue(text, result);
+	return result;
 }
 
 /**
@@ -51,5 +61,5 @@ export function formatJson(
  * Only returns true for objects and arrays.
  */
 export function isJsonString(text: string): boolean {
-  return formatJson(text).isJson;
+	return formatJson(text).isJson;
 }

--- a/frontend/src/lib/ndjson.ts
+++ b/frontend/src/lib/ndjson.ts
@@ -2,47 +2,47 @@
  * Iterates over an NDJSON response stream, yielding one parsed value per line.
  */
 export async function* iterateNDJSONStream<T>(
-  stream: ReadableStream<Uint8Array>,
-  signal?: AbortSignal
+	stream: ReadableStream<Uint8Array>,
+	signal?: AbortSignal,
 ): AsyncGenerator<T, void, unknown> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
 
-  try {
-    while (true) {
-      if (signal?.aborted) {
-        reader.cancel().catch(() => {});
-        break;
-      }
+	try {
+		while (true) {
+			if (signal?.aborted) {
+				reader.cancel().catch(() => {});
+				break;
+			}
 
-      const { done, value } = await reader.read();
-      if (done) break;
+			const { done, value } = await reader.read();
+			if (done) break;
 
-      buffer += decoder.decode(value, { stream: true });
+			buffer += decoder.decode(value, { stream: true });
 
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+			const lines = buffer.split("\n");
+			buffer = lines.pop() ?? "";
 
-      for (const line of lines) {
-        if (line.trim()) {
-          try {
-            yield JSON.parse(line) as T;
-          } catch (error) {
-            console.error("Failed to parse NDJSON line:", line, error);
-          }
-        }
-      }
-    }
+			for (const line of lines) {
+				if (line.trim()) {
+					try {
+						yield JSON.parse(line) as T;
+					} catch (error) {
+						console.error("Failed to parse NDJSON line:", line, error);
+					}
+				}
+			}
+		}
 
-    if (buffer.trim()) {
-      try {
-        yield JSON.parse(buffer) as T;
-      } catch (error) {
-        console.error("Failed to parse final NDJSON line:", buffer, error);
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
+		if (buffer.trim()) {
+			try {
+				yield JSON.parse(buffer) as T;
+			} catch (error) {
+				console.error("Failed to parse final NDJSON line:", buffer, error);
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,13 +1,13 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+	return twMerge(clsx(inputs));
 }
 
 /**
  * Escapes special regex metacharacters in a string for safe use in RegExp
  */
 export function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/frontend/src/routes/containers/$containerId/logs.tsx
+++ b/frontend/src/routes/containers/$containerId/logs.tsx
@@ -5,12 +5,13 @@ import {
 	useNavigate,
 	useRouter,
 } from "@tanstack/react-router";
-import { ArrowLeftIcon, ChevronDownIcon, TerminalIcon } from "lucide-react";
-import { useRef, useState } from "react";
+import { ArrowLeftIcon, TerminalIcon } from "lucide-react";
+import { useRef } from "react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
 	Tooltip,
 	TooltipContent,
@@ -50,10 +51,6 @@ function ContainerLogsPage() {
 	const canGoBack = useCanGoBack();
 	const queryClient = useQueryClient();
 
-	const [showLabels, setShowLabels] = useState(false);
-	const [showEnvVariables, setShowEnvVariables] = useState(false);
-	const [showResourceLimits, setShowResourceLimits] = useState(false);
-	const [showTerminal, setShowTerminal] = useState(false);
 	const logViewerRef = useRef<LogViewerHandle>(null);
 	const logViewState = useUrlLogViewState();
 
@@ -236,62 +233,26 @@ function ContainerLogsPage() {
 										</div>
 									</div>
 
-									{/* Labels Section */}
-									{container.labels &&
-										Object.keys(container.labels).length > 0 && (
-											<div className="space-y-2 border-t pt-4">
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={() => setShowLabels((value) => !value)}
-													className="h-8 w-full justify-start text-muted-foreground hover:text-foreground"
-												>
-													<ChevronDownIcon
-														className={`mr-2 size-4 transition-transform ${
-															showLabels ? "rotate-180" : ""
-														}`}
-													/>
-													{showLabels ? "Hide" : "Show"} container labels (
-													{Object.keys(container.labels).length})
-												</Button>
-												{showLabels && (
-													<div className="max-h-[200px] space-y-2 overflow-y-auto rounded-md border bg-muted/30 p-3">
-														{Object.entries(container.labels).map(
-															([key, value]) => (
-																<div
-																	key={key}
-																	className="rounded-md bg-background p-2 text-xs"
-																>
-																	<div className="mb-1 font-semibold text-foreground">
-																		{key}
-																	</div>
-																	<div className="break-all font-mono text-muted-foreground">
-																		{value}
-																	</div>
-																</div>
-															),
-														)}
-													</div>
-												)}
-											</div>
-										)}
+									<Tabs defaultValue="environment" className="border-t pt-4">
+										<TabsList>
+											<TabsTrigger value="environment">Environment</TabsTrigger>
+											<TabsTrigger value="resources">Resources</TabsTrigger>
+											<TabsTrigger value="labels">
+												Labels
+												{container.labels &&
+													Object.keys(container.labels).length > 0 && (
+														<span className="text-muted-foreground">
+															{Object.keys(container.labels).length}
+														</span>
+													)}
+											</TabsTrigger>
+											<TabsTrigger value="terminal">
+												<TerminalIcon className="size-4" />
+												Terminal
+											</TabsTrigger>
+										</TabsList>
 
-									{/* Environment Variables Section */}
-									<div className="space-y-2 border-t pt-4">
-										<Button
-											variant="ghost"
-											size="sm"
-											onClick={() => setShowEnvVariables((value) => !value)}
-											className="h-8 w-full justify-start text-muted-foreground hover:text-foreground"
-										>
-											<ChevronDownIcon
-												className={`mr-2 size-4 transition-transform ${
-													showEnvVariables ? "rotate-180" : ""
-												}`}
-											/>
-											{showEnvVariables ? "Hide" : "Show"} environment variables
-										</Button>
-										{showEnvVariables && container && (
+										<TabsContent value="environment" className="pt-2">
 											<div className="max-h-[300px] overflow-y-auto">
 												<EnvironmentVariables
 													containerId={actualContainerId}
@@ -300,58 +261,50 @@ function ContainerLogsPage() {
 													onContainerIdChange={handleContainerRecreated}
 												/>
 											</div>
-										)}
-									</div>
+										</TabsContent>
 
-									{/* Resource Limits Section */}
-									<div className="space-y-2 border-t pt-4">
-										<Button
-											variant="ghost"
-											size="sm"
-											onClick={() => setShowResourceLimits((value) => !value)}
-											className="h-8 w-full justify-start text-muted-foreground hover:text-foreground"
-										>
-											<ChevronDownIcon
-												className={`mr-2 size-4 transition-transform ${
-													showResourceLimits ? "rotate-180" : ""
-												}`}
-											/>
-											{showResourceLimits ? "Hide" : "Show"} resource limits
-										</Button>
-										{showResourceLimits && container && (
+										<TabsContent value="resources" className="pt-2">
 											<ResourceLimits
 												containerId={actualContainerId}
 												containerHost={container.host}
 												isReadOnly={containersData?.readOnly}
 											/>
-										)}
-									</div>
+										</TabsContent>
 
-									{/* Terminal Section */}
-									<div className="space-y-2 border-t pt-4">
-										<Button
-											variant="ghost"
-											size="sm"
-											onClick={() => setShowTerminal((value) => !value)}
-											className="h-8 w-full justify-start text-muted-foreground hover:text-foreground"
-										>
-											<ChevronDownIcon
-												className={`mr-2 size-4 transition-transform ${
-													showTerminal ? "rotate-180" : ""
-												}`}
+										<TabsContent value="labels" className="pt-2">
+											{container.labels &&
+											Object.keys(container.labels).length > 0 ? (
+												<div className="max-h-[300px] overflow-y-auto">
+													{Object.entries(container.labels).map(
+														([key, value]) => (
+															<div
+																key={key}
+																className="border-b py-2 text-xs last:border-b-0"
+															>
+																<div className="mb-0.5 font-medium text-foreground">
+																	{key}
+																</div>
+																<div className="break-all font-mono text-muted-foreground">
+																	{value}
+																</div>
+															</div>
+														),
+													)}
+												</div>
+											) : (
+												<p className="py-2 text-sm text-muted-foreground">
+													This container has no labels.
+												</p>
+											)}
+										</TabsContent>
+
+										<TabsContent value="terminal" className="pt-2">
+											<Terminal
+												containerId={actualContainerId}
+												host={container.host}
 											/>
-											<TerminalIcon className="mr-2 size-4" />
-											{showTerminal ? "Hide" : "Show"} terminal
-										</Button>
-										{container && showTerminal && (
-											<div className="mt-2">
-												<Terminal
-													containerId={actualContainerId}
-													host={container.host}
-												/>
-											</div>
-										)}
-									</div>
+										</TabsContent>
+									</Tabs>
 								</div>
 							</CardContent>
 						</Card>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,31 +6,31 @@ import { requireAuthIfEnabled } from "@/lib/auth-guard";
 
 // Define search params schema for the dashboard
 const dashboardSearchSchema = z
-  .object({
-    search: z.string().optional(),
-    state: z.string().optional(),
-    sort: z.enum(["asc", "desc"]).optional(),
-    group: z.enum(["none", "compose"]).optional(),
-    page: z.number().optional(),
-    pageSize: z.number().optional(),
-    from: z.string().optional(),
-    to: z.string().optional(),
-  })
-  .passthrough()
-  .catch({});
+	.object({
+		search: z.string().optional(),
+		state: z.string().optional(),
+		sort: z.enum(["asc", "desc"]).optional(),
+		group: z.enum(["none", "compose"]).optional(),
+		page: z.number().optional(),
+		pageSize: z.number().optional(),
+		from: z.string().optional(),
+		to: z.string().optional(),
+	})
+	.passthrough()
+	.catch({});
 
 export const Route = createFileRoute("/")({
-  validateSearch: dashboardSearchSchema.parse,
-  beforeLoad: async () => {
-    await requireAuthIfEnabled();
-  },
-  component: Index,
+	validateSearch: dashboardSearchSchema.parse,
+	beforeLoad: async () => {
+		await requireAuthIfEnabled();
+	},
+	component: Index,
 });
 
 function Index() {
-  return (
-    <main className="container mx-auto px-4 py-8">
-      <ContainersDashboard />
-    </main>
-  );
+	return (
+		<main className="container mx-auto px-4 py-8">
+			<ContainersDashboard />
+		</main>
+	);
 }

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -4,8 +4,8 @@ import { SettingsPage } from "@/features/settings/components/settings-page";
 import { requireAuthIfEnabled } from "@/lib/auth-guard";
 
 export const Route = createFileRoute("/settings")({
-  beforeLoad: async () => {
-    await requireAuthIfEnabled();
-  },
-  component: SettingsPage,
+	beforeLoad: async () => {
+		await requireAuthIfEnabled();
+	},
+	component: SettingsPage,
 });


### PR DESCRIPTION
Follow-up UX pass on the container detail page after the feature wave (#73-#78), plus the formatting baseline. Four commits, best reviewed individually:

## 1. Repo-wide biome formatting (`style`)
All 53 pre-existing violations were safe fixes (tab indentation and import ordering). `biome check` is now fully clean on the frontend, so the formatter can be enforced going forward. Whitespace/import-order only — no behavioral changes. This is the bulk of the diff; review the remaining commits for the real changes.

## 2. Tabbed detail sections
The four stacked collapsible sections (labels, environment variables, resource limits, terminal) are replaced with a flat tabbed panel — Environment | Resources | Labels | Terminal — removing the cards-in-cards nesting. Labels render as simple rows. The terminal still only connects when its tab is opened. Adds `@radix-ui/react-tabs` and the shadcn Tabs primitive.

## 3. Environment editor as a key/value table with bulk paste
The per-variable bordered boxes (each repeating Key/Value labels around disabled inputs) become a single header row with dense monospace rows — plain text in view mode, inputs only while editing. New: pasting a multi-line `.env` into the key field imports every pair at once, updating existing keys and adding new ones (comments skipped, quotes stripped). Implemented via `onPaste` interception since text inputs strip newlines before `onChange`; the parser is exported and unit-tested.

## 4. Calendar-based custom time range in the log viewer
The custom range editor swaps native `datetime-local` inputs for the shadcn range Calendar plus from/to time fields, matching the dashboard's date-range picker. The trigger button shows the selected range instead of a generic Edit label.

## Verification
- TypeScript, biome (clean), and all 73 frontend tests pass; production build succeeds.
- Exercised live against Podman 6.0.1: tab switching, env editing, a real multi-line `.env` paste (existing key updated + two added with badges), and a calendar range applied end-to-end (`since`/`until` propagate to the URL and the log query).

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV