### PR TITLE
feat: API access tokens

### DIFF
--- a/frontend/src/features/settings/api/create-api-token.ts
+++ b/frontend/src/features/settings/api/create-api-token.ts
@@ -1,0 +1,21 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+import type { CreatedAPIToken } from "../types";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/settings/api-tokens`;
+
+export async function createApiToken(name: string): Promise<CreatedAPIToken> {
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ name }),
+	});
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to create API token");
+	}
+
+	return (await response.json()) as CreatedAPIToken;
+}

--- a/frontend/src/features/settings/api/delete-api-token.ts
+++ b/frontend/src/features/settings/api/delete-api-token.ts
@@ -1,0 +1,19 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/settings/api-tokens`;
+
+export async function deleteApiToken(prefix: string): Promise<string> {
+	const response = await authenticatedFetch(
+		`${ENDPOINT}/${encodeURIComponent(prefix)}`,
+		{ method: "DELETE" },
+	);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to revoke API token");
+	}
+
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "API token revoked";
+}

--- a/frontend/src/features/settings/api/get-api-tokens.ts
+++ b/frontend/src/features/settings/api/get-api-tokens.ts
@@ -1,0 +1,17 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+import type { APITokensResponse } from "../types";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/settings/api-tokens`;
+
+export async function getApiTokens(): Promise<APITokensResponse> {
+	const response = await authenticatedFetch(ENDPOINT);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to load API tokens");
+	}
+
+	return (await response.json()) as APITokensResponse;
+}

--- a/frontend/src/features/settings/components/api-tokens-section.tsx
+++ b/frontend/src/features/settings/components/api-tokens-section.tsx
@@ -1,0 +1,271 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+import {
+	useApiTokens,
+	useCreateApiToken,
+	useDeleteApiToken,
+} from "../hooks/use-settings";
+import type { APIToken, CreatedAPIToken } from "../types";
+
+export function ApiTokensSection() {
+	const { data, isLoading, error } = useApiTokens();
+	const createMutation = useCreateApiToken();
+	const deleteMutation = useDeleteApiToken();
+
+	const [isCreating, setIsCreating] = useState(false);
+	const [newName, setNewName] = useState("");
+	const [createdToken, setCreatedToken] = useState<CreatedAPIToken | null>(
+		null,
+	);
+	const [copied, setCopied] = useState(false);
+	const [tokenToRevoke, setTokenToRevoke] = useState<APIToken | null>(null);
+
+	const tokens = data?.tokens ?? [];
+
+	function handleCreate() {
+		const name = newName.trim();
+		if (!name) {
+			toast.error("Token name is required");
+			return;
+		}
+		createMutation.mutate(name, {
+			onSuccess: (token) => {
+				toast.success(`Token "${token.name}" created`);
+				setCreatedToken(token);
+				setCopied(false);
+				setNewName("");
+				setIsCreating(false);
+			},
+			onError: (err) => toast.error(err.message),
+		});
+	}
+
+	function handleCopy() {
+		if (!createdToken) return;
+		navigator.clipboard
+			.writeText(createdToken.token)
+			.then(() => {
+				setCopied(true);
+				toast.success("Token copied to clipboard");
+			})
+			.catch(() => toast.error("Failed to copy token"));
+	}
+
+	function handleRevoke() {
+		if (!tokenToRevoke) return;
+		deleteMutation.mutate(tokenToRevoke.prefix, {
+			onSuccess: (msg) => toast.success(msg),
+			onError: (err) => toast.error(err.message),
+		});
+		setTokenToRevoke(null);
+	}
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>API Access</CardTitle>
+				<CardDescription>
+					Generate long-lived tokens for the LogDeck CLI and other external
+					tools. Send a token as{" "}
+					<code className="font-mono text-xs">
+						Authorization: Bearer &lt;token&gt;
+					</code>{" "}
+					to authenticate API requests.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{createdToken && (
+					<div className="space-y-2 border rounded-md p-3 bg-muted/50">
+						<p className="text-sm font-medium">
+							Token "{createdToken.name}" created
+						</p>
+						<div className="flex items-center gap-2">
+							<code className="flex-1 font-mono text-xs break-all rounded bg-background border px-2 py-1.5">
+								{createdToken.token}
+							</code>
+							<Button variant="outline" size="sm" onClick={handleCopy}>
+								{copied ? (
+									<Check className="size-3.5" />
+								) : (
+									<Copy className="size-3.5" />
+								)}
+								{copied ? "Copied" : "Copy"}
+							</Button>
+						</div>
+						<p className="text-xs text-amber-600 dark:text-amber-400">
+							Copy this token now. It will not be shown again.
+						</p>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => setCreatedToken(null)}
+						>
+							Done
+						</Button>
+					</div>
+				)}
+
+				{isLoading && <Spinner className="size-4" />}
+				{error && (
+					<p className="text-sm text-destructive">
+						Failed to load API tokens: {error.message}
+					</p>
+				)}
+
+				{!isLoading && !error && tokens.length === 0 && (
+					<p className="text-sm text-muted-foreground">
+						No API tokens created yet.
+					</p>
+				)}
+
+				{tokens.length > 0 && (
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead>Token</TableHead>
+								<TableHead>Created</TableHead>
+								<TableHead className="text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{tokens.map((t) => (
+								<TableRow key={t.prefix}>
+									<TableCell className="font-medium">{t.name}</TableCell>
+									<TableCell className="font-mono text-xs text-muted-foreground">
+										{t.prefix}…
+									</TableCell>
+									<TableCell className="text-xs text-muted-foreground">
+										{new Date(t.createdAt).toLocaleDateString()}
+									</TableCell>
+									<TableCell className="text-right">
+										<Button
+											variant="ghost"
+											size="sm"
+											disabled={deleteMutation.isPending}
+											onClick={() => setTokenToRevoke(t)}
+											className="text-destructive hover:text-destructive"
+										>
+											Revoke
+										</Button>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				)}
+
+				{isCreating ? (
+					<div className="flex items-end gap-3 border rounded-md p-3">
+						<div className="space-y-1.5 flex-1">
+							<Label htmlFor="new-token-name">Name</Label>
+							<Input
+								id="new-token-name"
+								value={newName}
+								onChange={(e) => setNewName(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleCreate();
+								}}
+								placeholder="my-cli"
+								className="h-8"
+								maxLength={64}
+							/>
+						</div>
+						<div className="flex gap-1">
+							<Button
+								size="sm"
+								disabled={createMutation.isPending}
+								onClick={handleCreate}
+							>
+								{createMutation.isPending ? (
+									<>
+										<Spinner className="size-3" />
+										Creating...
+									</>
+								) : (
+									"Create"
+								)}
+							</Button>
+							<Button
+								size="sm"
+								variant="ghost"
+								onClick={() => {
+									setIsCreating(false);
+									setNewName("");
+								}}
+							>
+								Cancel
+							</Button>
+						</div>
+					</div>
+				) : (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setIsCreating(true)}
+					>
+						Create token
+					</Button>
+				)}
+			</CardContent>
+
+			<AlertDialog
+				open={tokenToRevoke !== null}
+				onOpenChange={(open) => {
+					if (!open) setTokenToRevoke(null);
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Revoke API token?</AlertDialogTitle>
+						<AlertDialogDescription>
+							The token "{tokenToRevoke?.name}" will stop working immediately.
+							Any CLI or tool using it will lose access. This cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleRevoke}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Revoke
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</Card>
+	);
+}

--- a/frontend/src/features/settings/components/settings-page.tsx
+++ b/frontend/src/features/settings/components/settings-page.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from "@/components/ui/spinner";
 
 import { useSettings } from "../hooks/use-settings";
+import { ApiTokensSection } from "./api-tokens-section";
 import { AuthSection } from "./auth-section";
 import { CoolifyHostsSection } from "./coolify-hosts-section";
 import { DockerHostsSection } from "./docker-hosts-section";
@@ -52,6 +53,7 @@ export function SettingsPage() {
 				key={`${data.auth.enabled}-${data.auth.adminUsername}`}
 				config={data.auth}
 			/>
+			<ApiTokensSection />
 		</div>
 	);
 }

--- a/frontend/src/features/settings/hooks/use-settings.ts
+++ b/frontend/src/features/settings/hooks/use-settings.ts
@@ -1,5 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { createApiToken } from "../api/create-api-token";
+import { deleteApiToken } from "../api/delete-api-token";
+import { getApiTokens } from "../api/get-api-tokens";
 import { getSettings } from "../api/get-settings";
 import { testCoolifyHost } from "../api/test-coolify-host";
 import { testDockerHost } from "../api/test-docker-host";
@@ -9,6 +12,7 @@ import { updateDockerHosts } from "../api/update-docker-hosts";
 import { updateReadOnly } from "../api/update-read-only";
 
 const SETTINGS_KEY = ["settings"] as const;
+const API_TOKENS_KEY = ["settings", "api-tokens"] as const;
 
 export function useSettings() {
 	return useQuery({
@@ -57,6 +61,34 @@ export function useUpdateAuth() {
 		mutationFn: (payload: UpdateAuthPayload) => updateAuth(payload),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
+		},
+	});
+}
+
+export function useApiTokens() {
+	return useQuery({
+		queryKey: API_TOKENS_KEY,
+		queryFn: getApiTokens,
+		staleTime: 30_000,
+	});
+}
+
+export function useCreateApiToken() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (name: string) => createApiToken(name),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: API_TOKENS_KEY });
+		},
+	});
+}
+
+export function useDeleteApiToken() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (prefix: string) => deleteApiToken(prefix),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: API_TOKENS_KEY });
 		},
 	});
 }

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -41,6 +41,21 @@ export interface SettingsResponse {
 	auth: AuthConfig;
 }
 
+export interface APIToken {
+	name: string;
+	prefix: string;
+	createdAt: string;
+}
+
+export interface APITokensResponse {
+	tokens: APIToken[];
+}
+
+export interface CreatedAPIToken extends APIToken {
+	/** The full token, returned exactly once at creation time. */
+	token: string;
+}
+
 export interface TestConnectionResult {
 	success: boolean;
 	message: string;

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -79,7 +79,7 @@ func (ar *APIRouter) Routes() *chi.Mux {
 
 		// All other routes go through dynamic auth middleware
 		r.Group(func(protected chi.Router) {
-			protected.Use(auth.DynamicMiddleware(ar.registry.Auth))
+			protected.Use(auth.DynamicMiddleware(ar.registry.Auth, ar.lookupAPIToken))
 
 			protected.Get("/auth/me", ar.handleGetMe)
 			protected.Get("/events", ar.GetContainerEvents)
@@ -135,13 +135,16 @@ func (ar *APIRouter) registerContainerRoutes(r chi.Router) {
 func (ar *APIRouter) registerSettingsRoutes(r chi.Router) {
 	r.Route("/settings", func(r chi.Router) {
 		// Settings follow the same auth pattern — protected when auth is enabled
-		r.Use(auth.DynamicMiddleware(ar.registry.Auth))
+		r.Use(auth.DynamicMiddleware(ar.registry.Auth, ar.lookupAPIToken))
 
 		r.Get("/", ar.GetSettings)
 		r.Put("/docker-hosts", ar.UpdateDockerHosts)
 		r.Put("/coolify-hosts", ar.UpdateCoolifyHosts)
 		r.Put("/read-only", ar.UpdateReadOnly)
 		r.Put("/auth", ar.UpdateAuth)
+		r.Get("/api-tokens", ar.ListAPITokens)
+		r.Post("/api-tokens", ar.CreateAPIToken)
+		r.Delete("/api-tokens/{prefix}", ar.DeleteAPIToken)
 		r.Post("/test/docker-host", ar.TestDockerHost)
 		r.Post("/test/coolify-host", ar.TestCoolifyHost)
 	})

--- a/server/internal/api/settings_apitokens.go
+++ b/server/internal/api/settings_apitokens.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/auth"
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	maxAPITokens       = 20
+	maxAPITokenNameLen = 64
+)
+
+var (
+	errTokenLimit     = fmt.Errorf("maximum of %d API tokens reached", maxAPITokens)
+	errTokenNameTaken = errors.New("a token with this name already exists")
+	errTokenNotFound  = errors.New("API token not found")
+)
+
+// lookupAPIToken resolves a presented API token against the tokens stored in
+// the current file config. It reads through the config manager on every call
+// so it stays correct across hot-swapped config updates. Comparison is
+// constant-time over the SHA256 hashes.
+func (ar *APIRouter) lookupAPIToken(token string) (string, bool) {
+	hash := auth.HashAPIToken(token)
+	fc := ar.manager.FileConfigSnapshot()
+
+	name := ""
+	found := false
+	for _, t := range fc.APITokens {
+		if subtle.ConstantTimeCompare([]byte(hash), []byte(t.Hash)) == 1 {
+			name = t.Name
+			found = true
+		}
+	}
+	return name, found
+}
+
+// ListAPITokens handles GET /api/v1/settings/api-tokens.
+func (ar *APIRouter) ListAPITokens(w http.ResponseWriter, r *http.Request) {
+	fc := ar.manager.FileConfigSnapshot()
+	tokens := make([]map[string]any, 0, len(fc.APITokens))
+	for _, t := range fc.APITokens {
+		tokens = append(tokens, map[string]any{
+			"name":      t.Name,
+			"prefix":    t.Prefix,
+			"createdAt": t.CreatedAt,
+		})
+	}
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"tokens": tokens})
+}
+
+// CreateAPIToken handles POST /api/v1/settings/api-tokens. The full token is
+// returned exactly once; only its hash is stored.
+func (ar *APIRouter) CreateAPIToken(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	if len(name) > maxAPITokenNameLen {
+		http.Error(w, fmt.Sprintf("name must be at most %d characters", maxAPITokenNameLen), http.StatusBadRequest)
+		return
+	}
+
+	token, hash, prefix, err := auth.GenerateAPIToken()
+	if err != nil {
+		http.Error(w, "failed to generate token", http.StatusInternalServerError)
+		return
+	}
+
+	createdAt := time.Now().UTC().Format(time.RFC3339)
+	err = ar.manager.UpdateAPITokens(func(current []config.APIToken) ([]config.APIToken, error) {
+		if len(current) >= maxAPITokens {
+			return nil, errTokenLimit
+		}
+		for _, t := range current {
+			if t.Name == name {
+				return nil, errTokenNameTaken
+			}
+		}
+		return append(current, config.APIToken{
+			Name:      name,
+			Hash:      hash,
+			Prefix:    prefix,
+			CreatedAt: createdAt,
+		}), nil
+	})
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errTokenLimit) || errors.Is(err, errTokenNameTaken) {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	WriteJsonResponse(w, http.StatusCreated, map[string]any{
+		"token":     token,
+		"name":      name,
+		"prefix":    prefix,
+		"createdAt": createdAt,
+	})
+}
+
+// DeleteAPIToken handles DELETE /api/v1/settings/api-tokens/{prefix}.
+func (ar *APIRouter) DeleteAPIToken(w http.ResponseWriter, r *http.Request) {
+	prefix := chi.URLParam(r, "prefix")
+
+	err := ar.manager.UpdateAPITokens(func(current []config.APIToken) ([]config.APIToken, error) {
+		next := current[:0]
+		for _, t := range current {
+			if t.Prefix != prefix {
+				next = append(next, t)
+			}
+		}
+		if len(next) == len(current) {
+			return nil, errTokenNotFound
+		}
+		return next, nil
+	})
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errTokenNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"message": "API token revoked"})
+}

--- a/server/internal/api/settings_apitokens_test.go
+++ b/server/internal/api/settings_apitokens_test.go
@@ -1,0 +1,221 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type createdTokenResponse struct {
+	Token     string `json:"token"`
+	Name      string `json:"name"`
+	Prefix    string `json:"prefix"`
+	CreatedAt string `json:"createdAt"`
+}
+
+func createToken(t *testing.T, router http.Handler, jwt, name string) createdTokenResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/settings/api-tokens",
+		strings.NewReader(fmt.Sprintf(`{"name":%q}`, name)))
+	if jwt != "" {
+		r.Header.Set("Authorization", "Bearer "+jwt)
+	}
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 creating token, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp createdTokenResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse create response: %v", err)
+	}
+	return resp
+}
+
+func TestCreateAndListAPITokens(t *testing.T) {
+	router := newTestRouter(t, nil)
+
+	created := createToken(t, router, "", "my-cli")
+	if !strings.HasPrefix(created.Token, "ldk_") {
+		t.Errorf("token %q does not start with ldk_", created.Token)
+	}
+	if created.Prefix != created.Token[:12] {
+		t.Errorf("prefix %q does not match token start", created.Prefix)
+	}
+	if created.Name != "my-cli" || created.CreatedAt == "" {
+		t.Errorf("unexpected create response: %+v", created)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/settings/api-tokens", nil)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 listing tokens, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var list struct {
+		Tokens []map[string]any `json:"tokens"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatalf("failed to parse list response: %v", err)
+	}
+	if len(list.Tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(list.Tokens))
+	}
+	entry := list.Tokens[0]
+	if entry["name"] != "my-cli" || entry["prefix"] != created.Prefix {
+		t.Errorf("unexpected list entry: %v", entry)
+	}
+	if _, hasHash := entry["hash"]; hasHash {
+		t.Error("list response must not include the token hash")
+	}
+	if _, hasToken := entry["token"]; hasToken {
+		t.Error("list response must not include the full token")
+	}
+}
+
+func TestCreateAPITokenValidation(t *testing.T) {
+	router := newTestRouter(t, nil)
+	createToken(t, router, "", "dup")
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty name", `{"name":""}`},
+		{"whitespace name", `{"name":"   "}`},
+		{"duplicate name", `{"name":"dup"}`},
+		{"name too long", fmt.Sprintf(`{"name":%q}`, strings.Repeat("a", 65))},
+		{"invalid json", `{`},
+	}
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/api/v1/settings/api-tokens", strings.NewReader(tc.body))
+		router.ServeHTTP(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d: %s", tc.name, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestCreateAPITokenCap(t *testing.T) {
+	router := newTestRouter(t, nil)
+	for i := 0; i < 20; i++ {
+		createToken(t, router, "", fmt.Sprintf("token-%d", i))
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/settings/api-tokens", strings.NewReader(`{"name":"one-too-many"}`))
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 when exceeding token cap, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteAPIToken(t *testing.T) {
+	router := newTestRouter(t, nil)
+	created := createToken(t, router, "", "to-delete")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/api/v1/settings/api-tokens/"+created.Prefix, nil)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 deleting token, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Deleting again should 404.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("DELETE", "/api/v1/settings/api-tokens/"+created.Prefix, nil)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 deleting unknown token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITokenAuthenticatesRequestsWhenAuthEnabled(t *testing.T) {
+	svc := newTestAuthService(t)
+	router := newTestRouter(t, svc)
+
+	jwt, err := svc.GenerateToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	created := createToken(t, router, jwt, "cli")
+
+	// The API token must authenticate protected routes.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/auth/me", nil)
+	r.Header.Set("Authorization", "Bearer "+created.Token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with API token, got %d: %s", w.Code, w.Body.String())
+	}
+	var me struct {
+		User struct {
+			Username string `json:"username"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &me); err != nil {
+		t.Fatalf("failed to parse /auth/me response: %v", err)
+	}
+	if me.User.Username != "token:cli" {
+		t.Errorf("expected user %q, got %q", "token:cli", me.User.Username)
+	}
+
+	// Settings routes accept it too.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/settings", nil)
+	r.Header.Set("Authorization", "Bearer "+created.Token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 on settings with API token, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// A revoked token must stop working immediately.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("DELETE", "/api/v1/settings/api-tokens/"+created.Prefix, nil)
+	r.Header.Set("Authorization", "Bearer "+jwt)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 revoking token, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/auth/me", nil)
+	r.Header.Set("Authorization", "Bearer "+created.Token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with revoked API token, got %d", w.Code)
+	}
+
+	// A random ldk_ token must not authenticate.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/auth/me", nil)
+	r.Header.Set("Authorization", "Bearer ldk_not-a-real-token")
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with bogus API token, got %d", w.Code)
+	}
+}
+
+func TestAPITokenEndpointsRequireAuthWhenEnabled(t *testing.T) {
+	router := newTestRouter(t, newTestAuthService(t))
+
+	endpoints := []struct{ method, path string }{
+		{"GET", "/api/v1/settings/api-tokens"},
+		{"POST", "/api/v1/settings/api-tokens"},
+		{"DELETE", "/api/v1/settings/api-tokens/ldk_abcd1234"},
+	}
+	for _, e := range endpoints {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(e.method, e.path, nil)
+		router.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: expected 401 without token, got %d", e.method, e.path, w.Code)
+		}
+	}
+}

--- a/server/internal/auth/apitoken.go
+++ b/server/internal/auth/apitoken.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+// APITokenPrefix is the fixed prefix of every LogDeck API token.
+const APITokenPrefix = "ldk_"
+
+// APITokenDisplayLen is how many leading characters of a token are stored
+// for display and identification (includes the "ldk_" prefix).
+const APITokenDisplayLen = 12
+
+// GenerateAPIToken creates a new API token from 32 random bytes.
+// It returns the full token (shown to the user exactly once), the SHA256 hex
+// hash to persist, and the display prefix used to identify the token.
+func GenerateAPIToken() (token, hash, prefix string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", "", err
+	}
+	token = APITokenPrefix + base64.RawURLEncoding.EncodeToString(b)
+	return token, HashAPIToken(token), token[:APITokenDisplayLen], nil
+}
+
+// HashAPIToken returns the hex-encoded SHA256 hash of a token. API tokens are
+// high-entropy secrets, so a fast unsalted hash is appropriate for
+// per-request lookup.
+func HashAPIToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}

--- a/server/internal/auth/apitoken_test.go
+++ b/server/internal/auth/apitoken_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateAPIToken(t *testing.T) {
+	token, hash, prefix, err := GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken failed: %v", err)
+	}
+
+	if !strings.HasPrefix(token, APITokenPrefix) {
+		t.Errorf("token %q does not start with %q", token, APITokenPrefix)
+	}
+	// ldk_ (4) + base64url of 32 bytes without padding (43)
+	if len(token) != 47 {
+		t.Errorf("expected token length 47, got %d", len(token))
+	}
+	if prefix != token[:APITokenDisplayLen] {
+		t.Errorf("prefix %q does not match first %d chars of token", prefix, APITokenDisplayLen)
+	}
+	if hash != HashAPIToken(token) {
+		t.Errorf("returned hash does not match HashAPIToken(token)")
+	}
+	// sha256 hex is 64 chars
+	if len(hash) != 64 {
+		t.Errorf("expected 64-char hex hash, got %d chars", len(hash))
+	}
+}
+
+func TestGenerateAPITokenUnique(t *testing.T) {
+	a, _, _, err := GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken failed: %v", err)
+	}
+	b, _, _, err := GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken failed: %v", err)
+	}
+	if a == b {
+		t.Error("two generated tokens are identical")
+	}
+}

--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -5,15 +5,23 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
 )
 
 type contextKey string
 
 const UserContextKey contextKey = "user"
 
+// APITokenLookup resolves a presented API token to its name. Implementations
+// must compare against stored hashes in constant time.
+type APITokenLookup func(token string) (name string, ok bool)
+
 // DynamicMiddleware creates an auth middleware that resolves the auth service per request.
 // If getService returns nil, auth is disabled and the request passes through.
-func DynamicMiddleware(getService func() *Service) func(http.Handler) http.Handler {
+// If lookupAPIToken is non-nil, bearer tokens with the API token prefix are
+// authenticated against stored API tokens instead of as JWTs.
+func DynamicMiddleware(getService func() *Service, lookupAPIToken APITokenLookup) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			svc := getService()
@@ -21,7 +29,7 @@ func DynamicMiddleware(getService func() *Service) func(http.Handler) http.Handl
 				next.ServeHTTP(w, r)
 				return
 			}
-			validateAndServe(svc, next, w, r)
+			validateAndServe(svc, lookupAPIToken, next, w, r)
 		})
 	}
 }
@@ -30,13 +38,14 @@ func DynamicMiddleware(getService func() *Service) func(http.Handler) http.Handl
 func Middleware(authService *Service) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			validateAndServe(authService, next, w, r)
+			validateAndServe(authService, nil, next, w, r)
 		})
 	}
 }
 
-// validateAndServe extracts and validates the JWT token, then serves the request.
-func validateAndServe(svc *Service, next http.Handler, w http.ResponseWriter, r *http.Request) {
+// validateAndServe extracts and validates the bearer token (API token or JWT),
+// then serves the request.
+func validateAndServe(svc *Service, lookupAPIToken APITokenLookup, next http.Handler, w http.ResponseWriter, r *http.Request) {
 	authHeader := r.Header.Get("Authorization")
 	var tokenString string
 
@@ -53,6 +62,21 @@ func validateAndServe(svc *Service, next http.Handler, w http.ResponseWriter, r 
 			http.Error(w, "Authorization header or token query parameter required", http.StatusUnauthorized)
 			return
 		}
+	}
+
+	// API tokens are identified by their fixed prefix; a JWT never starts
+	// with it, so there is no fallthrough between the two schemes.
+	if strings.HasPrefix(tokenString, APITokenPrefix) {
+		if lookupAPIToken != nil {
+			if name, ok := lookupAPIToken(tokenString); ok {
+				user := models.User{Username: "token:" + name, Role: "admin"}
+				ctx := context.WithValue(r.Context(), UserContextKey, user)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+		}
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
 	}
 
 	claims, err := svc.VerifyToken(tokenString)

--- a/server/internal/auth/middleware_test.go
+++ b/server/internal/auth/middleware_test.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+func testService(t *testing.T) *Service {
+	t.Helper()
+	svc := NewServiceFromFileConfig(&config.FileAuthConfig{
+		Enabled:           true,
+		JWTSecret:         "test-secret",
+		AdminUsername:     "admin",
+		AdminPasswordHash: HashPasswordSHA256("password", "salt"),
+		AdminPasswordSalt: "salt",
+	})
+	if svc == nil {
+		t.Fatal("failed to create auth service")
+	}
+	return svc
+}
+
+// echoUserHandler records the user set on the request context.
+func echoUserHandler(gotUser *models.User) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, ok := r.Context().Value(UserContextKey).(models.User); ok {
+			*gotUser = u
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestDynamicMiddlewareAcceptsAPIToken(t *testing.T) {
+	svc := testService(t)
+	token, hash, _, err := GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken failed: %v", err)
+	}
+
+	lookup := func(presented string) (string, bool) {
+		if HashAPIToken(presented) == hash {
+			return "ci", true
+		}
+		return "", false
+	}
+
+	var gotUser models.User
+	handler := DynamicMiddleware(func() *Service { return svc }, lookup)(echoUserHandler(&gotUser))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with valid API token, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotUser.Username != "token:ci" {
+		t.Errorf("expected context user %q, got %q", "token:ci", gotUser.Username)
+	}
+}
+
+func TestDynamicMiddlewareRejectsUnknownAPIToken(t *testing.T) {
+	svc := testService(t)
+	lookup := func(string) (string, bool) { return "", false }
+
+	var gotUser models.User
+	handler := DynamicMiddleware(func() *Service { return svc }, lookup)(echoUserHandler(&gotUser))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer ldk_unknown-token")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for unknown API token, got %d", w.Code)
+	}
+}
+
+func TestDynamicMiddlewareStillAcceptsJWT(t *testing.T) {
+	svc := testService(t)
+	lookup := func(string) (string, bool) { return "", false }
+
+	jwtToken, err := svc.GenerateToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	var gotUser models.User
+	handler := DynamicMiddleware(func() *Service { return svc }, lookup)(echoUserHandler(&gotUser))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer "+jwtToken)
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with valid JWT, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotUser.Username != "admin" {
+		t.Errorf("expected context user %q, got %q", "admin", gotUser.Username)
+	}
+}
+
+func TestDynamicMiddlewarePassesThroughWhenAuthDisabled(t *testing.T) {
+	var gotUser models.User
+	handler := DynamicMiddleware(func() *Service { return nil }, nil)(echoUserHandler(&gotUser))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with auth disabled, got %d", w.Code)
+	}
+}

--- a/server/internal/config/manager.go
+++ b/server/internal/config/manager.go
@@ -11,10 +11,20 @@ import (
 
 // FileConfig represents the JSON config file structure.
 type FileConfig struct {
-	DockerHosts  []DockerHost          `json:"dockerHosts,omitempty"`
-	CoolifyHosts []CoolifyHostConfig   `json:"coolifyHosts,omitempty"`
-	ReadOnly     *bool                 `json:"readOnly,omitempty"`
-	Auth         *FileAuthConfig       `json:"auth,omitempty"`
+	DockerHosts  []DockerHost        `json:"dockerHosts,omitempty"`
+	CoolifyHosts []CoolifyHostConfig `json:"coolifyHosts,omitempty"`
+	ReadOnly     *bool               `json:"readOnly,omitempty"`
+	Auth         *FileAuthConfig     `json:"auth,omitempty"`
+	APITokens    []APIToken          `json:"apiTokens,omitempty"`
+}
+
+// APIToken represents a stored API access token. Only the SHA256 hash of the
+// token is persisted; the raw token is shown to the user exactly once.
+type APIToken struct {
+	Name      string `json:"name"`
+	Hash      string `json:"hash"`
+	Prefix    string `json:"prefix"`
+	CreatedAt string `json:"createdAt"`
 }
 
 // FileAuthConfig represents auth settings in the config file.
@@ -49,12 +59,12 @@ type Manager struct {
 	mu          sync.RWMutex
 	filePath    string
 	envSnapshot EnvSnapshot
-	envConfig   *Config          // config derived purely from env vars
-	fileConfig  FileConfig       // config from file
-	merged      *Config          // final merged config
-	sources     ConfigSources    // per-category source tracking
-	onChange    []func(*Config)  // callbacks when config changes
-	generation  uint64           // incremented on each merge to detect stale callbacks
+	envConfig   *Config         // config derived purely from env vars
+	fileConfig  FileConfig      // config from file
+	merged      *Config         // final merged config
+	sources     ConfigSources   // per-category source tracking
+	onChange    []func(*Config) // callbacks when config changes
+	generation  uint64          // incremented on each merge to detect stale callbacks
 }
 
 // ConfigSources tracks the source of each config category.
@@ -262,6 +272,31 @@ func (m *Manager) UpdateAuth(mutate func(current *FileAuthConfig) (*FileAuthConf
 		return err
 	}
 	m.remerge() // unlocks m.mu before firing callbacks
+	return nil
+}
+
+// UpdateAPITokens applies a mutation function to the stored API tokens
+// atomically. Tokens live only in the file config (never env), so no remerge
+// is needed — readers access them through FileConfigSnapshot.
+func (m *Manager) UpdateAPITokens(mutate func(current []APIToken) ([]APIToken, error)) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Clone to prevent mutate from modifying the live config in-place.
+	current := make([]APIToken, len(m.fileConfig.APITokens))
+	copy(current, m.fileConfig.APITokens)
+
+	updated, err := mutate(current)
+	if err != nil {
+		return err
+	}
+
+	old := m.fileConfig.APITokens
+	m.fileConfig.APITokens = updated
+	if err := m.persist(); err != nil {
+		m.fileConfig.APITokens = old
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Enables external API access — the foundation for the CLI (#83) and any other tooling.

## Server
- Named tokens (`ldk_` + base64url of 32 random bytes) created in Settings; only the sha256 hash, a 12-char display prefix, name, and creation date are stored (file config via the config manager, hot-swap safe).
- `GET/POST /api/v1/settings/api-tokens` and `DELETE /api/v1/settings/api-tokens/{prefix}` — the full token is returned exactly once at creation. Validation: unique non-empty name, 20-token cap.
- `auth.DynamicMiddleware` gained a token lookup: Bearer values starting with `ldk_` are checked against stored hashes with a constant-time compare on every request (reads live config, so revocation is instant); JWTs flow through unchanged. Context user becomes `token:<name>`.
- Read-only mode still gates mutations regardless of auth method.

## Frontend
- "API Access" section in Settings: token table (name, prefix, created), create flow with one-time reveal + copy button and a won't-be-shown-again warning, revoke with confirmation.

## Verification
- New unit tests: token generation/format, middleware (token accepted, unknown rejected, JWT unaffected, auth-disabled passthrough), and router-level tests covering create/list/delete, validation, the cap, end-to-end auth via token, and instant revocation.
- Live against Podman: created a token, enabled auth at runtime, tokenless request → 401, token → full access including mutations, revoked second token rejected immediately.

Note: managing tokens requires the file config to be writable; non-Docker runs need `CONFIG_PATH` set (the default is `/data/config.json`).

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV