### PR TITLE
feat: logdeck CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release CLI
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+
+      - name: Build binaries
+        working-directory: server
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          mkdir -p ../dist
+          for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do
+            GOOS="${target%/*}"
+            GOARCH="${target#*/}"
+            out="logdeck"
+            CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+              go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" \
+              -o "$out" ./cmd/logdeck
+            # Unversioned asset names keep releases/latest/download URLs stable
+            tar -czf "../dist/logdeck_${GOOS}_${GOARCH}.tar.gz" "$out"
+            rm "$out"
+          done
+          cd ../dist && shasum -a 256 *.tar.gz > checksums.txt
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/Readme.md
+++ b/Readme.md
@@ -45,6 +45,17 @@ LogDeck works with Podman as well as Docker, using Podman's Docker-compatible AP
 
 For setup instructions, see the [Podman Setup Guide](./podman.md).
 
+### Command-Line Interface
+
+A scriptable `logdeck` CLI talks to the server's HTTP API — built for automation and AI agents:
+
+- List containers and stacks, inspect, read/follow/search logs, and check stats from the terminal
+- `logdeck grep` searches the recent logs of every running container across all hosts
+- Lifecycle actions, resource limits, and compose stack controls
+- Table output for humans, JSON/NDJSON output (`-o json`) for machines
+
+See the [CLI Guide](./docs/cli.md) for installation and every command.
+
 ### Container Lifecycle Management
 
 - Start, stop, restart, and remove containers

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,188 @@
+# LogDeck CLI
+
+## Overview
+
+`logdeck` is a command-line client for a running LogDeck server. It talks to the same HTTP API as the web interface, so everything you can see in the UI — containers, logs, stats, events, compose stacks — is available from the terminal.
+
+The CLI is built for scripting and AI agents: it is fully non-interactive, every command supports machine-readable JSON output (`-o json`), errors always go to stderr, and exit codes are consistent (0 success, 1 runtime error, 2 usage error).
+
+## Install / Build
+
+The CLI lives in the same Go module as the server and builds to a single static binary:
+
+```bash
+cd server
+go build ./cmd/logdeck
+./logdeck --help
+```
+
+## Connection and Authentication
+
+The CLI connects to a LogDeck server over HTTP:
+
+| Flag      | Environment variable | Default                 |
+| --------- | -------------------- | ----------------------- |
+| `--url`   | `LOGDECK_URL`        | `http://localhost:8080` |
+| `--token` | `LOGDECK_TOKEN`      | (none)                  |
+
+```bash
+export LOGDECK_URL=https://logdeck.example.com
+export LOGDECK_TOKEN=<api token>
+logdeck status
+```
+
+The token is sent as `Authorization: Bearer <token>`. When the server has authentication disabled, no token is needed. On a 401 response the CLI tells you to authenticate with an API token created in LogDeck Settings, via `--token` or `LOGDECK_TOKEN`.
+
+## Output Formats
+
+Every command accepts `-o/--output`:
+
+- `table` (default): compact aligned columns for humans.
+- `json`: a single JSON document for one-shot commands; NDJSON (one JSON object per line) for streaming commands (`logs --follow`, `events`).
+
+Timestamps are RFC3339. There are no colors, spinners, prompts, or pagination.
+
+## Commands
+
+### status
+
+Server health, version, and a per-host summary. The natural first call to discover what a server manages. Exits nonzero if the server is unreachable.
+
+```bash
+logdeck status
+```
+
+### containers
+
+List containers across all hosts, with optional filters.
+
+```bash
+logdeck containers --state running --host prod
+```
+
+### stacks
+
+List compose projects (grouped by the `com.docker.compose.project` / `io.podman.compose.project` labels) with container counts and hosts.
+
+```bash
+logdeck stacks
+```
+
+### inspect
+
+Full inspect data for one container. Table mode shows key facts; `-o json` prints the complete inspect document.
+
+```bash
+logdeck inspect web -o json
+```
+
+### logs
+
+Read or follow the parsed logs of a container, or a whole compose stack with `--stack`. `--since`/`--until` accept RFC3339 timestamps or relative durations (`30s`, `15m`, `2h`, `1d`).
+
+```bash
+logdeck logs web --tail 200 --level ERROR --since 1h
+logdeck logs web --follow
+logdeck logs --stack myapp --search "timeout" --since 30m
+```
+
+Stack logs are merged by timestamp with the container name shown per line. Following a stack is limited to its first 20 containers (the server's per-request aggregate limit); one-shot stack reads batch beyond that automatically.
+
+### grep
+
+Search the recent logs of every running container across all hosts, merged by timestamp. Bounded to the last 15 minutes by default so it stays fast.
+
+```bash
+logdeck grep "connection refused" --since 1h --level ERROR
+```
+
+### stats
+
+CPU and memory usage for all running containers, or one.
+
+```bash
+logdeck stats
+logdeck stats web
+```
+
+### events
+
+Stream container lifecycle events (start, stop, die, ...). Streams until interrupted, or use `--for` to read for a fixed duration and exit.
+
+```bash
+logdeck events --for 30s
+```
+
+### start / stop / restart / rm
+
+Container lifecycle actions. Containers are matched by exact name first, then ID prefix; ambiguous matches list the candidates and `--host` disambiguates.
+
+```bash
+logdeck restart web
+logdeck stop web --host staging
+```
+
+### stack
+
+Start, stop, or restart every container of a compose project. Applies to every host that has the project unless `--host` narrows it.
+
+```bash
+logdeck stack restart myapp
+```
+
+### env
+
+Print a container's environment variables as `KEY=value` lines.
+
+```bash
+logdeck env web
+```
+
+### resources
+
+Show or update a container's resource limits and restart policy. Memory accepts human units (`512m`, `1.5g`), CPUs accept fractions.
+
+```bash
+logdeck resources web
+logdeck resources set web --memory 512m --cpus 1.5 --restart on-failure --max-retries 3
+```
+
+### images / volumes / networks
+
+Read-only listings across all hosts, with an optional `--host` filter.
+
+```bash
+logdeck images --host prod
+logdeck volumes
+logdeck networks
+```
+
+## Using with AI Agents
+
+The CLI is designed so an agent can debug containerized services without a browser. A typical investigation:
+
+```bash
+# What is running, and is the server healthy?
+logdeck status -o json
+logdeck containers -o json
+
+# Anything failing right now?
+logdeck grep "error|exception|panic" --since 15m -o json
+
+# Zoom into the suspect service
+logdeck logs api --tail 500 --level ERROR --since 1h -o json
+logdeck inspect api -o json
+logdeck stats api -o json
+
+# Act, then confirm
+logdeck restart api
+logdeck logs api --follow
+```
+
+Notes for agents:
+
+- `-o json` always emits a single JSON document on stdout for one-shot commands; streaming commands (`logs --follow`, `events`) emit NDJSON, one object per line.
+- Errors go to stderr as `{"error": "..."}` in JSON mode; stdout stays clean for parsing.
+- Exit codes: 0 success, 1 runtime/server error, 2 usage error.
+- `--since`/`--until` accept relative durations (`15m`, `2h`, `1d`), so no date math is needed.
+- `logdeck grep` is the fastest way to find which container is emitting an error across an entire deployment.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,9 +6,17 @@
 
 The CLI is built for scripting and AI agents: it is fully non-interactive, every command supports machine-readable JSON output (`-o json`), errors always go to stderr, and exit codes are consistent (0 success, 1 runtime error, 2 usage error).
 
-## Install / Build
+## Install
 
-The CLI lives in the same Go module as the server and builds to a single static binary:
+Install the latest release binary (macOS and Linux, amd64/arm64):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/AmoabaKelvin/logdeck/main/install.sh | sh
+```
+
+Binaries are published on [GitHub Releases](https://github.com/AmoabaKelvin/logdeck/releases) with checksums; the installer picks the right one for your OS/architecture and installs to `/usr/local/bin` or `~/.local/bin`. Check your version with `logdeck --version`.
+
+Or build from source — the CLI lives in the same Go module as the server and builds to a single static binary:
 
 ```bash
 cd server

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,20 +18,36 @@ go build ./cmd/logdeck
 
 ## Connection and Authentication
 
-The CLI connects to a LogDeck server over HTTP:
-
-| Flag      | Environment variable | Default                 |
-| --------- | -------------------- | ----------------------- |
-| `--url`   | `LOGDECK_URL`        | `http://localhost:8080` |
-| `--token` | `LOGDECK_TOKEN`      | (none)                  |
+Connect once with `logdeck login` — it verifies the connection (health check, plus an authenticated call when a token is given) and saves it as a named context, kubectl-style. From then on every command uses that context:
 
 ```bash
-export LOGDECK_URL=https://logdeck.example.com
-export LOGDECK_TOKEN=<api token>
-logdeck status
+logdeck login --url https://logdeck.example.com --token ldk_... --name prod
+logdeck status        # now talks to prod
+```
+
+Contexts persist in `~/.config/logdeck/config.json` (respecting `XDG_CONFIG_HOME`). Because the file stores API tokens, it is created with `0600` permissions inside a `0700` directory, and the CLI never prints a saved token — only its `ldk_` prefix.
+
+Manage contexts with:
+
+```bash
+logdeck context list          # name, url, token prefix, current marker
+logdeck context use staging   # switch the current context
+logdeck context rm old        # delete a context
+logdeck logout                # remove the token from the current (or named) context, keeping its URL
 ```
 
 The token is sent as `Authorization: Bearer <token>`. When the server has authentication disabled, no token is needed. On a 401 response the CLI tells you to authenticate with an API token created in LogDeck Settings, via `--token` or `LOGDECK_TOKEN`.
+
+### Resolution order
+
+Flags and environment variables override the saved context — useful for CI or one-off calls. URL and token resolve independently, each from the first source that provides it:
+
+1. Explicit `--url` / `--token` flags
+2. `LOGDECK_URL` / `LOGDECK_TOKEN` environment variables
+3. The active context from the config file (`--context <name>` selects another saved context for one invocation)
+4. Default `http://localhost:8080`
+
+`logdeck status` shows which source supplied the URL and token.
 
 ## Output Formats
 
@@ -44,9 +60,33 @@ Timestamps are RFC3339. There are no colors, spinners, prompts, or pagination.
 
 ## Commands
 
+### login
+
+Verify a server connection and save it as the current context. Fails with the Settings hint if the server requires authentication and no working token is given.
+
+```bash
+logdeck login --url https://logdeck.example.com --token ldk_... --name prod
+```
+
+### context
+
+Manage saved contexts: `list`, `use <name>`, `rm <name>`.
+
+```bash
+logdeck context list
+```
+
+### logout
+
+Remove the saved token from the current (or a named) context, keeping its URL.
+
+```bash
+logdeck logout prod
+```
+
 ### status
 
-Server health, version, and a per-host summary. The natural first call to discover what a server manages. Exits nonzero if the server is unreachable.
+Server health, version, and a per-host summary, plus where the connection settings came from (flag, env, or context). The natural first call to discover what a server manages. Exits nonzero if the server is unreachable.
 
 ```bash
 logdeck status
@@ -162,6 +202,9 @@ logdeck networks
 The CLI is designed so an agent can debug containerized services without a browser. A typical investigation:
 
 ```bash
+# One-time setup on this machine (or use LOGDECK_URL/LOGDECK_TOKEN in CI)
+logdeck login --url https://logdeck.example.com --token ldk_...
+
 # What is running, and is the server healthy?
 logdeck status -o json
 logdeck containers -o json

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# LogDeck CLI installer.
+#   curl -fsSL https://raw.githubusercontent.com/AmoabaKelvin/logdeck/main/install.sh | sh
+# Installs the latest logdeck release binary for this OS/arch.
+set -eu
+
+REPO="AmoabaKelvin/logdeck"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$os" in
+  darwin | linux) ;;
+  *)
+    echo "Unsupported OS: $os (darwin and linux binaries are published)" >&2
+    exit 1
+    ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  arm64 | aarch64) arch="arm64" ;;
+  *)
+    echo "Unsupported architecture: $arch (amd64 and arm64 binaries are published)" >&2
+    exit 1
+    ;;
+esac
+
+url="https://github.com/${REPO}/releases/latest/download/logdeck_${os}_${arch}.tar.gz"
+
+if [ -w /usr/local/bin ]; then
+  install_dir="/usr/local/bin"
+else
+  install_dir="${HOME}/.local/bin"
+  mkdir -p "$install_dir"
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading $url"
+curl -fsSL "$url" -o "$tmp/logdeck.tar.gz"
+tar -xzf "$tmp/logdeck.tar.gz" -C "$tmp"
+install -m 0755 "$tmp/logdeck" "$install_dir/logdeck"
+
+echo "Installed $("$install_dir/logdeck" --version) to $install_dir/logdeck"
+
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *)
+    echo "Note: $install_dir is not on your PATH. Add it with:"
+    echo "  export PATH=\"$install_dir:\$PATH\""
+    ;;
+esac

--- a/server/cmd/logdeck/main.go
+++ b/server/cmd/logdeck/main.go
@@ -6,6 +6,10 @@ import (
 	"github.com/AmoabaKelvin/logdeck/internal/cli"
 )
 
+// version is injected at build time via
+// -ldflags "-X main.version=<version>". Defaults to "dev".
+var version = "dev"
+
 func main() {
-	os.Exit(cli.Execute())
+	os.Exit(cli.Execute(version))
 }

--- a/server/cmd/logdeck/main.go
+++ b/server/cmd/logdeck/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/AmoabaKelvin/logdeck/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Execute())
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
@@ -36,6 +37,8 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.10 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -10,6 +10,7 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -49,6 +50,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 h1:8Tjv8EJ+pM1xP8mK6egEbD1OgnVTyacbefKhmbLhIhU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2/go.mod h1:pkJQ2tZHJ0aFOVEEot6oZmaVEZcRme73eIFmhiVuRWs=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
@@ -71,11 +74,16 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil/v4 v4.25.10 h1:at8lk/5T1OgtuCp+AwrDofFRjnvosn0nkN2OLQ6g8tA=
 github.com/shirou/gopsutil/v4 v4.25.10/go.mod h1:+kSwyC8DRUD9XXEHCAFjK+0nuArFJM0lva+StQAcskM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -107,6 +115,7 @@ go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJr
 go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.44.0 h1:A97SsFvM3AIwEEmTBiaxPPTYpDC47w720rdiiUvgoAU=
 golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
 golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=

--- a/server/internal/cli/actions.go
+++ b/server/internal/cli/actions.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// newActionCmd builds start/stop/restart/rm: resolve the container, then POST
+// the matching lifecycle endpoint.
+func newActionCmd(a *app, name, endpoint, pastTense string) *cobra.Command {
+	var host string
+
+	verb := strings.ToUpper(endpoint[:1]) + endpoint[1:]
+	cmd := &cobra.Command{
+		Use:   name + " <name|id>",
+		Short: verb + " a container",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			container, err := a.resolve(ctx, args[0], host)
+			if err != nil {
+				return err
+			}
+
+			query := url.Values{"host": {container.Host}}
+			if err := a.client.post(ctx, "/containers/"+container.ID+"/"+endpoint, query, nil, nil); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{
+					"message": "Container " + pastTense,
+					"name":    containerName(container),
+					"id":      container.ID,
+					"host":    container.Host,
+				})
+			}
+			fmt.Printf("%s %s (host %s)\n", pastTense, containerName(container), container.Host)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "host name (disambiguates duplicate container names)")
+	return cmd
+}
+
+var validStackActions = map[string]bool{"start": true, "stop": true, "restart": true}
+
+func newStackCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "stack <start|stop|restart> <project>",
+		Short: "Start, stop, or restart a whole compose project",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("expected an action and a project (e.g. logdeck stack restart myapp)")
+			}
+			if !validStackActions[args[0]] {
+				return fmt.Errorf("invalid action %q: must be one of start, stop, restart", args[0])
+			}
+			return nil
+		},
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			action, project := args[0], args[1]
+
+			hosts := []string{host}
+			if host == "" {
+				resp, err := a.fetchContainers(ctx)
+				if err != nil {
+					return err
+				}
+				seen := map[string]bool{}
+				hosts = nil
+				for _, c := range resp.Containers {
+					if composeProject(c.Labels) == project && !seen[c.Host] {
+						seen[c.Host] = true
+						hosts = append(hosts, c.Host)
+					}
+				}
+				if len(hosts) == 0 {
+					return fmt.Errorf("no containers found for stack %q", project)
+				}
+			}
+
+			var results []composeResult
+			var failures int
+			for _, h := range hosts {
+				result, err := a.composeAction(ctx, project, action, h)
+				if err != nil {
+					return err
+				}
+				results = append(results, result)
+				failures += len(result.Failed)
+			}
+
+			if a.jsonOutput() {
+				if err := a.printJSON(map[string]any{"results": results}); err != nil {
+					return err
+				}
+			} else {
+				for _, r := range results {
+					fmt.Printf("host %s: %d/%d succeeded\n", r.Host, r.Succeeded, r.Total)
+					for _, f := range r.Failed {
+						fmt.Fprintf(os.Stderr, "  failed: %s: %s\n", f.Name, f.Error)
+					}
+				}
+			}
+
+			if failures > 0 {
+				return fmt.Errorf("%d container(s) failed to %s", failures, action)
+			}
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "apply only on this host (default: every host that has the project)")
+	return cmd
+}
+
+// composeAction posts a compose project action. The server returns the result
+// body with HTTP 500 when some containers fail, so decode it in both cases.
+func (a *app) composeAction(ctx context.Context, project, action, host string) (composeResult, error) {
+	status, body, err := a.client.postRaw(ctx, "/compose/"+project+"/"+action, url.Values{"host": {host}})
+	if err != nil {
+		return composeResult{}, err
+	}
+
+	var result composeResult
+	if decodeErr := json.Unmarshal(body, &result); decodeErr == nil && result.Project != "" {
+		return result, nil
+	}
+
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		message = fmt.Sprintf("HTTP %d", status)
+	}
+	if status == 401 {
+		message += " (" + authHint + ")"
+	}
+	return composeResult{}, fmt.Errorf("host %s: %s", host, message)
+}

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const requestTimeout = 30 * time.Second
+
+const authHint = "authenticate with an API token created in LogDeck Settings, via --token or LOGDECK_TOKEN"
+
+// client is a thin HTTP client for the LogDeck API (/api/v1).
+type client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+func newClient(baseURL, token string) *client {
+	return &client{baseURL: baseURL, token: token, http: &http.Client{}}
+}
+
+func (c *client) newRequest(ctx context.Context, method, path string, query url.Values, body any) (*http.Request, error) {
+	endpoint := c.baseURL + "/api/v1" + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	return req, nil
+}
+
+// do performs a one-shot request and decodes the JSON response into out
+// (which may be nil to discard the body).
+func (c *client) do(ctx context.Context, method, path string, query url.Values, body, out any) error {
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := c.newRequest(ctx, method, path, query, body)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("cannot reach LogDeck server at %s: %v", c.baseURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return responseError(resp)
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (c *client) get(ctx context.Context, path string, query url.Values, out any) error {
+	return c.do(ctx, http.MethodGet, path, query, nil, out)
+}
+
+func (c *client) post(ctx context.Context, path string, query url.Values, body, out any) error {
+	return c.do(ctx, http.MethodPost, path, query, body, out)
+}
+
+func (c *client) put(ctx context.Context, path string, query url.Values, body, out any) error {
+	return c.do(ctx, http.MethodPut, path, query, body, out)
+}
+
+// postRaw performs a POST and returns the status code and raw body. Used for
+// endpoints (compose actions) that return a useful JSON body on failure too.
+func (c *client) postRaw(ctx context.Context, path string, query url.Values) (int, []byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := c.newRequest(ctx, http.MethodPost, path, query, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("cannot reach LogDeck server at %s: %v", c.baseURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, body, nil
+}
+
+// stream opens a streaming GET request (no client-side timeout) and returns
+// the response body. The caller must close it.
+func (c *client) stream(ctx context.Context, path string, query url.Values) (io.ReadCloser, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, path, query, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reach LogDeck server at %s: %v", c.baseURL, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		return nil, responseError(resp)
+	}
+	return resp.Body, nil
+}
+
+// responseError turns a non-2xx response into an error carrying the server's
+// message. 401 responses get a hint about API token authentication.
+func responseError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	message := strings.TrimSpace(string(body))
+
+	// Server errors may be JSON like {"error": "..."} or plain text.
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) == nil && payload.Error != "" {
+		message = payload.Error
+	}
+	if message == "" {
+		message = resp.Status
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("HTTP 401: %s (%s)", message, authHint)
+	}
+	return fmt.Errorf("HTTP %d: %s", resp.StatusCode, message)
+}

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientSendsBearerToken(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	defer server.Close()
+
+	c := newClient(server.URL, "secret123")
+	var out struct {
+		Status string `json:"status"`
+	}
+	if err := c.get(context.Background(), "/healthz", nil, &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer secret123" {
+		t.Errorf("Authorization = %q, want Bearer secret123", gotAuth)
+	}
+	if out.Status != "ok" {
+		t.Errorf("status = %q, want ok", out.Status)
+	}
+}
+
+func TestClientUnauthorizedHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Invalid or expired token", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	err := newClient(server.URL, "").get(context.Background(), "/containers", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "LOGDECK_TOKEN") || !strings.Contains(err.Error(), "LogDeck Settings") {
+		t.Errorf("401 error should hint at token auth, got: %v", err)
+	}
+}
+
+func TestClientSurfacesServerMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Server is in read-only mode", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	err := newClient(server.URL, "").post(context.Background(), "/containers/x/stop", nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "read-only mode") || !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected server message and status, got: %v", err)
+	}
+}
+
+func TestClientUnreachable(t *testing.T) {
+	err := newClient("http://127.0.0.1:1", "").get(context.Background(), "/healthz", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+	if !strings.Contains(err.Error(), "cannot reach LogDeck server") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestAggregatedLogsBatching verifies >20 targets are split into multiple
+// requests and the results are merged chronologically.
+func TestAggregatedLogsBatching(t *testing.T) {
+	var requests int
+	var perRequestTargets []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/logs/aggregate" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		requests++
+		targets := strings.Split(r.URL.Query().Get("targets"), ",")
+		perRequestTargets = append(perRequestTargets, len(targets))
+
+		// Later batches return earlier timestamps to prove merging happens.
+		ts := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC).Add(-time.Duration(requests) * time.Minute)
+		fmt.Fprintf(w, `{"logs":[{"timestamp":%q,"level":"INFO","message":"batch %d"}],"count":1}`,
+			ts.Format(time.RFC3339), requests)
+	}))
+	defer server.Close()
+
+	a := &app{client: newClient(server.URL, ""), output: "table"}
+
+	targets := make([]string, 25)
+	for i := range targets {
+		targets[i] = fmt.Sprintf("prod~id%d~name%d", i, i)
+	}
+
+	logs, err := a.aggregatedLogs(context.Background(), targets, url.Values{"tail": {"100"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requests != 2 {
+		t.Errorf("expected 2 requests, got %d", requests)
+	}
+	if perRequestTargets[0] != 20 || perRequestTargets[1] != 5 {
+		t.Errorf("unexpected batch sizes: %v", perRequestTargets)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 merged entries, got %d", len(logs))
+	}
+	if logs[0].Message != "batch 2" || logs[1].Message != "batch 1" {
+		t.Errorf("entries not merged by timestamp: %q then %q", logs[0].Message, logs[1].Message)
+	}
+}
+
+func TestIsHeartbeat(t *testing.T) {
+	if !isHeartbeat([]byte(`{"type":"heartbeat"}`)) {
+		t.Error("heartbeat line not detected")
+	}
+	if isHeartbeat([]byte(`{"timestamp":"2026-01-02T12:00:00Z","message":"type: heartbeat"}`)) {
+		t.Error("regular entry misdetected as heartbeat")
+	}
+	if isHeartbeat([]byte(`not json`)) {
+		t.Error("non-JSON misdetected as heartbeat")
+	}
+}

--- a/server/internal/cli/config.go
+++ b/server/internal/cli/config.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const defaultServerURL = "http://localhost:8080"
+
+// contextConfig is one saved server connection.
+type contextConfig struct {
+	URL   string `json:"url"`
+	Token string `json:"token,omitempty"`
+}
+
+// cliConfig is the on-disk CLI configuration (saved contexts).
+type cliConfig struct {
+	CurrentContext string                   `json:"currentContext,omitempty"`
+	Contexts       map[string]contextConfig `json:"contexts,omitempty"`
+}
+
+// configPath returns ~/.config/logdeck/config.json, respecting XDG_CONFIG_HOME.
+func configPath() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "logdeck", "config.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %v", err)
+	}
+	return filepath.Join(home, ".config", "logdeck", "config.json"), nil
+}
+
+// loadConfig reads the config file; a missing file is an empty config.
+func loadConfig(path string) (cliConfig, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return cliConfig{}, nil
+	}
+	if err != nil {
+		return cliConfig{}, err
+	}
+	var cfg cliConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cliConfig{}, fmt.Errorf("invalid config file %s: %v", path, err)
+	}
+	return cfg, nil
+}
+
+// saveConfig writes the config with restrictive permissions: the file stores
+// API tokens, so 0600 for the file and 0700 for its directory.
+func saveConfig(path string, cfg cliConfig) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	// os.WriteFile only applies the mode on create; tighten pre-existing files.
+	return os.Chmod(path, 0o600)
+}
+
+// setContext saves (or overwrites) a context and makes it current.
+func (c *cliConfig) setContext(name string, ctx contextConfig) {
+	if c.Contexts == nil {
+		c.Contexts = map[string]contextConfig{}
+	}
+	c.Contexts[name] = ctx
+	c.CurrentContext = name
+}
+
+func (c *cliConfig) useContext(name string) error {
+	if _, ok := c.Contexts[name]; !ok {
+		return fmt.Errorf("no context named %q (see: logdeck context list)", name)
+	}
+	c.CurrentContext = name
+	return nil
+}
+
+// removeContext deletes a context, clearing currentContext if it was current.
+func (c *cliConfig) removeContext(name string) error {
+	if _, ok := c.Contexts[name]; !ok {
+		return fmt.Errorf("no context named %q (see: logdeck context list)", name)
+	}
+	delete(c.Contexts, name)
+	if c.CurrentContext == name {
+		c.CurrentContext = ""
+	}
+	return nil
+}
+
+// clearToken removes the token from a context, keeping its URL.
+func (c *cliConfig) clearToken(name string) error {
+	ctx, ok := c.Contexts[name]
+	if !ok {
+		return fmt.Errorf("no context named %q (see: logdeck context list)", name)
+	}
+	ctx.Token = ""
+	c.Contexts[name] = ctx
+	return nil
+}
+
+// connection is a resolved server connection plus where each value came from.
+type connection struct {
+	url         string
+	token       string
+	urlSource   string // "flag", "env", `context "name"`, or "default"
+	tokenSource string // "flag", "env", `context "name"`, or "none"
+}
+
+// resolveConnection applies the precedence order: explicit flags >
+// LOGDECK_URL/LOGDECK_TOKEN env > active context (or the --context override)
+// > default. URL and token resolve independently.
+func resolveConnection(flagURL string, urlSet bool, flagToken string, tokenSet bool, envURL, envToken string, cfg cliConfig, contextOverride string) (connection, error) {
+	var active contextConfig
+	var activeName string
+	if contextOverride != "" {
+		found, ok := cfg.Contexts[contextOverride]
+		if !ok {
+			return connection{}, fmt.Errorf("no context named %q (see: logdeck context list)", contextOverride)
+		}
+		active, activeName = found, contextOverride
+	} else if cfg.CurrentContext != "" {
+		// A dangling currentContext is ignored rather than fatal.
+		if found, ok := cfg.Contexts[cfg.CurrentContext]; ok {
+			active, activeName = found, cfg.CurrentContext
+		}
+	}
+
+	conn := connection{url: defaultServerURL, urlSource: "default", tokenSource: "none"}
+	if activeName != "" {
+		source := fmt.Sprintf("context %q", activeName)
+		if active.URL != "" {
+			conn.url, conn.urlSource = active.URL, source
+		}
+		if active.Token != "" {
+			conn.token, conn.tokenSource = active.Token, source
+		}
+	}
+	if envURL != "" {
+		conn.url, conn.urlSource = envURL, "env"
+	}
+	if envToken != "" {
+		conn.token, conn.tokenSource = envToken, "env"
+	}
+	if urlSet {
+		conn.url, conn.urlSource = flagURL, "flag"
+	}
+	if tokenSet {
+		conn.token, conn.tokenSource = flagToken, "flag"
+	}
+	return conn, nil
+}
+
+// tokenPreview shows enough of a token to identify it (its ldk_ prefix)
+// without ever printing the secret itself.
+func tokenPreview(token string) string {
+	if token == "" {
+		return "none"
+	}
+	if len(token) <= 8 {
+		return "****"
+	}
+	return token[:8] + "..."
+}

--- a/server/internal/cli/config_test.go
+++ b/server/internal/cli/config_test.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigPathRespectsXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
+	path, err := configPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != filepath.Join("/custom/config", "logdeck", "config.json") {
+		t.Errorf("unexpected path: %s", path)
+	}
+}
+
+func TestLoadConfigMissingFile(t *testing.T) {
+	cfg, err := loadConfig(filepath.Join(t.TempDir(), "nope", "config.json"))
+	if err != nil {
+		t.Fatalf("missing file should not error, got: %v", err)
+	}
+	if cfg.CurrentContext != "" || len(cfg.Contexts) != 0 {
+		t.Errorf("expected empty config, got %+v", cfg)
+	}
+}
+
+func TestSaveLoadRoundtrip(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	path, err := configPath()
+	if err != nil {
+		t.Fatalf("configPath: %v", err)
+	}
+
+	want := cliConfig{
+		CurrentContext: "prod",
+		Contexts: map[string]contextConfig{
+			"prod":    {URL: "https://logdeck.example.com", Token: "ldk_secret123456"},
+			"staging": {URL: "http://staging:8080"},
+		},
+	}
+	if err := saveConfig(path, want); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	got, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if got.CurrentContext != "prod" || len(got.Contexts) != 2 {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+	if got.Contexts["prod"] != want.Contexts["prod"] || got.Contexts["staging"] != want.Contexts["staging"] {
+		t.Errorf("contexts mismatch: %+v", got.Contexts)
+	}
+
+	// Tokens live in this file: check restrictive permissions.
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o600 {
+		t.Errorf("config file permissions = %o, want 600", perm)
+	}
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("config dir permissions = %o, want 700", perm)
+	}
+}
+
+func TestContextSemantics(t *testing.T) {
+	var cfg cliConfig
+
+	cfg.setContext("prod", contextConfig{URL: "https://prod", Token: "ldk_prod12345"})
+	cfg.setContext("staging", contextConfig{URL: "https://staging"})
+	if cfg.CurrentContext != "staging" {
+		t.Errorf("setContext should make the context current, got %q", cfg.CurrentContext)
+	}
+
+	if err := cfg.useContext("prod"); err != nil {
+		t.Fatalf("useContext: %v", err)
+	}
+	if cfg.CurrentContext != "prod" {
+		t.Errorf("useContext did not switch, got %q", cfg.CurrentContext)
+	}
+	if err := cfg.useContext("nope"); err == nil {
+		t.Error("useContext with unknown name should error")
+	}
+
+	if err := cfg.clearToken("prod"); err != nil {
+		t.Fatalf("clearToken: %v", err)
+	}
+	if cfg.Contexts["prod"].Token != "" || cfg.Contexts["prod"].URL != "https://prod" {
+		t.Errorf("clearToken should drop the token and keep the URL, got %+v", cfg.Contexts["prod"])
+	}
+	if err := cfg.clearToken("nope"); err == nil {
+		t.Error("clearToken with unknown name should error")
+	}
+
+	if err := cfg.removeContext("prod"); err != nil {
+		t.Fatalf("removeContext: %v", err)
+	}
+	if cfg.CurrentContext != "" {
+		t.Errorf("removing the current context should clear currentContext, got %q", cfg.CurrentContext)
+	}
+	if _, ok := cfg.Contexts["prod"]; ok {
+		t.Error("context not removed")
+	}
+	if err := cfg.removeContext("prod"); err == nil {
+		t.Error("removeContext twice should error")
+	}
+	// Removing a non-current context keeps currentContext.
+	cfg.setContext("other", contextConfig{URL: "https://other"})
+	cfg.setContext("keep", contextConfig{URL: "https://keep"})
+	if err := cfg.removeContext("other"); err != nil {
+		t.Fatalf("removeContext: %v", err)
+	}
+	if cfg.CurrentContext != "keep" {
+		t.Errorf("currentContext should survive removing another context, got %q", cfg.CurrentContext)
+	}
+}
+
+func TestResolveConnectionPrecedence(t *testing.T) {
+	cfg := cliConfig{
+		CurrentContext: "prod",
+		Contexts: map[string]contextConfig{
+			"prod":    {URL: "https://ctx", Token: "ctx-token"},
+			"staging": {URL: "https://staging", Token: "staging-token"},
+		},
+	}
+
+	// Default: nothing set, no config.
+	conn, err := resolveConnection("", false, "", false, "", "", cliConfig{}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conn.url != defaultServerURL || conn.urlSource != "default" || conn.token != "" || conn.tokenSource != "none" {
+		t.Errorf("default resolution wrong: %+v", conn)
+	}
+
+	// Context supplies both.
+	conn, _ = resolveConnection("", false, "", false, "", "", cfg, "")
+	if conn.url != "https://ctx" || conn.urlSource != `context "prod"` || conn.token != "ctx-token" {
+		t.Errorf("context resolution wrong: %+v", conn)
+	}
+
+	// Env beats context.
+	conn, _ = resolveConnection("", false, "", false, "https://env", "env-token", cfg, "")
+	if conn.url != "https://env" || conn.urlSource != "env" || conn.token != "env-token" || conn.tokenSource != "env" {
+		t.Errorf("env should beat context: %+v", conn)
+	}
+
+	// Flags beat env and context.
+	conn, _ = resolveConnection("https://flag", true, "flag-token", true, "https://env", "env-token", cfg, "")
+	if conn.url != "https://flag" || conn.urlSource != "flag" || conn.token != "flag-token" || conn.tokenSource != "flag" {
+		t.Errorf("flags should beat everything: %+v", conn)
+	}
+
+	// URL and token resolve independently (flag url + context token).
+	conn, _ = resolveConnection("https://flag", true, "", false, "", "", cfg, "")
+	if conn.urlSource != "flag" || conn.token != "ctx-token" || conn.tokenSource != `context "prod"` {
+		t.Errorf("mixed sources wrong: %+v", conn)
+	}
+
+	// --context override selects a non-current context.
+	conn, _ = resolveConnection("", false, "", false, "", "", cfg, "staging")
+	if conn.url != "https://staging" || conn.token != "staging-token" || conn.urlSource != `context "staging"` {
+		t.Errorf("context override wrong: %+v", conn)
+	}
+
+	// Unknown --context errors.
+	if _, err := resolveConnection("", false, "", false, "", "", cfg, "nope"); err == nil {
+		t.Error("unknown context override should error")
+	}
+
+	// Dangling currentContext falls back to defaults.
+	conn, err = resolveConnection("", false, "", false, "", "", cliConfig{CurrentContext: "gone"}, "")
+	if err != nil || conn.url != defaultServerURL {
+		t.Errorf("dangling currentContext should fall back to default: %+v, err %v", conn, err)
+	}
+}
+
+func TestTokenPreview(t *testing.T) {
+	if got := tokenPreview(""); got != "none" {
+		t.Errorf("empty token preview = %q", got)
+	}
+	if got := tokenPreview("short"); got != "****" {
+		t.Errorf("short token preview = %q", got)
+	}
+	got := tokenPreview("ldk_abcdef123456789")
+	if got != "ldk_abcd..." {
+		t.Errorf("token preview = %q, want ldk_abcd...", got)
+	}
+}

--- a/server/internal/cli/containers.go
+++ b/server/internal/cli/containers.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newContainersCmd(a *app) *cobra.Command {
+	var state, host string
+
+	cmd := &cobra.Command{
+		Use:   "containers",
+		Short: "List containers across all hosts",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			resp, err := a.fetchContainers(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			filtered := make([]containerInfo, 0, len(resp.Containers))
+			for _, c := range resp.Containers {
+				if state != "" && c.State != state {
+					continue
+				}
+				if host != "" && c.Host != host {
+					continue
+				}
+				filtered = append(filtered, c)
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]any{
+					"containers": filtered,
+					"hostErrors": resp.HostErrors,
+					"readOnly":   resp.ReadOnly,
+				})
+			}
+
+			warnHostErrors(resp.HostErrors)
+			rows := make([][]string, 0, len(filtered))
+			for _, c := range filtered {
+				rows = append(rows, []string{containerName(c), c.State, c.Image, c.Host, c.Status})
+			}
+			renderTable(os.Stdout, []string{"NAME", "STATE", "IMAGE", "HOST", "UPTIME"}, rows)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&state, "state", "", "filter by state (running, exited, paused, restarting, dead)")
+	cmd.Flags().StringVar(&host, "host", "", "filter by host name")
+	return cmd
+}
+
+// warnHostErrors reports unreachable hosts on stderr in table mode.
+func warnHostErrors(errors []hostError) {
+	for _, he := range errors {
+		fmt.Fprintf(os.Stderr, "warning: host %s unreachable: %s\n", he.Host, he.Message)
+	}
+}
+
+func newInspectCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "inspect <name|id>",
+		Short: "Show full inspect data for a container",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			container, err := a.resolve(ctx, args[0], host)
+			if err != nil {
+				return err
+			}
+
+			var resp struct {
+				Container json.RawMessage `json:"container"`
+			}
+			query := url.Values{"host": {container.Host}}
+			if err := a.client.get(ctx, "/containers/"+container.ID+"/", query, &resp); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				var inspect any
+				if err := json.Unmarshal(resp.Container, &inspect); err != nil {
+					return err
+				}
+				return a.printJSON(inspect)
+			}
+
+			var inspect map[string]any
+			if err := json.Unmarshal(resp.Container, &inspect); err != nil {
+				return err
+			}
+			printInspectSummary(container, inspect)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "host name (disambiguates duplicate container names)")
+	return cmd
+}
+
+// dig walks nested maps, returning "" if any key is missing.
+func dig(m map[string]any, keys ...string) string {
+	current := any(m)
+	for _, key := range keys {
+		asMap, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = asMap[key]
+	}
+	switch v := current.(type) {
+	case string:
+		return v
+	case float64:
+		return fmt.Sprintf("%v", v)
+	case bool:
+		return fmt.Sprintf("%v", v)
+	default:
+		return ""
+	}
+}
+
+func printInspectSummary(container containerInfo, inspect map[string]any) {
+	rows := [][]string{
+		{"Name", containerName(container)},
+		{"ID", container.ID},
+		{"Host", container.Host},
+		{"Image", dig(inspect, "Config", "Image")},
+		{"State", dig(inspect, "State", "Status")},
+		{"Started", dig(inspect, "State", "StartedAt")},
+		{"Exit code", dig(inspect, "State", "ExitCode")},
+		{"Restarts", dig(inspect, "RestartCount")},
+		{"Restart policy", dig(inspect, "HostConfig", "RestartPolicy", "Name")},
+		{"Created", dig(inspect, "Created")},
+	}
+	if project := composeProject(container.Labels); project != "" {
+		rows = append(rows, []string{"Compose project", project})
+	}
+	if cmd := dig(inspect, "Path"); cmd != "" {
+		rows = append(rows, []string{"Command", cmd})
+	}
+	renderTable(os.Stdout, []string{"FIELD", "VALUE"}, rows)
+	fmt.Fprintln(os.Stderr, "\nhint: use -o json for the full inspect document")
+}

--- a/server/internal/cli/context.go
+++ b/server/internal/cli/context.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newLoginCmd(a *app) *cobra.Command {
+	var name string
+
+	cmd := &cobra.Command{
+		Use:   "login --url <url> [--token <token>] [--name <context>]",
+		Short: "Verify a server connection and save it as the current context",
+		Long:  "Verify a server connection and save it as a context in the CLI config\nfile, making it the current context for future invocations.",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if !cmd.Flags().Changed("url") {
+				return fmt.Errorf("--url is required (example: logdeck login --url https://logdeck.example.com --token ldk_...)")
+			}
+			if name == "" {
+				return fmt.Errorf("--name must not be empty")
+			}
+			serverURL := strings.TrimRight(a.url, "/")
+			token := ""
+			if cmd.Flags().Changed("token") {
+				token = a.token
+			}
+
+			// Verify the connection with exactly what was given, ignoring
+			// env vars and existing contexts.
+			probe := newClient(serverURL, token)
+			var health struct {
+				Status string `json:"status"`
+			}
+			if err := probe.get(ctx, "/healthz", nil, &health); err != nil {
+				return err
+			}
+			// Prove the token works (or that the server needs none): hit an
+			// authenticated endpoint. A 401 carries the Settings hint.
+			if err := probe.get(ctx, "/containers", nil, nil); err != nil {
+				return err
+			}
+
+			path, err := configPath()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadConfig(path)
+			if err != nil {
+				return err
+			}
+			cfg.setContext(name, contextConfig{URL: serverURL, Token: token})
+			if err := saveConfig(path, cfg); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]any{
+					"message": "context saved",
+					"context": name,
+					"url":     serverURL,
+					"token":   tokenPreview(token),
+					"current": true,
+				})
+			}
+			fmt.Printf("Saved context %q (%s, token %s) and made it current.\n", name, serverURL, tokenPreview(token))
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&name, "name", "default", "name to save the context under")
+	return cmd
+}
+
+func newLogoutCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout [<context>]",
+		Short: "Remove the saved token from a context (keeps its URL)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			path, err := configPath()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadConfig(path)
+			if err != nil {
+				return err
+			}
+
+			name := cfg.CurrentContext
+			if len(args) == 1 {
+				name = args[0]
+			}
+			if name == "" {
+				return fmt.Errorf("no current context; pass a context name (see: logdeck context list)")
+			}
+			if err := cfg.clearToken(name); err != nil {
+				return err
+			}
+			if err := saveConfig(path, cfg); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"message": "token removed", "context": name})
+			}
+			fmt.Printf("Removed token from context %q.\n", name)
+			return nil
+		}),
+	}
+}
+
+func newContextCmd(a *app) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Manage saved server contexts",
+	}
+	cmd.AddCommand(newContextListCmd(a), newContextUseCmd(a), newContextRmCmd(a))
+	return cmd
+}
+
+func newContextListCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List saved contexts",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			path, err := configPath()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadConfig(path)
+			if err != nil {
+				return err
+			}
+
+			names := make([]string, 0, len(cfg.Contexts))
+			for name := range cfg.Contexts {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			if a.jsonOutput() {
+				contexts := make([]map[string]any, 0, len(names))
+				for _, name := range names {
+					contexts = append(contexts, map[string]any{
+						"name":    name,
+						"url":     cfg.Contexts[name].URL,
+						"token":   tokenPreview(cfg.Contexts[name].Token),
+						"current": name == cfg.CurrentContext,
+					})
+				}
+				return a.printJSON(map[string]any{
+					"currentContext": cfg.CurrentContext,
+					"contexts":       contexts,
+				})
+			}
+
+			rows := make([][]string, 0, len(names))
+			for _, name := range names {
+				marker := ""
+				if name == cfg.CurrentContext {
+					marker = "*"
+				}
+				rows = append(rows, []string{marker, name, cfg.Contexts[name].URL, tokenPreview(cfg.Contexts[name].Token)})
+			}
+			renderTable(os.Stdout, []string{"CURRENT", "NAME", "URL", "TOKEN"}, rows)
+			return nil
+		}),
+	}
+}
+
+func newContextUseCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <name>",
+		Short: "Make a saved context the current one",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			path, err := configPath()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadConfig(path)
+			if err != nil {
+				return err
+			}
+			if err := cfg.useContext(args[0]); err != nil {
+				return err
+			}
+			if err := saveConfig(path, cfg); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"message": "context switched", "context": args[0]})
+			}
+			fmt.Printf("Switched to context %q (%s).\n", args[0], cfg.Contexts[args[0]].URL)
+			return nil
+		}),
+	}
+}
+
+func newContextRmCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "rm <name>",
+		Short: "Delete a saved context",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			path, err := configPath()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadConfig(path)
+			if err != nil {
+				return err
+			}
+			if err := cfg.removeContext(args[0]); err != nil {
+				return err
+			}
+			if err := saveConfig(path, cfg); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"message": "context removed", "context": args[0]})
+			}
+			fmt.Printf("Removed context %q.\n", args[0])
+			return nil
+		}),
+	}
+}

--- a/server/internal/cli/env.go
+++ b/server/internal/cli/env.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+func newEnvCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "env <name|id>",
+		Short: "Show a container's environment variables",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			container, err := a.resolve(ctx, args[0], host)
+			if err != nil {
+				return err
+			}
+
+			var resp struct {
+				Env map[string]string `json:"env"`
+			}
+			query := url.Values{"host": {container.Host}}
+			if err := a.client.get(ctx, "/containers/"+container.ID+"/env", query, &resp); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				if resp.Env == nil {
+					resp.Env = map[string]string{}
+				}
+				return a.printJSON(map[string]any{"env": resp.Env})
+			}
+
+			keys := make([]string, 0, len(resp.Env))
+			for key := range resp.Env {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				fmt.Printf("%s=%s\n", key, resp.Env[key])
+			}
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "host name (disambiguates duplicate container names)")
+	return cmd
+}

--- a/server/internal/cli/events.go
+++ b/server/internal/cli/events.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newEventsCmd(a *app) *cobra.Command {
+	var follow bool
+	var forDuration string
+
+	cmd := &cobra.Command{
+		Use:   "events",
+		Short: "Stream container lifecycle events",
+		Long:  "Stream container lifecycle events from all hosts. Streams until\ninterrupted; use --for to read for a fixed duration and exit.",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if forDuration != "" {
+				d, err := parseDuration(forDuration)
+				if err != nil || d <= 0 {
+					return fmt.Errorf("invalid --for duration %q (examples: 10s, 1m)", forDuration)
+				}
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, d)
+				defer cancel()
+			}
+
+			body, err := a.client.stream(ctx, "/events", nil)
+			if err != nil {
+				return err
+			}
+			defer body.Close()
+
+			return a.scanNDJSON(ctx, body, func(line []byte) error {
+				var event containerEvent
+				if err := json.Unmarshal(line, &event); err != nil {
+					return nil // skip malformed lines
+				}
+				timestamp := time.Unix(event.Timestamp, 0).UTC().Format(time.RFC3339)
+				if a.jsonOutput() {
+					payload, err := json.Marshal(map[string]string{
+						"timestamp":     timestamp,
+						"host":          event.Host,
+						"containerId":   event.ContainerID,
+						"containerName": event.ContainerName,
+						"action":        event.Action,
+					})
+					if err != nil {
+						return err
+					}
+					fmt.Println(string(payload))
+					return nil
+				}
+				fmt.Printf("%s %s %s %s\n", timestamp, event.Host, event.ContainerName, event.Action)
+				return nil
+			})
+		}),
+	}
+
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "stream until interrupted (the default)")
+	cmd.Flags().StringVar(&forDuration, "for", "", "read events for this long, then exit (e.g. 10s)")
+	return cmd
+}

--- a/server/internal/cli/grep.go
+++ b/server/internal/cli/grep.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newGrepCmd(a *app) *cobra.Command {
+	var since, level, host string
+	var tail int
+
+	cmd := &cobra.Command{
+		Use:   "grep <regex>",
+		Short: "Search recent logs of all running containers",
+		Long:  "Search the recent logs of every running container across all hosts,\nmerged by timestamp. Bounded to the last 15 minutes by default (--since).",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			pattern := args[0]
+			if _, err := regexp.Compile(pattern); err != nil {
+				return fmt.Errorf("invalid regex %q: %v", pattern, err)
+			}
+
+			sinceValue, err := parseTimeArg(since, time.Now())
+			if err != nil {
+				return err
+			}
+
+			resp, err := a.fetchContainers(ctx)
+			if err != nil {
+				return err
+			}
+
+			var running []containerInfo
+			for _, c := range resp.Containers {
+				if c.State != "running" {
+					continue
+				}
+				if host != "" && c.Host != host {
+					continue
+				}
+				running = append(running, c)
+			}
+			if len(running) == 0 {
+				return a.printLogs(nil, true)
+			}
+
+			query := url.Values{}
+			query.Set("search", pattern)
+			query.Set("tail", strconv.Itoa(tail))
+			if sinceValue != "" {
+				query.Set("since", sinceValue)
+			}
+			if level != "" {
+				query.Set("level", strings.ToUpper(level))
+			}
+
+			logs, err := a.aggregatedLogs(ctx, buildTargets(running), query)
+			if err != nil {
+				return err
+			}
+			return a.printLogs(logs, true)
+		}),
+	}
+
+	cmd.Flags().StringVar(&since, "since", "15m", "only logs after this time (RFC3339 or relative: 30s, 15m, 2h, 1d)")
+	cmd.Flags().StringVar(&level, "level", "", "filter by log level (TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC)")
+	cmd.Flags().StringVar(&host, "host", "", "only search containers on this host")
+	cmd.Flags().IntVar(&tail, "tail", 1000, "lines scanned per container (max 10000)")
+	return cmd
+}

--- a/server/internal/cli/listings.go
+++ b/server/internal/cli/listings.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newImagesCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "List images across all hosts",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var resp struct {
+				Images     []imageInfo `json:"images"`
+				HostErrors []hostError `json:"hostErrors"`
+			}
+			if err := a.client.get(cmd.Context(), "/images", nil, &resp); err != nil {
+				return err
+			}
+
+			filtered := make([]imageInfo, 0, len(resp.Images))
+			for _, image := range resp.Images {
+				if host != "" && image.Host != host {
+					continue
+				}
+				filtered = append(filtered, image)
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]any{"images": filtered, "hostErrors": resp.HostErrors})
+			}
+
+			warnHostErrors(resp.HostErrors)
+			now := time.Now()
+			rows := make([][]string, 0, len(filtered))
+			for _, image := range filtered {
+				tag := "<none>"
+				if len(image.RepoTags) > 0 {
+					tag = image.RepoTags[0]
+				}
+				rows = append(rows, []string{
+					tag,
+					shortID(image.ID),
+					humanBytes(uint64(image.Size)),
+					humanAge(time.Unix(image.Created, 0), now),
+					image.Host,
+				})
+			}
+			renderTable(os.Stdout, []string{"TAG", "ID", "SIZE", "CREATED", "HOST"}, rows)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "filter by host name")
+	return cmd
+}
+
+func newVolumesCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "volumes",
+		Short: "List volumes across all hosts",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var resp struct {
+				Volumes    []volumeInfo `json:"volumes"`
+				HostErrors []hostError  `json:"hostErrors"`
+			}
+			if err := a.client.get(cmd.Context(), "/volumes", nil, &resp); err != nil {
+				return err
+			}
+
+			filtered := make([]volumeInfo, 0, len(resp.Volumes))
+			for _, volume := range resp.Volumes {
+				if host != "" && volume.Host != host {
+					continue
+				}
+				filtered = append(filtered, volume)
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]any{"volumes": filtered, "hostErrors": resp.HostErrors})
+			}
+
+			warnHostErrors(resp.HostErrors)
+			rows := make([][]string, 0, len(filtered))
+			for _, volume := range filtered {
+				rows = append(rows, []string{volume.Name, volume.Driver, volume.Created, volume.Host})
+			}
+			renderTable(os.Stdout, []string{"NAME", "DRIVER", "CREATED", "HOST"}, rows)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "filter by host name")
+	return cmd
+}
+
+func newNetworksCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "networks",
+		Short: "List networks across all hosts",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var resp struct {
+				Networks   []networkInfo `json:"networks"`
+				HostErrors []hostError   `json:"hostErrors"`
+			}
+			if err := a.client.get(cmd.Context(), "/networks", nil, &resp); err != nil {
+				return err
+			}
+
+			filtered := make([]networkInfo, 0, len(resp.Networks))
+			for _, network := range resp.Networks {
+				if host != "" && network.Host != host {
+					continue
+				}
+				filtered = append(filtered, network)
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]any{"networks": filtered, "hostErrors": resp.HostErrors})
+			}
+
+			warnHostErrors(resp.HostErrors)
+			rows := make([][]string, 0, len(filtered))
+			for _, network := range filtered {
+				rows = append(rows, []string{
+					network.Name,
+					network.Driver,
+					network.Scope,
+					strings.Join(network.Subnets, ","),
+					network.Host,
+				})
+			}
+			renderTable(os.Stdout, []string{"NAME", "DRIVER", "SCOPE", "SUBNETS", "HOST"}, rows)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "filter by host name")
+	return cmd
+}

--- a/server/internal/cli/logs.go
+++ b/server/internal/cli/logs.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// maxAggregateTargets mirrors the server's per-request limit for
+// /logs/aggregate.
+const maxAggregateTargets = 20
+
+type logFlags struct {
+	tail   int
+	level  string
+	search string
+	since  string
+	until  string
+	follow bool
+}
+
+func (f *logFlags) register(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&f.tail, "tail", 100, "number of lines from the end of the logs (max 10000)")
+	cmd.Flags().StringVar(&f.level, "level", "", "filter by log level (TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC)")
+	cmd.Flags().StringVar(&f.search, "search", "", "filter by regex")
+	cmd.Flags().StringVar(&f.since, "since", "", "only logs after this time (RFC3339 or relative: 30s, 15m, 2h, 1d)")
+	cmd.Flags().StringVar(&f.until, "until", "", "only logs before this time (RFC3339 or relative: 30s, 15m, 2h, 1d)")
+	cmd.Flags().BoolVarP(&f.follow, "follow", "f", false, "stream new logs continuously")
+}
+
+// query converts flags to log endpoint query params, resolving relative times.
+func (f *logFlags) query(now time.Time) (url.Values, error) {
+	query := url.Values{}
+	query.Set("tail", strconv.Itoa(f.tail))
+	since, err := parseTimeArg(f.since, now)
+	if err != nil {
+		return nil, err
+	}
+	if since != "" {
+		query.Set("since", since)
+	}
+	until, err := parseTimeArg(f.until, now)
+	if err != nil {
+		return nil, err
+	}
+	if until != "" {
+		query.Set("until", until)
+	}
+	if f.level != "" {
+		query.Set("level", strings.ToUpper(f.level))
+	}
+	if f.search != "" {
+		query.Set("search", f.search)
+	}
+	return query, nil
+}
+
+func newLogsCmd(a *app) *cobra.Command {
+	var flags logFlags
+	var stack, host string
+
+	cmd := &cobra.Command{
+		Use:   "logs [<name|id>]",
+		Short: "Read or follow container logs (or a whole stack with --stack)",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return fmt.Errorf("accepts at most one container")
+			}
+			stackFlag, _ := cmd.Flags().GetString("stack")
+			if (stackFlag != "") == (len(args) == 1) {
+				return fmt.Errorf("specify either a container or --stack <project>")
+			}
+			return nil
+		},
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			query, err := flags.query(time.Now())
+			if err != nil {
+				return err
+			}
+
+			if stack != "" {
+				return a.stackLogs(ctx, stack, host, flags.follow, query)
+			}
+
+			container, err := a.resolve(ctx, args[0], host)
+			if err != nil {
+				return err
+			}
+			query.Set("host", container.Host)
+			path := "/containers/" + container.ID + "/logs/parsed"
+
+			if flags.follow {
+				query.Set("follow", "true")
+				return a.followLogs(ctx, path, query, false)
+			}
+
+			var resp struct {
+				Logs  []logEntry `json:"logs"`
+				Count int        `json:"count"`
+			}
+			if err := a.client.get(ctx, path, query, &resp); err != nil {
+				return err
+			}
+			return a.printLogs(resp.Logs, false)
+		}),
+	}
+
+	flags.register(cmd)
+	cmd.Flags().StringVar(&stack, "stack", "", "read aggregated logs for a compose project instead of one container")
+	cmd.Flags().StringVar(&host, "host", "", "host name (disambiguates, or narrows --stack to one host)")
+	return cmd
+}
+
+// stackLogs reads aggregated logs for every container of a compose project.
+func (a *app) stackLogs(ctx context.Context, project, host string, follow bool, query url.Values) error {
+	resp, err := a.fetchContainers(ctx)
+	if err != nil {
+		return err
+	}
+
+	var members []containerInfo
+	for _, c := range resp.Containers {
+		if composeProject(c.Labels) != project {
+			continue
+		}
+		if host != "" && c.Host != host {
+			continue
+		}
+		members = append(members, c)
+	}
+	if len(members) == 0 {
+		return fmt.Errorf("no containers found for stack %q", project)
+	}
+
+	targets := buildTargets(members)
+
+	if follow {
+		if len(targets) > maxAggregateTargets {
+			fmt.Fprintf(os.Stderr, "warning: stack %s has %d containers; following only the first %d\n", project, len(targets), maxAggregateTargets)
+			targets = targets[:maxAggregateTargets]
+		}
+		query.Set("targets", strings.Join(targets, ","))
+		query.Set("follow", "true")
+		return a.followLogs(ctx, "/logs/aggregate", query, true)
+	}
+
+	logs, err := a.aggregatedLogs(ctx, targets, query)
+	if err != nil {
+		return err
+	}
+	return a.printLogs(logs, true)
+}
+
+// buildTargets encodes containers as host~id~name aggregate targets.
+func buildTargets(containers []containerInfo) []string {
+	targets := make([]string, 0, len(containers))
+	for _, c := range containers {
+		targets = append(targets, c.Host+"~"+c.ID+"~"+containerName(c))
+	}
+	return targets
+}
+
+// aggregatedLogs fetches one-shot aggregate logs, batching targets by the
+// server's per-request limit and merging results by timestamp.
+func (a *app) aggregatedLogs(ctx context.Context, targets []string, query url.Values) ([]logEntry, error) {
+	var all []logEntry
+	for _, batch := range batchStrings(targets, maxAggregateTargets) {
+		batchQuery := url.Values{}
+		for key, values := range query {
+			batchQuery[key] = values
+		}
+		batchQuery.Set("targets", strings.Join(batch, ","))
+
+		var resp struct {
+			Logs []logEntry `json:"logs"`
+		}
+		if err := a.client.get(ctx, "/logs/aggregate", batchQuery, &resp); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Logs...)
+	}
+	mergeByTimestamp(all)
+	return all, nil
+}
+
+// mergeByTimestamp sorts entries chronologically (stable, so same-timestamp
+// lines keep their per-container order).
+func mergeByTimestamp(entries []logEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Timestamp.Before(entries[j].Timestamp)
+	})
+}
+
+// printLogs writes one-shot log results: a single JSON document in json mode,
+// one formatted line per entry otherwise.
+func (a *app) printLogs(logs []logEntry, withName bool) error {
+	if a.jsonOutput() {
+		if logs == nil {
+			logs = []logEntry{}
+		}
+		return a.printJSON(map[string]any{"logs": logs, "count": len(logs)})
+	}
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	for _, entry := range logs {
+		fmt.Fprintln(out, formatLogLine(entry, withName))
+	}
+	return nil
+}
+
+// followLogs streams an NDJSON log endpoint, skipping heartbeats. Table mode
+// formats entries; json mode echoes the raw NDJSON lines.
+func (a *app) followLogs(ctx context.Context, path string, query url.Values, withName bool) error {
+	body, err := a.client.stream(ctx, path, query)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	return a.scanNDJSON(ctx, body, func(line []byte) error {
+		if a.jsonOutput() {
+			fmt.Println(string(line))
+			return nil
+		}
+		var entry logEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return nil // skip malformed lines rather than aborting the stream
+		}
+		fmt.Println(formatLogLine(entry, withName))
+		return nil
+	})
+}
+
+// scanNDJSON reads an NDJSON stream line by line, skipping blank lines and
+// heartbeats. Context cancellation (Ctrl-C, --for expiry) is a clean stop.
+func (a *app) scanNDJSON(ctx context.Context, body interface{ Read([]byte) (int, error) }, handle func(line []byte) error) error {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 || isHeartbeat(line) {
+			continue
+		}
+		if err := handle(line); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		return err
+	}
+	return nil
+}
+
+func isHeartbeat(line []byte) bool {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(line, &probe); err != nil {
+		return false
+	}
+	return probe.Type == "heartbeat"
+}

--- a/server/internal/cli/parse.go
+++ b/server/internal/cli/parse.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parseDuration parses Go durations plus a "d" (day) suffix: 30s, 15m, 2h, 1d.
+func parseDuration(value string) (time.Duration, error) {
+	if strings.HasSuffix(value, "d") {
+		if days, err := strconv.ParseFloat(strings.TrimSuffix(value, "d"), 64); err == nil {
+			return time.Duration(days * 24 * float64(time.Hour)), nil
+		}
+	}
+	return time.ParseDuration(value)
+}
+
+// parseTimeArg accepts an RFC3339 timestamp or a relative duration
+// (30s, 15m, 2h, 1d, meaning "that long ago") and returns RFC3339.
+// An empty value passes through unchanged.
+func parseTimeArg(value string, now time.Time) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	if _, err := time.Parse(time.RFC3339, value); err == nil {
+		return value, nil
+	}
+	d, err := parseDuration(value)
+	if err != nil || d < 0 {
+		return "", fmt.Errorf("invalid time %q: use RFC3339 or a relative duration like 30s, 15m, 2h, 1d", value)
+	}
+	return now.Add(-d).UTC().Format(time.RFC3339), nil
+}
+
+var memoryUnits = []struct {
+	suffix string
+	factor int64
+}{
+	{"kib", 1 << 10}, {"kb", 1 << 10}, {"k", 1 << 10},
+	{"mib", 1 << 20}, {"mb", 1 << 20}, {"m", 1 << 20},
+	{"gib", 1 << 30}, {"gb", 1 << 30}, {"g", 1 << 30},
+	{"b", 1},
+}
+
+// parseMemory converts human memory values ("512m", "1.5g", "104857600")
+// to bytes. Units are binary (1k = 1024), matching Docker's -m flag.
+func parseMemory(value string) (int64, error) {
+	s := strings.ToLower(strings.TrimSpace(value))
+	factor := int64(1)
+	for _, unit := range memoryUnits {
+		if strings.HasSuffix(s, unit.suffix) {
+			s = strings.TrimSuffix(s, unit.suffix)
+			factor = unit.factor
+			break
+		}
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid memory value %q (examples: 512m, 1.5g, 104857600)", value)
+	}
+	return int64(math.Round(n * float64(factor))), nil
+}
+
+// cpusToNano converts a CPU count (1.5) to Docker nanoCPUs (1.5e9).
+func cpusToNano(cpus float64) int64 {
+	return int64(math.Round(cpus * 1e9))
+}
+
+// batchStrings splits items into chunks of at most size.
+func batchStrings(items []string, size int) [][]string {
+	if size <= 0 || len(items) == 0 {
+		return nil
+	}
+	var batches [][]string
+	for start := 0; start < len(items); start += size {
+		end := min(start+size, len(items))
+		batches = append(batches, items[start:end])
+	}
+	return batches
+}

--- a/server/internal/cli/parse_test.go
+++ b/server/internal/cli/parse_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTimeArg(t *testing.T) {
+	now := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"}, // RFC3339 passes through
+		{"30s", "2026-01-02T11:59:30Z"},
+		{"15m", "2026-01-02T11:45:00Z"},
+		{"2h", "2026-01-02T10:00:00Z"},
+		{"1d", "2026-01-01T12:00:00Z"},
+		{"1h30m", "2026-01-02T10:30:00Z"},
+	}
+	for _, tt := range tests {
+		got, err := parseTimeArg(tt.in, now)
+		if err != nil {
+			t.Errorf("parseTimeArg(%q) unexpected error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseTimeArg(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+	for _, invalid := range []string{"tomorrow", "5x", "-1h", "h"} {
+		if _, err := parseTimeArg(invalid, now); err == nil {
+			t.Errorf("parseTimeArg(%q) expected error", invalid)
+		}
+	}
+}
+
+func TestParseMemory(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int64
+	}{
+		{"512m", 512 << 20},
+		{"512M", 512 << 20},
+		{"512mb", 512 << 20},
+		{"1g", 1 << 30},
+		{"1.5g", 3 << 29},
+		{"64k", 64 << 10},
+		{"100", 100},
+		{"100b", 100},
+		{"0", 0},
+	}
+	for _, tt := range tests {
+		got, err := parseMemory(tt.in)
+		if err != nil {
+			t.Errorf("parseMemory(%q) unexpected error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseMemory(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+
+	for _, invalid := range []string{"", "abc", "-1g", "1t5"} {
+		if _, err := parseMemory(invalid); err == nil {
+			t.Errorf("parseMemory(%q) expected error", invalid)
+		}
+	}
+}
+
+func TestCpusToNano(t *testing.T) {
+	if got := cpusToNano(1.5); got != 1_500_000_000 {
+		t.Errorf("cpusToNano(1.5) = %d, want 1500000000", got)
+	}
+	if got := cpusToNano(0); got != 0 {
+		t.Errorf("cpusToNano(0) = %d, want 0", got)
+	}
+}
+
+func TestBatchStrings(t *testing.T) {
+	items := make([]string, 45)
+	for i := range items {
+		items[i] = "x"
+	}
+	batches := batchStrings(items, 20)
+	if len(batches) != 3 {
+		t.Fatalf("expected 3 batches, got %d", len(batches))
+	}
+	if len(batches[0]) != 20 || len(batches[1]) != 20 || len(batches[2]) != 5 {
+		t.Errorf("unexpected batch sizes: %d, %d, %d", len(batches[0]), len(batches[1]), len(batches[2]))
+	}
+	if batchStrings(nil, 20) != nil {
+		t.Error("expected nil for empty input")
+	}
+	if got := batchStrings([]string{"a"}, 20); len(got) != 1 || len(got[0]) != 1 {
+		t.Errorf("single item should give one batch of one, got %v", got)
+	}
+}
+
+func TestMergeByTimestamp(t *testing.T) {
+	base := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	entries := []logEntry{
+		{Timestamp: base.Add(2 * time.Second), Message: "c"},
+		{Timestamp: base, Message: "a"},
+		{Timestamp: base.Add(time.Second), Message: "b"},
+		{Timestamp: base, Message: "a2"}, // same timestamp: stable order preserved
+	}
+	mergeByTimestamp(entries)
+	got := entries[0].Message + entries[1].Message + entries[2].Message + entries[3].Message
+	if got != "aa2bc" {
+		t.Errorf("unexpected merge order: %q", got)
+	}
+}

--- a/server/internal/cli/resolve.go
+++ b/server/internal/cli/resolve.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// containerName returns the primary display name (leading / stripped).
+func containerName(c containerInfo) string {
+	if len(c.Names) == 0 {
+		return shortID(c.ID)
+	}
+	return strings.TrimPrefix(c.Names[0], "/")
+}
+
+func nameMatches(c containerInfo, query string) bool {
+	for _, name := range c.Names {
+		if strings.TrimPrefix(name, "/") == query {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveContainer matches query against a container list: exact name first
+// (leading / stripped), then ID prefix. host filters candidates when set.
+func resolveContainer(containers []containerInfo, query, host string) (containerInfo, error) {
+	var candidates []containerInfo
+	for _, c := range containers {
+		if host != "" && c.Host != host {
+			continue
+		}
+		if nameMatches(c, query) {
+			candidates = append(candidates, c)
+		}
+	}
+	if len(candidates) == 0 {
+		for _, c := range containers {
+			if host != "" && c.Host != host {
+				continue
+			}
+			if strings.HasPrefix(c.ID, query) {
+				candidates = append(candidates, c)
+			}
+		}
+	}
+
+	switch len(candidates) {
+	case 1:
+		return candidates[0], nil
+	case 0:
+		if host != "" {
+			return containerInfo{}, fmt.Errorf("no container matches %q on host %q", query, host)
+		}
+		return containerInfo{}, fmt.Errorf("no container matches %q", query)
+	}
+
+	lines := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		lines = append(lines, fmt.Sprintf("  %s (host %s, id %s)", containerName(c), c.Host, shortID(c.ID)))
+	}
+	return containerInfo{}, fmt.Errorf("%q is ambiguous, candidates:\n%s\nuse --host to disambiguate", query, strings.Join(lines, "\n"))
+}
+
+// fetchContainers loads the full container list once; commands resolve names
+// and derive the required ?host= parameter from it.
+func (a *app) fetchContainers(ctx context.Context) (containersResponse, error) {
+	var resp containersResponse
+	err := a.client.get(ctx, "/containers", nil, &resp)
+	return resp, err
+}
+
+// resolve fetches the container list and resolves query within it.
+func (a *app) resolve(ctx context.Context, query, host string) (containerInfo, error) {
+	resp, err := a.fetchContainers(ctx)
+	if err != nil {
+		return containerInfo{}, err
+	}
+	return resolveContainer(resp.Containers, query, host)
+}

--- a/server/internal/cli/resolve_test.go
+++ b/server/internal/cli/resolve_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func testContainers() []containerInfo {
+	return []containerInfo{
+		{ID: "aaa111bbb222ccc", Names: []string{"/web"}, Host: "prod", State: "running"},
+		{ID: "ddd333eee444fff", Names: []string{"/web"}, Host: "staging", State: "running"},
+		{ID: "abc999888777666", Names: []string{"/db"}, Host: "prod", State: "running"},
+	}
+}
+
+func TestResolveContainerExactName(t *testing.T) {
+	c, err := resolveContainer(testContainers(), "db", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.ID != "abc999888777666" || c.Host != "prod" {
+		t.Errorf("resolved wrong container: %+v", c)
+	}
+}
+
+func TestResolveContainerIDPrefix(t *testing.T) {
+	c, err := resolveContainer(testContainers(), "ddd333", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Host != "staging" {
+		t.Errorf("resolved wrong container: %+v", c)
+	}
+}
+
+func TestResolveContainerNameBeatsIDPrefix(t *testing.T) {
+	// "web" only matches names, but a name match must win over checking IDs.
+	containers := []containerInfo{
+		{ID: "web123", Names: []string{"/other"}, Host: "prod"},
+		{ID: "zzz", Names: []string{"/web"}, Host: "prod"},
+	}
+	c, err := resolveContainer(containers, "web", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.ID != "zzz" {
+		t.Errorf("expected exact name match to win, got %+v", c)
+	}
+}
+
+func TestResolveContainerAmbiguous(t *testing.T) {
+	_, err := resolveContainer(testContainers(), "web", "")
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "prod") || !strings.Contains(message, "staging") {
+		t.Errorf("ambiguity error should list candidate hosts, got: %s", message)
+	}
+	if !strings.Contains(message, "--host") {
+		t.Errorf("ambiguity error should suggest --host, got: %s", message)
+	}
+}
+
+func TestResolveContainerHostDisambiguates(t *testing.T) {
+	c, err := resolveContainer(testContainers(), "web", "staging")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Host != "staging" {
+		t.Errorf("resolved wrong container: %+v", c)
+	}
+}
+
+func TestResolveContainerNotFound(t *testing.T) {
+	if _, err := resolveContainer(testContainers(), "nope", ""); err == nil {
+		t.Error("expected not-found error")
+	}
+	if _, err := resolveContainer(testContainers(), "db", "staging"); err == nil {
+		t.Error("expected not-found error when host filter excludes the match")
+	}
+}
+
+func TestContainerName(t *testing.T) {
+	if got := containerName(containerInfo{Names: []string{"/web"}}); got != "web" {
+		t.Errorf("containerName = %q, want web", got)
+	}
+	if got := containerName(containerInfo{ID: "abcdef123456789"}); got != "abcdef123456" {
+		t.Errorf("containerName fallback = %q, want short id", got)
+	}
+}

--- a/server/internal/cli/resources.go
+++ b/server/internal/cli/resources.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newResourcesCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "resources <name|id>",
+		Short: "Show a container's resource limits and restart policy",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			container, err := a.resolve(ctx, args[0], host)
+			if err != nil {
+				return err
+			}
+
+			var resources containerResources
+			query := url.Values{"host": {container.Host}}
+			if err := a.client.get(ctx, "/containers/"+container.ID+"/resources", query, &resources); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(resources)
+			}
+
+			memory := "unlimited"
+			if resources.MemoryBytes > 0 {
+				memory = humanBytes(uint64(resources.MemoryBytes))
+			}
+			cpus := "unlimited"
+			if resources.NanoCPUs > 0 {
+				cpus = fmt.Sprintf("%g", float64(resources.NanoCPUs)/1e9)
+			}
+			policy := resources.RestartPolicy.Name
+			if policy == "" {
+				policy = "no"
+			}
+			if resources.RestartPolicy.MaximumRetryCount > 0 {
+				policy = fmt.Sprintf("%s (max retries %d)", policy, resources.RestartPolicy.MaximumRetryCount)
+			}
+
+			renderTable(os.Stdout, []string{"FIELD", "VALUE"}, [][]string{
+				{"Memory limit", memory},
+				{"CPU limit", cpus},
+				{"Restart policy", policy},
+			})
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "host name (disambiguates duplicate container names)")
+	cmd.AddCommand(newResourcesSetCmd(a))
+	return cmd
+}
+
+func newResourcesSetCmd(a *app) *cobra.Command {
+	var host, memory, restart string
+	var cpus float64
+	var maxRetries int
+
+	cmd := &cobra.Command{
+		Use:   "set <name|id>",
+		Short: "Update a container's resource limits or restart policy",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			var req updateResourcesRequest
+			if cmd.Flags().Changed("memory") {
+				bytes, err := parseMemory(memory)
+				if err != nil {
+					return err
+				}
+				req.MemoryBytes = &bytes
+			}
+			if cmd.Flags().Changed("cpus") {
+				if cpus < 0 {
+					return fmt.Errorf("--cpus must be >= 0")
+				}
+				nano := cpusToNano(cpus)
+				req.NanoCPUs = &nano
+			}
+			if cmd.Flags().Changed("restart") || cmd.Flags().Changed("max-retries") {
+				if restart == "" {
+					return fmt.Errorf("--max-retries requires --restart on-failure")
+				}
+				req.RestartPolicy = &restartPolicySpec{Name: restart, MaximumRetryCount: maxRetries}
+			}
+			if req.MemoryBytes == nil && req.NanoCPUs == nil && req.RestartPolicy == nil {
+				return fmt.Errorf("nothing to update: pass at least one of --memory, --cpus, --restart")
+			}
+
+			container, err := a.resolve(ctx, args[0], host)
+			if err != nil {
+				return err
+			}
+
+			query := url.Values{"host": {container.Host}}
+			if err := a.client.put(ctx, "/containers/"+container.ID+"/resources", query, req, nil); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{
+					"message": "Container resources updated",
+					"name":    containerName(container),
+					"id":      container.ID,
+					"host":    container.Host,
+				})
+			}
+			fmt.Printf("updated resources for %s (host %s)\n", containerName(container), container.Host)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "host name (disambiguates duplicate container names)")
+	cmd.Flags().StringVar(&memory, "memory", "", "memory limit (e.g. 512m, 1.5g; 0 = unlimited)")
+	cmd.Flags().Float64Var(&cpus, "cpus", 0, "CPU limit (e.g. 1.5; 0 = unlimited)")
+	cmd.Flags().StringVar(&restart, "restart", "", "restart policy: no, always, unless-stopped, on-failure")
+	cmd.Flags().IntVar(&maxRetries, "max-retries", 0, "maximum retries (only with --restart on-failure)")
+	return cmd
+}

--- a/server/internal/cli/root.go
+++ b/server/internal/cli/root.go
@@ -1,0 +1,126 @@
+// Package cli implements the logdeck command-line client. It talks to a
+// running LogDeck server over its HTTP API and is designed to be
+// non-interactive, scriptable, and machine-readable (see the -o json flag).
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+type app struct {
+	url    string
+	token  string
+	output string
+
+	client *client
+
+	// ran flips to true once a command's RunE body starts executing, so
+	// Execute can tell usage errors (exit 2) from runtime errors (exit 1).
+	ran bool
+}
+
+func (a *app) jsonOutput() bool { return a.output == "json" }
+
+// run wraps a RunE body, marking that command execution started.
+func (a *app) run(fn func(cmd *cobra.Command, args []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		a.ran = true
+		return fn(cmd, args)
+	}
+}
+
+// printJSON writes a single indented JSON document to stdout.
+func (a *app) printJSON(v any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(v)
+}
+
+func (a *app) printError(err error) {
+	if a.jsonOutput() {
+		payload, _ := json.Marshal(map[string]string{"error": err.Error()})
+		fmt.Fprintln(os.Stderr, string(payload))
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+}
+
+// Execute runs the CLI and returns the process exit code:
+// 0 success, 1 runtime error, 2 usage error.
+func Execute() int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	a := &app{}
+	root := newRootCmd(a)
+	err := root.ExecuteContext(ctx)
+	if err == nil {
+		return 0
+	}
+	if !a.ran {
+		fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+		fmt.Fprintln(os.Stderr, "Run 'logdeck --help' for usage.")
+		return 2
+	}
+	a.printError(err)
+	return 1
+}
+
+func envOr(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func newRootCmd(a *app) *cobra.Command {
+	root := &cobra.Command{
+		Use:           "logdeck",
+		Short:         "Command-line client for a running LogDeck server",
+		Long:          "logdeck talks to a running LogDeck server over its HTTP API.\nIt is non-interactive and scriptable; use -o json for machine-readable output.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if a.output != "table" && a.output != "json" {
+				return fmt.Errorf("invalid output format %q (must be table or json)", a.output)
+			}
+			a.client = newClient(strings.TrimRight(a.url, "/"), a.token)
+			return nil
+		},
+	}
+
+	root.PersistentFlags().StringVar(&a.url, "url", envOr("LOGDECK_URL", "http://localhost:8080"), "LogDeck server URL (env: LOGDECK_URL)")
+	root.PersistentFlags().StringVar(&a.token, "token", os.Getenv("LOGDECK_TOKEN"), "API token sent as a Bearer token (env: LOGDECK_TOKEN)")
+	root.PersistentFlags().StringVarP(&a.output, "output", "o", "table", "output format: table or json")
+
+	root.AddCommand(
+		newStatusCmd(a),
+		newContainersCmd(a),
+		newStacksCmd(a),
+		newInspectCmd(a),
+		newLogsCmd(a),
+		newGrepCmd(a),
+		newStatsCmd(a),
+		newEventsCmd(a),
+		newActionCmd(a, "start", "start", "started"),
+		newActionCmd(a, "stop", "stop", "stopped"),
+		newActionCmd(a, "restart", "restart", "restarted"),
+		newActionCmd(a, "rm", "remove", "removed"),
+		newStackCmd(a),
+		newEnvCmd(a),
+		newResourcesCmd(a),
+		newImagesCmd(a),
+		newVolumesCmd(a),
+		newNetworksCmd(a),
+	)
+
+	return root
+}

--- a/server/internal/cli/root.go
+++ b/server/internal/cli/root.go
@@ -57,12 +57,13 @@ func (a *app) printError(err error) {
 
 // Execute runs the CLI and returns the process exit code:
 // 0 success, 1 runtime error, 2 usage error.
-func Execute() int {
+func Execute(version string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	a := &app{}
 	root := newRootCmd(a)
+	root.Version = version
 	err := root.ExecuteContext(ctx)
 	if err == nil {
 		return 0

--- a/server/internal/cli/root.go
+++ b/server/internal/cli/root.go
@@ -16,11 +16,13 @@ import (
 )
 
 type app struct {
-	url    string
-	token  string
-	output string
+	url         string
+	token       string
+	output      string
+	contextName string
 
 	client *client
+	conn   connection
 
 	// ran flips to true once a command's RunE body starts executing, so
 	// Execute can tell usage errors (exit 2) from runtime errors (exit 1).
@@ -74,35 +76,59 @@ func Execute() int {
 	return 1
 }
 
-func envOr(key, fallback string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return fallback
-}
+const rootLong = `logdeck talks to a running LogDeck server over its HTTP API.
+It is non-interactive and scriptable; use -o json for machine-readable output.
+
+Connect once with "logdeck login" to save the server as a context in
+~/.config/logdeck/config.json. Connection settings resolve in this order:
+explicit --url/--token flags > LOGDECK_URL/LOGDECK_TOKEN env vars > the
+active context (--context selects another saved one) > http://localhost:8080.`
 
 func newRootCmd(a *app) *cobra.Command {
 	root := &cobra.Command{
 		Use:           "logdeck",
 		Short:         "Command-line client for a running LogDeck server",
-		Long:          "logdeck talks to a running LogDeck server over its HTTP API.\nIt is non-interactive and scriptable; use -o json for machine-readable output.",
+		Long:          rootLong,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if a.output != "table" && a.output != "json" {
 				return fmt.Errorf("invalid output format %q (must be table or json)", a.output)
 			}
-			a.client = newClient(strings.TrimRight(a.url, "/"), a.token)
+
+			path, err := configPath()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadConfig(path)
+			if err != nil {
+				return err
+			}
+			conn, err := resolveConnection(
+				a.url, cmd.Flags().Changed("url"),
+				a.token, cmd.Flags().Changed("token"),
+				os.Getenv("LOGDECK_URL"), os.Getenv("LOGDECK_TOKEN"),
+				cfg, a.contextName,
+			)
+			if err != nil {
+				return err
+			}
+			a.conn = conn
+			a.client = newClient(strings.TrimRight(conn.url, "/"), conn.token)
 			return nil
 		},
 	}
 
-	root.PersistentFlags().StringVar(&a.url, "url", envOr("LOGDECK_URL", "http://localhost:8080"), "LogDeck server URL (env: LOGDECK_URL)")
-	root.PersistentFlags().StringVar(&a.token, "token", os.Getenv("LOGDECK_TOKEN"), "API token sent as a Bearer token (env: LOGDECK_TOKEN)")
+	root.PersistentFlags().StringVar(&a.url, "url", "", "LogDeck server URL (overrides LOGDECK_URL and the active context; default http://localhost:8080)")
+	root.PersistentFlags().StringVar(&a.token, "token", "", "API token sent as a Bearer token (overrides LOGDECK_TOKEN and the active context)")
+	root.PersistentFlags().StringVar(&a.contextName, "context", "", "use this saved context instead of the current one for this invocation")
 	root.PersistentFlags().StringVarP(&a.output, "output", "o", "table", "output format: table or json")
 
 	root.AddCommand(
 		newStatusCmd(a),
+		newLoginCmd(a),
+		newLogoutCmd(a),
+		newContextCmd(a),
 		newContainersCmd(a),
 		newStacksCmd(a),
 		newInspectCmd(a),

--- a/server/internal/cli/stacks.go
+++ b/server/internal/cli/stacks.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// composeProjectLabels mirrors the server's grouping: docker compose sets the
+// com.docker.compose one, older podman-compose releases only the io.podman one.
+var composeProjectLabels = []string{
+	"com.docker.compose.project",
+	"io.podman.compose.project",
+}
+
+// composeProject returns the compose project a container belongs to, or "".
+func composeProject(labels map[string]string) string {
+	for _, key := range composeProjectLabels {
+		if value := labels[key]; value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+type stackSummary struct {
+	Project    string   `json:"project"`
+	Containers int      `json:"containers"`
+	Running    int      `json:"running"`
+	Hosts      []string `json:"hosts"`
+}
+
+// groupStacks groups containers by compose project label, client-side.
+func groupStacks(containers []containerInfo) []stackSummary {
+	byProject := map[string]*stackSummary{}
+	hostsSeen := map[string]map[string]bool{}
+
+	for _, c := range containers {
+		project := composeProject(c.Labels)
+		if project == "" {
+			continue
+		}
+		summary, ok := byProject[project]
+		if !ok {
+			summary = &stackSummary{Project: project}
+			byProject[project] = summary
+			hostsSeen[project] = map[string]bool{}
+		}
+		summary.Containers++
+		if c.State == "running" {
+			summary.Running++
+		}
+		if c.Host != "" && !hostsSeen[project][c.Host] {
+			hostsSeen[project][c.Host] = true
+			summary.Hosts = append(summary.Hosts, c.Host)
+		}
+	}
+
+	stacks := make([]stackSummary, 0, len(byProject))
+	for _, summary := range byProject {
+		sort.Strings(summary.Hosts)
+		stacks = append(stacks, *summary)
+	}
+	sort.Slice(stacks, func(i, j int) bool { return stacks[i].Project < stacks[j].Project })
+	return stacks
+}
+
+func newStacksCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stacks",
+		Short: "List compose projects with container counts and hosts",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			resp, err := a.fetchContainers(cmd.Context())
+			if err != nil {
+				return err
+			}
+			stacks := groupStacks(resp.Containers)
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]any{"stacks": stacks})
+			}
+
+			rows := make([][]string, 0, len(stacks))
+			for _, s := range stacks {
+				rows = append(rows, []string{
+					s.Project,
+					strconv.Itoa(s.Containers),
+					strconv.Itoa(s.Running),
+					strings.Join(s.Hosts, ","),
+				})
+			}
+			renderTable(os.Stdout, []string{"PROJECT", "CONTAINERS", "RUNNING", "HOSTS"}, rows)
+			return nil
+		}),
+	}
+}

--- a/server/internal/cli/stacks_test.go
+++ b/server/internal/cli/stacks_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGroupStacks(t *testing.T) {
+	containers := []containerInfo{
+		{ID: "1", Host: "prod", State: "running", Labels: map[string]string{"com.docker.compose.project": "web"}},
+		{ID: "2", Host: "prod", State: "exited", Labels: map[string]string{"com.docker.compose.project": "web"}},
+		{ID: "3", Host: "staging", State: "running", Labels: map[string]string{"io.podman.compose.project": "web"}},
+		{ID: "4", Host: "prod", State: "running", Labels: map[string]string{"com.docker.compose.project": "api"}},
+		{ID: "5", Host: "prod", State: "running"}, // no project label: excluded
+	}
+
+	stacks := groupStacks(containers)
+	if len(stacks) != 2 {
+		t.Fatalf("expected 2 stacks, got %d: %+v", len(stacks), stacks)
+	}
+
+	// Sorted by project name.
+	api, web := stacks[0], stacks[1]
+	if api.Project != "api" || api.Containers != 1 || api.Running != 1 {
+		t.Errorf("unexpected api stack: %+v", api)
+	}
+	if web.Project != "web" || web.Containers != 3 || web.Running != 2 {
+		t.Errorf("unexpected web stack: %+v", web)
+	}
+	if !reflect.DeepEqual(web.Hosts, []string{"prod", "staging"}) {
+		t.Errorf("unexpected web hosts: %v", web.Hosts)
+	}
+}
+
+func TestComposeProject(t *testing.T) {
+	if got := composeProject(map[string]string{"com.docker.compose.project": "a"}); got != "a" {
+		t.Errorf("docker label: got %q", got)
+	}
+	if got := composeProject(map[string]string{"io.podman.compose.project": "b"}); got != "b" {
+		t.Errorf("podman label: got %q", got)
+	}
+	if got := composeProject(nil); got != "" {
+		t.Errorf("nil labels: got %q", got)
+	}
+}
+
+func TestBuildTargets(t *testing.T) {
+	targets := buildTargets([]containerInfo{
+		{ID: "abc", Names: []string{"/web"}, Host: "prod"},
+	})
+	if len(targets) != 1 || targets[0] != "prod~abc~web" {
+		t.Errorf("unexpected targets: %v", targets)
+	}
+}

--- a/server/internal/cli/stats.go
+++ b/server/internal/cli/stats.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newStatsCmd(a *app) *cobra.Command {
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "stats [<name|id>]",
+		Short: "Show CPU and memory usage for running containers",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			containers, err := a.fetchContainers(ctx)
+			if err != nil {
+				return err
+			}
+
+			var statsResp struct {
+				Stats []containerStats `json:"stats"`
+			}
+			if err := a.client.get(ctx, "/containers/stats", nil, &statsResp); err != nil {
+				return err
+			}
+
+			names := map[string]string{}
+			for _, c := range containers.Containers {
+				names[c.Host+"/"+c.ID] = containerName(c)
+			}
+
+			stats := statsResp.Stats
+			if len(args) == 1 {
+				container, err := resolveContainer(containers.Containers, args[0], host)
+				if err != nil {
+					return err
+				}
+				stats = nil
+				for _, s := range statsResp.Stats {
+					if s.ID == container.ID && s.Host == container.Host {
+						stats = append(stats, s)
+					}
+				}
+				if len(stats) == 0 {
+					return fmt.Errorf("no stats for container %q (is it running?)", containerName(container))
+				}
+			}
+
+			if a.jsonOutput() {
+				if stats == nil {
+					stats = []containerStats{}
+				}
+				return a.printJSON(map[string]any{"stats": stats})
+			}
+
+			rows := make([][]string, 0, len(stats))
+			for _, s := range stats {
+				name := names[s.Host+"/"+s.ID]
+				if name == "" {
+					name = shortID(s.ID)
+				}
+				rows = append(rows, []string{
+					name,
+					s.Host,
+					fmt.Sprintf("%.1f%%", s.CPUPercent),
+					fmt.Sprintf("%.1f%%", s.MemoryPercent),
+					humanBytes(s.MemoryUsed),
+					humanBytes(s.MemoryLimit),
+				})
+			}
+			renderTable(os.Stdout, []string{"NAME", "HOST", "CPU%", "MEM%", "MEM USED", "MEM LIMIT"}, rows)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "host name (disambiguates duplicate container names)")
+	return cmd
+}

--- a/server/internal/cli/status.go
+++ b/server/internal/cli/status.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func newStatusCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show server health, version, and per-host summary",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			var health struct {
+				Status string `json:"status"`
+			}
+			if err := a.client.get(ctx, "/healthz", nil, &health); err != nil {
+				return err
+			}
+
+			var version struct {
+				Version string `json:"version"`
+			}
+			if err := a.client.get(ctx, "/version", nil, &version); err != nil {
+				return err
+			}
+
+			var hosts struct {
+				Hosts []hostInfo `json:"hosts"`
+			}
+			if err := a.client.get(ctx, "/hosts/stats", nil, &hosts); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]any{
+					"url":     a.client.baseURL,
+					"status":  health.Status,
+					"version": version.Version,
+					"hosts":   hosts.Hosts,
+				})
+			}
+
+			fmt.Printf("Server:  %s\n", a.client.baseURL)
+			fmt.Printf("Status:  %s\n", health.Status)
+			fmt.Printf("Version: %s\n\n", version.Version)
+
+			rows := make([][]string, 0, len(hosts.Hosts))
+			for _, h := range hosts.Hosts {
+				name := h.Name
+				if name == "" {
+					name = h.Host
+				}
+				if !h.Available {
+					rows = append(rows, []string{name, "no", "-", "-", "-", "-", h.Error})
+					continue
+				}
+				rows = append(rows, []string{
+					name,
+					"yes",
+					fmt.Sprintf("%d up / %d down", h.ContainersRunning, h.ContainersStopped),
+					strconv.Itoa(h.NCPU),
+					humanBytes(uint64(h.MemTotal)),
+					h.ServerVersion,
+					"",
+				})
+			}
+			renderTable(os.Stdout, []string{"HOST", "AVAILABLE", "CONTAINERS", "CPUS", "MEMORY", "ENGINE", "ERROR"}, rows)
+			return nil
+		}),
+	}
+}

--- a/server/internal/cli/status.go
+++ b/server/internal/cli/status.go
@@ -39,14 +39,24 @@ func newStatusCmd(a *app) *cobra.Command {
 
 			if a.jsonOutput() {
 				return a.printJSON(map[string]any{
-					"url":     a.client.baseURL,
-					"status":  health.Status,
-					"version": version.Version,
-					"hosts":   hosts.Hosts,
+					"url":         a.client.baseURL,
+					"urlSource":   a.conn.urlSource,
+					"tokenSource": a.conn.tokenSource,
+					"status":      health.Status,
+					"version":     version.Version,
+					"hosts":       hosts.Hosts,
 				})
 			}
 
+			source := "url from " + a.conn.urlSource
+			if a.conn.tokenSource == "none" {
+				source += ", no token"
+			} else {
+				source += ", token from " + a.conn.tokenSource
+			}
+
 			fmt.Printf("Server:  %s\n", a.client.baseURL)
+			fmt.Printf("Source:  %s\n", source)
 			fmt.Printf("Status:  %s\n", health.Status)
 			fmt.Printf("Version: %s\n\n", version.Version)
 

--- a/server/internal/cli/table.go
+++ b/server/internal/cli/table.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+// renderTable writes compact aligned columns using text/tabwriter.
+func renderTable(w io.Writer, headers []string, rows [][]string) {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, strings.Join(headers, "\t"))
+	for _, row := range rows {
+		fmt.Fprintln(tw, strings.Join(row, "\t"))
+	}
+	tw.Flush()
+}
+
+func shortID(id string) string {
+	id = strings.TrimPrefix(id, "sha256:")
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}
+
+// humanBytes renders a byte count with binary units (matching the units
+// parseMemory accepts).
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	value := float64(n)
+	suffixes := []string{"KiB", "MiB", "GiB", "TiB", "PiB"}
+	for _, suffix := range suffixes {
+		value /= unit
+		if value < unit || suffix == suffixes[len(suffixes)-1] {
+			return fmt.Sprintf("%.1f%s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%.1f%s", value, suffixes[len(suffixes)-1])
+}
+
+// humanAge renders how long ago a time was, coarsely ("3d ago", "5m ago").
+func humanAge(t time.Time, now time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+// formatLogTimestamp renders an entry timestamp in RFC3339, or "-" when the
+// parser could not extract one.
+func formatLogTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Format(time.RFC3339)
+}
+
+// formatLogLine renders one parsed log entry for table output. Multi-line
+// messages (grouped continuations) keep their newlines.
+func formatLogLine(e logEntry, withName bool) string {
+	if withName && e.ContainerName != "" {
+		return fmt.Sprintf("%s %-7s [%s] %s", formatLogTimestamp(e.Timestamp), e.Level, e.ContainerName, e.Message)
+	}
+	return fmt.Sprintf("%s %-7s %s", formatLogTimestamp(e.Timestamp), e.Level, e.Message)
+}

--- a/server/internal/cli/types.go
+++ b/server/internal/cli/types.go
@@ -1,0 +1,137 @@
+package cli
+
+import "time"
+
+// API response shapes. Field names mirror the server's JSON exactly
+// (see server/internal/models and server/internal/api).
+
+type containerInfo struct {
+	ID      string            `json:"id"`
+	Names   []string          `json:"names"`
+	Image   string            `json:"image"`
+	Command string            `json:"command"`
+	Created int64             `json:"created"`
+	State   string            `json:"state"`
+	Status  string            `json:"status"`
+	Labels  map[string]string `json:"labels,omitempty"`
+	Host    string            `json:"host"`
+}
+
+type dockerHost struct {
+	Name string `json:"name"`
+	Host string `json:"host"`
+}
+
+type hostError struct {
+	Host    string `json:"host"`
+	Message string `json:"message"`
+}
+
+type containersResponse struct {
+	Containers []containerInfo `json:"containers"`
+	Hosts      []dockerHost    `json:"hosts"`
+	HostErrors []hostError     `json:"hostErrors"`
+	ReadOnly   bool            `json:"readOnly"`
+}
+
+type containerStats struct {
+	ID            string  `json:"id"`
+	Host          string  `json:"host"`
+	CPUPercent    float64 `json:"cpu_percent"`
+	MemoryPercent float64 `json:"memory_percent"`
+	MemoryUsed    uint64  `json:"memory_used"`
+	MemoryLimit   uint64  `json:"memory_limit"`
+}
+
+type hostInfo struct {
+	Host              string `json:"host"`
+	Available         bool   `json:"available"`
+	Error             string `json:"error,omitempty"`
+	Name              string `json:"name,omitempty"`
+	OperatingSystem   string `json:"operating_system,omitempty"`
+	Architecture      string `json:"architecture,omitempty"`
+	ServerVersion     string `json:"server_version,omitempty"`
+	NCPU              int    `json:"ncpu"`
+	MemTotal          int64  `json:"mem_total"`
+	ContainersRunning int    `json:"containers_running"`
+	ContainersPaused  int    `json:"containers_paused"`
+	ContainersStopped int    `json:"containers_stopped"`
+	Images            int    `json:"images"`
+}
+
+type logEntry struct {
+	Timestamp         time.Time         `json:"timestamp"`
+	Level             string            `json:"level"`
+	Message           string            `json:"message"`
+	Stream            string            `json:"stream"`
+	Raw               string            `json:"raw"`
+	Fields            map[string]string `json:"fields,omitempty"`
+	ContinuationCount int               `json:"continuationCount,omitempty"`
+	ContainerID       string            `json:"containerId,omitempty"`
+	ContainerName     string            `json:"containerName,omitempty"`
+}
+
+type containerEvent struct {
+	Host          string `json:"host"`
+	ContainerID   string `json:"containerId"`
+	ContainerName string `json:"containerName"`
+	Action        string `json:"action"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+type imageInfo struct {
+	ID       string   `json:"id"`
+	RepoTags []string `json:"repo_tags"`
+	Size     int64    `json:"size"`
+	Created  int64    `json:"created"`
+	Host     string   `json:"host"`
+}
+
+type volumeInfo struct {
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	Mountpoint string            `json:"mountpoint"`
+	Created    string            `json:"created"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	Host       string            `json:"host"`
+}
+
+type networkInfo struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Driver  string   `json:"driver"`
+	Scope   string   `json:"scope"`
+	Subnets []string `json:"subnets,omitempty"`
+	Host    string   `json:"host"`
+}
+
+type restartPolicySpec struct {
+	Name              string `json:"name"`
+	MaximumRetryCount int    `json:"maximumRetryCount"`
+}
+
+type containerResources struct {
+	MemoryBytes   int64             `json:"memoryBytes"`
+	NanoCPUs      int64             `json:"nanoCPUs"`
+	RestartPolicy restartPolicySpec `json:"restartPolicy"`
+}
+
+type updateResourcesRequest struct {
+	MemoryBytes   *int64             `json:"memoryBytes,omitempty"`
+	NanoCPUs      *int64             `json:"nanoCPUs,omitempty"`
+	RestartPolicy *restartPolicySpec `json:"restartPolicy,omitempty"`
+}
+
+type composeFailure struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+type composeResult struct {
+	Project   string           `json:"project"`
+	Host      string           `json:"host"`
+	Total     int              `json:"total"`
+	Succeeded int              `json:"succeeded"`
+	Failed    []composeFailure `json:"failed"`
+}


### PR DESCRIPTION
The official `logdeck` CLI, built from scratch on top of the server's HTTP API — designed for AI agents and scripting: fully non-interactive, machine-readable, remote-first. Pairs with API tokens (#82).

## Commands
`status`, `containers`, `stacks`, `inspect`, `logs` (single container or `--stack`, with tail/level/search/since/until/follow), `grep` (search every running container's recent logs across all hosts, merged by timestamp — the debugging workhorse), `stats`, `events`, `start/stop/restart/rm`, `stack start|stop|restart`, `env`, `resources` + `resources set`, `images/volumes/networks`.

## The contract that makes it agent-friendly
- `-o json`: single JSON document for one-shot commands, NDJSON for streams; errors to stderr as `{"error":...}`; exit codes 0/1/2.
- Relative durations (`15m`, `2h`) for since/until; container resolution by exact name or id prefix with explicit ambiguity errors; the required `?host=` is supplied automatically.
- Aggregate requests batched past the server's 20-target limit and merged by timestamp; heartbeats skipped.

## Seamless remote access
`logdeck login --url <remote> --token ldk_... --name prod` verifies the connection and saves a kubectl-style context to `~/.config/logdeck/config.json` (0600). `context list/use/rm`, `logout`, one-shot `--context`. Precedence: flags > env > active context > localhost. `status` reports where its settings came from.

## Release story
- `release.yml`: on `v*` tags, builds darwin/linux amd64/arm64 tarballs with stamped `--version`, checksums, and publishes a GitHub Release with generated notes (the existing Docker publish fires on the same tags).
- `install.sh`: `curl -fsSL https://raw.githubusercontent.com/AmoabaKelvin/logdeck/main/install.sh | sh` — unversioned asset names keep latest/download URLs stable.
- `docs/cli.md` guide (install, connection, every command, an "Using with AI agents" section) + Readme section.

## Verification
- 30 unit tests (parsing, resolution, batching, merge, config roundtrip incl. permissions, precedence matrix) plus httptest-backed client tests; full module suite green.
- Dogfooded live against Podman: complete token flow (401 hint → token works → mutation → instant revoke), `grep` finding cross-container failures, NDJSON event stream of a real restart, login/context flow on a real machine, version stamping via ldflags.

First release after merge: `git tag v0.1.0 && git push origin v0.1.0`.

https://claude.ai/code/session_01EvF9bkDSJmToESrttC3TrV