### PR TITLE
fix: shift-click selection highlight and keyboard-shortcut help overlay

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/features/containers/components/log-viewer/log-viewer.test.tsx
+++ b/frontend/src/features/containers/components/log-viewer/log-viewer.test.tsx
@@ -176,3 +176,43 @@ describe("LogViewer streaming lifecycle", () => {
 		expect(streamSignal?.aborted).toBe(true);
 	});
 });
+
+describe("LogViewer shortcut help overlay", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mocks.getLogs.mockReset().mockResolvedValue([]);
+		mocks.streamLogs.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("toggles the overlay with ? and ignores ? typed into inputs", async () => {
+		await act(async () => {
+			render(<Harness />);
+			await drainMicrotasks();
+		});
+		expect(screen.queryByText("Keyboard shortcuts")).toBeNull();
+
+		// ? typed while focused in an input must not open the overlay.
+		await act(async () => {
+			fireEvent.keyDown(screen.getByPlaceholderText("Search logs..."), {
+				key: "?",
+				shiftKey: true,
+			});
+		});
+		expect(screen.queryByText("Keyboard shortcuts")).toBeNull();
+
+		await act(async () => {
+			fireEvent.keyDown(window, { key: "?", shiftKey: true });
+		});
+		expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
+
+		// Pressing ? again closes it.
+		await act(async () => {
+			fireEvent.keyDown(window, { key: "?", shiftKey: true });
+		});
+		expect(screen.queryByText("Keyboard shortcuts")).toBeNull();
+	});
+});

--- a/frontend/src/features/containers/components/log-viewer/log-viewer.tsx
+++ b/frontend/src/features/containers/components/log-viewer/log-viewer.tsx
@@ -79,6 +79,7 @@ import { SelectionActionBar } from "@/features/containers/components/selection-a
 import { useContainerLogStream } from "@/features/containers/hooks/use-container-log-stream";
 import { isJsonString } from "@/lib/json-format";
 import { mapRawRangeToGroupedRange } from "./animated-range";
+import { ShortcutHelpDialog } from "./shortcut-help";
 import { resolveTimeRange } from "./time-range";
 import { TimeRangeControl } from "./time-range-control";
 import { useLogFiltering } from "./use-log-filtering";
@@ -180,6 +181,7 @@ export function LogViewer({
 		new Set(),
 	);
 	const [lastClickedIndex, setLastClickedIndex] = useState<number | null>(null);
+	const [showShortcutHelp, setShowShortcutHelp] = useState(false);
 	const parentRef = useRef<HTMLDivElement>(null);
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const autoScrollRef = useRef(autoScroll);
@@ -697,6 +699,12 @@ export function LogViewer({
 				return;
 			}
 
+			if (event.key === "?") {
+				event.preventDefault();
+				setShowShortcutHelp((prev) => !prev);
+				return;
+			}
+
 			if (event.key === "/") {
 				event.preventDefault();
 				focusSearchInput();
@@ -1013,7 +1021,14 @@ export function LogViewer({
 				lines, <kbd className="font-mono">n</kbd>/
 				<kbd className="font-mono">N</kbd> matches,{" "}
 				<kbd className="font-mono">p</kbd>/<kbd className="font-mono">P</kbd>{" "}
-				pins
+				pins,{" "}
+				<button
+					type="button"
+					onClick={() => setShowShortcutHelp(true)}
+					className="underline underline-offset-2 hover:text-foreground"
+				>
+					<kbd className="font-mono">?</kbd> help
+				</button>
 			</p>
 			{/* Row 2: Options bar */}
 			<div className="flex flex-wrap items-center gap-2">
@@ -1298,12 +1313,9 @@ export function LogViewer({
 								Download as TXT
 							</DropdownMenuItem>
 							<DropdownMenuSeparator />
-							<DropdownMenuItem
-								disabled
-								className="text-[11px] text-muted-foreground"
-							>
-								<HelpCircleIcon className="size-3 mr-2" />/ search, j/k lines,
-								n/N matches
+							<DropdownMenuItem onClick={() => setShowShortcutHelp(true)}>
+								<HelpCircleIcon className="size-3.5 mr-2" />
+								Keyboard shortcuts
 							</DropdownMenuItem>
 						</DropdownMenuContent>
 					</DropdownMenu>
@@ -1457,6 +1469,12 @@ export function LogViewer({
 									role="button"
 									tabIndex={0}
 									onClick={(e) => handleLogClick(virtualRow.index, e)}
+									onMouseDown={(e) => {
+										// Suppress native text selection on shift-click so range
+										// selection doesn't highlight everything in between;
+										// normal click-drag selection stays intact.
+										if (e.shiftKey) e.preventDefault();
+									}}
 									onKeyDown={(e) => {
 										if (e.key === "Enter" || e.key === " ") {
 											e.preventDefault();
@@ -1554,11 +1572,19 @@ export function LogViewer({
 		</CardContent>
 	);
 
+	const shortcutHelpDialog = (
+		<ShortcutHelpDialog
+			open={showShortcutHelp}
+			onOpenChange={setShowShortcutHelp}
+		/>
+	);
+
 	if (variant === "page") {
 		return (
 			<Card>
 				<CardHeader>{pageToolbar}</CardHeader>
 				{logList}
+				{shortcutHelpDialog}
 			</Card>
 		);
 	}
@@ -1567,6 +1593,7 @@ export function LogViewer({
 		<div className="space-y-3">
 			{sheetToolbar}
 			<Card>{logList}</Card>
+			{shortcutHelpDialog}
 		</div>
 	);
 }

--- a/frontend/src/features/containers/components/log-viewer/shortcut-help.tsx
+++ b/frontend/src/features/containers/components/log-viewer/shortcut-help.tsx
@@ -1,0 +1,74 @@
+import { Fragment } from "react";
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+
+interface ShortcutEntry {
+	// Alternative keys for the same action, e.g. ["j", "↓"].
+	keys: string[];
+	description: string;
+}
+
+// Every shortcut handled by the log viewer (see the keydown handler in
+// log-viewer.tsx and shift-click range selection in handleLogClick).
+export const LOG_VIEWER_SHORTCUTS: ShortcutEntry[] = [
+	{ keys: ["/"], description: "Focus search" },
+	{ keys: ["j", "↓"], description: "Select next line" },
+	{ keys: ["k", "↑"], description: "Select previous line" },
+	{ keys: ["Shift+J", "Shift+↓"], description: "Extend selection down" },
+	{ keys: ["Shift+K", "Shift+↑"], description: "Extend selection up" },
+	{ keys: ["n"], description: "Next search match" },
+	{ keys: ["N"], description: "Previous search match" },
+	{ keys: ["p"], description: "Next pinned line" },
+	{ keys: ["P"], description: "Previous pinned line" },
+	{ keys: ["Shift+Click"], description: "Select a range of lines" },
+	{ keys: ["?"], description: "Toggle this help" },
+];
+
+interface ShortcutHelpDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function ShortcutHelpDialog({
+	open,
+	onOpenChange,
+}: ShortcutHelpDialogProps) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Keyboard shortcuts</DialogTitle>
+					<DialogDescription>
+						Available while viewing logs (not while typing in a field).
+					</DialogDescription>
+				</DialogHeader>
+				<div className="grid grid-cols-[auto_1fr] items-center gap-x-6 gap-y-2">
+					{LOG_VIEWER_SHORTCUTS.map((shortcut) => (
+						<Fragment key={shortcut.description}>
+							<KbdGroup>
+								{shortcut.keys.map((key, keyIndex) => (
+									<Fragment key={key}>
+										{keyIndex > 0 && (
+											<span className="text-xs text-muted-foreground">or</span>
+										)}
+										<Kbd>{key}</Kbd>
+									</Fragment>
+								))}
+							</KbdGroup>
+							<span className="text-sm text-muted-foreground">
+								{shortcut.description}
+							</span>
+						</Fragment>
+					))}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
Two log viewer UX fixes.

## Shift-click range selection no longer highlights text
Shift-clicking to select a range of log lines also triggered the browser's native text selection, visually highlighting everything between the two points. The row now prevents the default mousedown behavior only when shift is held — range selection and the Copy/Pin action bar work as before, and normal click-drag text selection is untouched.

## "?" keyboard-shortcut help overlay
The shortcuts existed but were undiscoverable. Pressing "?" (outside inputs) now opens a help dialog listing every shortcut — including ones the old hint line omitted (arrow-key aliases, Shift+J/K selection extension). Closes on Escape, outside click, or "?" again; the hint line links to it. Adds the shadcn dialog primitive (@radix-ui/react-dialog was already a dependency).

## Verification
TypeScript, biome, and all 74 frontend tests pass (including a new test for the "?" focus guards); verified in the browser — shift-click selects 4 lines with zero native highlight, overlay opens with the complete list.

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcuts help dialog to the log viewer.
  * Open shortcut help using the `?` key, the toolbar help button, or the overflow menu.
  * Added a reusable dialog component with optional close controls and standard layouts.

* **Bug Fixes**
  * Improved shift-click log selection by preventing unwanted text highlighting.
  * Typing `?` in the log search field no longer opens shortcut help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->