### PR TITLE
feat: scoped read-only API tokens

### DIFF
--- a/docs/app/docs/cli/page.tsx
+++ b/docs/app/docs/cli/page.tsx
@@ -205,10 +205,11 @@ logdeck status        # now talks to prod`}
           <strong>Settings → API Tokens</strong> and sent as{" "}
           <code>Authorization: Bearer &lt;token&gt;</code>. Tokens have a
           scope: <strong>admin</strong> tokens have full access, while{" "}
-          <strong>read-only</strong> tokens can read logs, stats, and container
-          details but cannot start, stop, or modify anything — useful for CI
-          jobs or AI agents that only need to read. When the server has
-          authentication disabled, no token is needed.
+          <strong>read-only</strong> tokens can read logs, stats, container
+          details, and events but cannot mutate anything, use the web
+          terminal, or read container environment variables or settings —
+          useful for CI jobs or AI agents that only need to read. When the
+          server has authentication disabled, no token is needed.
         </p>
 
         <h3 className="mb-3 mt-8 text-xl font-semibold">Resolution order</h3>

--- a/docs/app/docs/cli/page.tsx
+++ b/docs/app/docs/cli/page.tsx
@@ -203,7 +203,11 @@ logdeck status        # now talks to prod`}
         <p className="mb-4 text-base">
           API tokens are created in the LogDeck web UI under{" "}
           <strong>Settings → API Tokens</strong> and sent as{" "}
-          <code>Authorization: Bearer &lt;token&gt;</code>. When the server has
+          <code>Authorization: Bearer &lt;token&gt;</code>. Tokens have a
+          scope: <strong>admin</strong> tokens have full access, while{" "}
+          <strong>read-only</strong> tokens can read logs, stats, and container
+          details but cannot start, stop, or modify anything — useful for CI
+          jobs or AI agents that only need to read. When the server has
           authentication disabled, no token is needed.
         </p>
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -207,5 +207,6 @@ API tokens give the CLI and external tools their own credentials, so the admin l
 
 - Create and revoke tokens under Settings -> API Tokens.
 - Tokens are prefixed `ldk_` and shown in full only once, at creation.
+- Each token has a scope: `admin` (full access) or `read` (read-only: logs, stats, and container details, but no start/stop/restart, no edits, and no web terminal).
 - Requests authenticate with an `Authorization: Bearer <token>` header.
 - Tokens only matter when authentication is enabled; on an open instance the API is reachable without them.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -207,6 +207,6 @@ API tokens give the CLI and external tools their own credentials, so the admin l
 
 - Create and revoke tokens under Settings -> API Tokens.
 - Tokens are prefixed `ldk_` and shown in full only once, at creation.
-- Each token has a scope: `admin` (full access) or `read` (read-only: logs, stats, and container details, but no start/stop/restart, no edits, and no web terminal).
+- Each token has a scope: `admin` (full access) or `read` (read-only: logs, stats, container details, and events, but no mutations, no web terminal, and no access to container environment variables or settings).
 - Requests authenticate with an `Authorization: Bearer <token>` header.
 - Tokens only matter when authentication is enabled; on an open instance the API is reachable without them.

--- a/frontend/src/features/settings/api/create-api-token.ts
+++ b/frontend/src/features/settings/api/create-api-token.ts
@@ -1,15 +1,18 @@
 import { authenticatedFetch } from "@/lib/api-client";
 import { API_BASE_URL } from "@/types/api";
 
-import type { CreatedAPIToken } from "../types";
+import type { APITokenScope, CreatedAPIToken } from "../types";
 
 const ENDPOINT = `${API_BASE_URL}/api/v1/settings/api-tokens`;
 
-export async function createApiToken(name: string): Promise<CreatedAPIToken> {
+export async function createApiToken(
+	name: string,
+	scope: APITokenScope,
+): Promise<CreatedAPIToken> {
 	const response = await authenticatedFetch(ENDPOINT, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ name }),
+		body: JSON.stringify({ name, scope }),
 	});
 
 	if (!response.ok) {

--- a/frontend/src/features/settings/components/api-tokens-section.tsx
+++ b/frontend/src/features/settings/components/api-tokens-section.tsx
@@ -12,6 +12,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -22,6 +23,13 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import {
 	Table,
@@ -37,7 +45,7 @@ import {
 	useCreateApiToken,
 	useDeleteApiToken,
 } from "../hooks/use-settings";
-import type { APIToken, CreatedAPIToken } from "../types";
+import type { APIToken, APITokenScope, CreatedAPIToken } from "../types";
 import { showResultToast } from "./mutation-toast";
 
 export function ApiTokensSection() {
@@ -47,6 +55,7 @@ export function ApiTokensSection() {
 
 	const [isCreating, setIsCreating] = useState(false);
 	const [newName, setNewName] = useState("");
+	const [newScope, setNewScope] = useState<APITokenScope>("admin");
 	const [createdToken, setCreatedToken] = useState<CreatedAPIToken | null>(
 		null,
 	);
@@ -61,16 +70,20 @@ export function ApiTokensSection() {
 			toast.error("Token name is required");
 			return;
 		}
-		createMutation.mutate(name, {
-			onSuccess: (token) => {
-				toast.success(`Token "${token.name}" created`);
-				setCreatedToken(token);
-				setCopied(false);
-				setNewName("");
-				setIsCreating(false);
+		createMutation.mutate(
+			{ name, scope: newScope },
+			{
+				onSuccess: (token) => {
+					toast.success(`Token "${token.name}" created`);
+					setCreatedToken(token);
+					setCopied(false);
+					setNewName("");
+					setNewScope("admin");
+					setIsCreating(false);
+				},
+				onError: (err) => toast.error(err.message),
 			},
-			onError: (err) => toast.error(err.message),
-		});
+		);
 	}
 
 	function handleCopy() {
@@ -154,6 +167,7 @@ export function ApiTokensSection() {
 							<TableRow>
 								<TableHead>Name</TableHead>
 								<TableHead>Token</TableHead>
+								<TableHead>Scope</TableHead>
 								<TableHead>Created</TableHead>
 								<TableHead className="text-right">Actions</TableHead>
 							</TableRow>
@@ -164,6 +178,11 @@ export function ApiTokensSection() {
 									<TableCell className="font-medium">{t.name}</TableCell>
 									<TableCell className="font-mono text-xs text-muted-foreground">
 										{t.prefix}…
+									</TableCell>
+									<TableCell>
+										<Badge variant="secondary" className="text-xs font-normal">
+											{t.scope === "read" ? "Read-only" : "Admin"}
+										</Badge>
 									</TableCell>
 									<TableCell className="text-xs text-muted-foreground">
 										{new Date(t.createdAt).toLocaleDateString()}
@@ -200,6 +219,21 @@ export function ApiTokensSection() {
 								className="h-8"
 								maxLength={64}
 							/>
+						</div>
+						<div className="space-y-1.5">
+							<Label htmlFor="new-token-scope">Scope</Label>
+							<Select
+								value={newScope}
+								onValueChange={(value) => setNewScope(value as APITokenScope)}
+							>
+								<SelectTrigger id="new-token-scope" className="h-8 w-32">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="admin">Admin</SelectItem>
+									<SelectItem value="read">Read-only</SelectItem>
+								</SelectContent>
+							</Select>
 						</div>
 						<div className="flex gap-1">
 							<Button

--- a/frontend/src/features/settings/components/api-tokens-section.tsx
+++ b/frontend/src/features/settings/components/api-tokens-section.tsx
@@ -256,6 +256,7 @@ export function ApiTokensSection() {
 								onClick={() => {
 									setIsCreating(false);
 									setNewName("");
+									setNewScope("admin");
 								}}
 							>
 								Cancel

--- a/frontend/src/features/settings/hooks/use-settings.ts
+++ b/frontend/src/features/settings/hooks/use-settings.ts
@@ -10,6 +10,7 @@ import { type UpdateAuthPayload, updateAuth } from "../api/update-auth";
 import { updateCoolifyHosts } from "../api/update-coolify-hosts";
 import { updateDockerHosts } from "../api/update-docker-hosts";
 import { updateReadOnly } from "../api/update-read-only";
+import type { APITokenScope } from "../types";
 
 const SETTINGS_KEY = ["settings"] as const;
 const API_TOKENS_KEY = ["settings", "api-tokens"] as const;
@@ -76,7 +77,8 @@ export function useApiTokens() {
 export function useCreateApiToken() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: (name: string) => createApiToken(name),
+		mutationFn: ({ name, scope }: { name: string; scope: APITokenScope }) =>
+			createApiToken(name, scope),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: API_TOKENS_KEY });
 		},

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -41,10 +41,13 @@ export interface SettingsResponse {
 	auth: AuthConfig;
 }
 
+export type APITokenScope = "admin" | "read";
+
 export interface APIToken {
 	name: string;
 	prefix: string;
 	createdAt: string;
+	scope: APITokenScope;
 }
 
 export interface APITokensResponse {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -112,7 +112,8 @@ func (ar *APIRouter) registerContainerRoutes(r chi.Router) {
 		// Read-only routes (always available)
 		r.Get("/", ar.GetContainer)
 		r.Get("/logs/parsed", ar.GetContainerLogsParsed)
-		r.Get("/env", ar.GetEnvVariables)
+		// Env vars expose secrets, so read-scoped tokens are denied
+		r.With(auth.DenyReadScope).Get("/env", ar.GetEnvVariables)
 		r.Get("/resources", ar.GetContainerResources)
 
 		// Mutating routes (blocked in read-only mode)
@@ -126,7 +127,9 @@ func (ar *APIRouter) registerContainerRoutes(r chi.Router) {
 			mutating.Post("/remove", ar.RemoveContainer)
 			mutating.Put("/env", ar.UpdateEnvVariables)
 			mutating.Put("/resources", ar.UpdateContainerResources)
-			mutating.Get("/exec", ar.HandleTerminal)
+			// Exec is GET (websocket upgrade) but spawns a shell, so
+			// read-scoped tokens are denied explicitly
+			mutating.With(auth.DenyReadScope).Get("/exec", ar.HandleTerminal)
 		})
 	})
 }
@@ -135,6 +138,9 @@ func (ar *APIRouter) registerSettingsRoutes(r chi.Router) {
 	r.Route("/settings", func(r chi.Router) {
 		// Settings follow the same auth pattern — protected when auth is enabled
 		r.Use(auth.DynamicMiddleware(ar.registry.Auth, ar.lookupAPIToken))
+		// Settings expose host topology and token inventory, so read-scoped
+		// tokens are denied for the whole group
+		r.Use(auth.DenyReadScope)
 
 		r.Get("/", ar.GetSettings)
 		r.Put("/docker-hosts", ar.UpdateDockerHosts)

--- a/server/internal/api/settings_apitokens.go
+++ b/server/internal/api/settings_apitokens.go
@@ -29,19 +29,21 @@ var (
 // the current file config. It reads through the config manager on every call
 // so it stays correct across hot-swapped config updates. Comparison is
 // constant-time over the SHA256 hashes.
-func (ar *APIRouter) lookupAPIToken(token string) (string, bool) {
+func (ar *APIRouter) lookupAPIToken(token string) (string, string, bool) {
 	hash := auth.HashAPIToken(token)
 	fc := ar.manager.FileConfigSnapshot()
 
 	name := ""
+	scope := ""
 	found := false
 	for _, t := range fc.APITokens {
 		if subtle.ConstantTimeCompare([]byte(hash), []byte(t.Hash)) == 1 {
 			name = t.Name
+			scope = t.Scope
 			found = true
 		}
 	}
-	return name, found
+	return name, scope, found
 }
 
 // ListAPITokens handles GET /api/v1/settings/api-tokens.
@@ -53,6 +55,7 @@ func (ar *APIRouter) ListAPITokens(w http.ResponseWriter, r *http.Request) {
 			"name":      t.Name,
 			"prefix":    t.Prefix,
 			"createdAt": t.CreatedAt,
+			"scope":     auth.NormalizeAPITokenScope(t.Scope),
 		})
 	}
 	WriteJsonResponse(w, http.StatusOK, map[string]any{"tokens": tokens})
@@ -62,7 +65,8 @@ func (ar *APIRouter) ListAPITokens(w http.ResponseWriter, r *http.Request) {
 // returned exactly once; only its hash is stored.
 func (ar *APIRouter) CreateAPIToken(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name string `json:"name"`
+		Name  string `json:"name"`
+		Scope string `json:"scope"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -76,6 +80,15 @@ func (ar *APIRouter) CreateAPIToken(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(name) > maxAPITokenNameLen {
 		http.Error(w, fmt.Sprintf("name must be at most %d characters", maxAPITokenNameLen), http.StatusBadRequest)
+		return
+	}
+
+	scope := req.Scope
+	if scope == "" {
+		scope = auth.APITokenScopeAdmin
+	}
+	if scope != auth.APITokenScopeAdmin && scope != auth.APITokenScopeRead {
+		http.Error(w, `scope must be "admin" or "read"`, http.StatusBadRequest)
 		return
 	}
 
@@ -100,6 +113,7 @@ func (ar *APIRouter) CreateAPIToken(w http.ResponseWriter, r *http.Request) {
 			Hash:      hash,
 			Prefix:    prefix,
 			CreatedAt: createdAt,
+			Scope:     scope,
 		}), nil
 	})
 	if err != nil {
@@ -116,6 +130,7 @@ func (ar *APIRouter) CreateAPIToken(w http.ResponseWriter, r *http.Request) {
 		"name":      name,
 		"prefix":    prefix,
 		"createdAt": createdAt,
+		"scope":     scope,
 	})
 }
 

--- a/server/internal/api/settings_apitokens_test.go
+++ b/server/internal/api/settings_apitokens_test.go
@@ -5,8 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/auth"
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/services"
 )
 
 type createdTokenResponse struct {
@@ -14,6 +20,7 @@ type createdTokenResponse struct {
 	Name      string `json:"name"`
 	Prefix    string `json:"prefix"`
 	CreatedAt string `json:"createdAt"`
+	Scope     string `json:"scope"`
 }
 
 func createToken(t *testing.T, router http.Handler, jwt, name string) createdTokenResponse {
@@ -68,6 +75,9 @@ func TestCreateAndListAPITokens(t *testing.T) {
 	entry := list.Tokens[0]
 	if entry["name"] != "my-cli" || entry["prefix"] != created.Prefix {
 		t.Errorf("unexpected list entry: %v", entry)
+	}
+	if entry["scope"] != "admin" {
+		t.Errorf("expected default scope %q, got %v", "admin", entry["scope"])
 	}
 	if _, hasHash := entry["hash"]; hasHash {
 		t.Error("list response must not include the token hash")
@@ -199,6 +209,155 @@ func TestAPITokenAuthenticatesRequestsWhenAuthEnabled(t *testing.T) {
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 with bogus API token, got %d", w.Code)
+	}
+}
+
+func TestCreateAPITokenScopes(t *testing.T) {
+	router := newTestRouter(t, nil)
+
+	// A read-scoped token is created and listed with its scope.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/settings/api-tokens",
+		strings.NewReader(`{"name":"agent","scope":"read"}`))
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 creating read token, got %d: %s", w.Code, w.Body.String())
+	}
+	var created createdTokenResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to parse create response: %v", err)
+	}
+	if created.Scope != "read" {
+		t.Errorf("expected scope %q in create response, got %q", "read", created.Scope)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/settings/api-tokens", nil)
+	router.ServeHTTP(w, r)
+	var list struct {
+		Tokens []map[string]any `json:"tokens"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatalf("failed to parse list response: %v", err)
+	}
+	if len(list.Tokens) != 1 || list.Tokens[0]["scope"] != "read" {
+		t.Errorf("expected listed token with scope read, got %v", list.Tokens)
+	}
+
+	// An invalid scope is rejected.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/api/v1/settings/api-tokens",
+		strings.NewReader(`{"name":"bad","scope":"superuser"}`))
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid scope, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestReadScopeAPITokenEnforcement(t *testing.T) {
+	svc := newTestAuthService(t)
+	router := newTestRouter(t, svc)
+
+	jwt, err := svc.GenerateToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/settings/api-tokens",
+		strings.NewReader(`{"name":"agent","scope":"read"}`))
+	r.Header.Set("Authorization", "Bearer "+jwt)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 creating read token, got %d: %s", w.Code, w.Body.String())
+	}
+	var created createdTokenResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("failed to parse create response: %v", err)
+	}
+
+	// Read routes are allowed.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/settings/api-tokens", nil)
+	r.Header.Set("Authorization", "Bearer "+created.Token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 on read route with read token, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Mutating routes are denied.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/api/v1/settings/api-tokens",
+		strings.NewReader(`{"name":"another"}`))
+	r.Header.Set("Authorization", "Bearer "+created.Token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 on mutating route with read token, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The exec websocket endpoint is GET but mutating, so it is denied.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/containers/abc123/exec", nil)
+	r.Header.Set("Authorization", "Bearer "+created.Token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 on exec endpoint with read token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLegacyAPITokenWithoutScopeIsAdmin(t *testing.T) {
+	token, hash, prefix, err := auth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken failed: %v", err)
+	}
+
+	// Simulate a config written before scopes existed: no scope field.
+	for _, key := range []string{
+		"JWT_SECRET", "ADMIN_USERNAME", "ADMIN_PASSWORD", "ADMIN_PASSWORD_SALT",
+		"DOCKER_HOSTS", "COOLIFY_CONFIGS", "READONLY_MODE", "CORS_ALLOWED_ORIGINS",
+	} {
+		t.Setenv(key, "")
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	cfg := fmt.Sprintf(
+		`{"apiTokens":[{"name":"legacy","hash":%q,"prefix":%q,"createdAt":"2026-01-01T00:00:00Z"}]}`,
+		hash, prefix)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	t.Setenv("CONFIG_PATH", cfgPath)
+
+	svc := newTestAuthService(t)
+	manager := config.NewManager()
+	registry := services.NewRegistry(nil, nil, svc, manager.Config())
+	router := NewRouter(registry, manager, "test")
+
+	// The legacy token is listed with an admin scope.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/settings/api-tokens", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 listing tokens with legacy token, got %d: %s", w.Code, w.Body.String())
+	}
+	var list struct {
+		Tokens []map[string]any `json:"tokens"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatalf("failed to parse list response: %v", err)
+	}
+	if len(list.Tokens) != 1 || list.Tokens[0]["scope"] != "admin" {
+		t.Errorf("expected legacy token listed with scope admin, got %v", list.Tokens)
+	}
+
+	// The legacy token can still perform mutating operations.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/api/v1/settings/api-tokens",
+		strings.NewReader(`{"name":"created-by-legacy"}`))
+	r.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201 creating token with legacy token, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/api/settings_apitokens_test.go
+++ b/server/internal/api/settings_apitokens_test.go
@@ -276,13 +276,23 @@ func TestReadScopeAPITokenEnforcement(t *testing.T) {
 		t.Fatalf("failed to parse create response: %v", err)
 	}
 
-	// Read routes are allowed.
+	// Plain read routes are allowed.
 	w = httptest.NewRecorder()
-	r = httptest.NewRequest("GET", "/api/v1/settings/api-tokens", nil)
+	r = httptest.NewRequest("GET", "/api/v1/auth/me", nil)
 	r.Header.Set("Authorization", "Bearer "+created.Token)
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 on read route with read token, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// A container that happens to be named "exec" is a plain read: the
+	// request passes auth and fails on the missing host param (400), not 403.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/containers/exec", nil)
+	r.Header.Set("Authorization", "Bearer "+created.Token)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 on container named exec with read token, got %d: %s", w.Code, w.Body.String())
 	}
 
 	// Mutating routes are denied.
@@ -295,13 +305,43 @@ func TestReadScopeAPITokenEnforcement(t *testing.T) {
 		t.Errorf("expected 403 on mutating route with read token, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// The exec websocket endpoint is GET but mutating, so it is denied.
-	w = httptest.NewRecorder()
-	r = httptest.NewRequest("GET", "/api/v1/containers/abc123/exec", nil)
-	r.Header.Set("Authorization", "Bearer "+created.Token)
-	router.ServeHTTP(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Errorf("expected 403 on exec endpoint with read token, got %d: %s", w.Code, w.Body.String())
+	// GET routes that are sensitive or mutating are denied too.
+	deniedReads := []string{
+		"/api/v1/containers/abc123/exec",
+		"/api/v1/containers/abc123/env",
+		"/api/v1/settings",
+		"/api/v1/settings/api-tokens",
+	}
+	for _, path := range deniedReads {
+		w = httptest.NewRecorder()
+		r = httptest.NewRequest("GET", path, nil)
+		r.Header.Set("Authorization", "Bearer "+created.Token)
+		router.ServeHTTP(w, r)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("GET %s: expected 403 with read token, got %d: %s", path, w.Code, w.Body.String())
+		}
+	}
+
+	// Admin credentials (JWT session and admin token) are unaffected on the
+	// routes denied to read tokens.
+	adminToken := createToken(t, router, jwt, "full-access")
+	for _, bearer := range []string{jwt, adminToken.Token} {
+		w = httptest.NewRecorder()
+		r = httptest.NewRequest("GET", "/api/v1/settings", nil)
+		r.Header.Set("Authorization", "Bearer "+bearer)
+		router.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200 on settings with admin credentials, got %d: %s", w.Code, w.Body.String())
+		}
+
+		// Passes auth; fails on the missing host param, not authorization.
+		w = httptest.NewRecorder()
+		r = httptest.NewRequest("GET", "/api/v1/containers/abc123/env", nil)
+		r.Header.Set("Authorization", "Bearer "+bearer)
+		router.ServeHTTP(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 on env route with admin credentials, got %d: %s", w.Code, w.Body.String())
+		}
 	}
 }
 

--- a/server/internal/auth/apitoken.go
+++ b/server/internal/auth/apitoken.go
@@ -23,11 +23,15 @@ const (
 
 // NormalizeAPITokenScope maps a stored scope to its effective value. Tokens
 // created before scopes existed have an empty scope and are treated as admin.
+// Any other unrecognized value (e.g. a hand-edited config) fails closed to
+// read so a typo never silently grants admin access.
 func NormalizeAPITokenScope(scope string) string {
-	if scope == APITokenScopeRead {
+	switch scope {
+	case "", APITokenScopeAdmin:
+		return APITokenScopeAdmin
+	default:
 		return APITokenScopeRead
 	}
-	return APITokenScopeAdmin
 }
 
 // GenerateAPIToken creates a new API token from 32 random bytes.

--- a/server/internal/auth/apitoken.go
+++ b/server/internal/auth/apitoken.go
@@ -14,6 +14,22 @@ const APITokenPrefix = "ldk_"
 // for display and identification (includes the "ldk_" prefix).
 const APITokenDisplayLen = 12
 
+// API token scopes. Admin tokens have full access; read tokens can only
+// perform read operations.
+const (
+	APITokenScopeAdmin = "admin"
+	APITokenScopeRead  = "read"
+)
+
+// NormalizeAPITokenScope maps a stored scope to its effective value. Tokens
+// created before scopes existed have an empty scope and are treated as admin.
+func NormalizeAPITokenScope(scope string) string {
+	if scope == APITokenScopeRead {
+		return APITokenScopeRead
+	}
+	return APITokenScopeAdmin
+}
+
 // GenerateAPIToken creates a new API token from 32 random bytes.
 // It returns the full token (shown to the user exactly once), the SHA256 hex
 // hash to persist, and the display prefix used to identify the token.

--- a/server/internal/auth/apitoken_test.go
+++ b/server/internal/auth/apitoken_test.go
@@ -35,6 +35,11 @@ func TestNormalizeAPITokenScope(t *testing.T) {
 		"":                 APITokenScopeAdmin, // legacy tokens without a scope are admin
 		APITokenScopeAdmin: APITokenScopeAdmin,
 		APITokenScopeRead:  APITokenScopeRead,
+		// Unknown values fail closed to read, never admin.
+		"readonly":  APITokenScopeRead,
+		"Read":      APITokenScopeRead,
+		"Admin":     APITokenScopeRead,
+		"superuser": APITokenScopeRead,
 	}
 	for in, want := range cases {
 		if got := NormalizeAPITokenScope(in); got != want {

--- a/server/internal/auth/apitoken_test.go
+++ b/server/internal/auth/apitoken_test.go
@@ -30,6 +30,19 @@ func TestGenerateAPIToken(t *testing.T) {
 	}
 }
 
+func TestNormalizeAPITokenScope(t *testing.T) {
+	cases := map[string]string{
+		"":                 APITokenScopeAdmin, // legacy tokens without a scope are admin
+		APITokenScopeAdmin: APITokenScopeAdmin,
+		APITokenScopeRead:  APITokenScopeRead,
+	}
+	for in, want := range cases {
+		if got := NormalizeAPITokenScope(in); got != want {
+			t.Errorf("NormalizeAPITokenScope(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestGenerateAPITokenUnique(t *testing.T) {
 	a, _, _, err := GenerateAPIToken()
 	if err != nil {

--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -13,9 +13,9 @@ type contextKey string
 
 const UserContextKey contextKey = "user"
 
-// APITokenLookup resolves a presented API token to its name. Implementations
-// must compare against stored hashes in constant time.
-type APITokenLookup func(token string) (name string, ok bool)
+// APITokenLookup resolves a presented API token to its name and scope.
+// Implementations must compare against stored hashes in constant time.
+type APITokenLookup func(token string) (name, scope string, ok bool)
 
 // DynamicMiddleware creates an auth middleware that resolves the auth service per request.
 // If getService returns nil, auth is disabled and the request passes through.
@@ -59,8 +59,13 @@ func validateAndServe(svc *Service, lookupAPIToken APITokenLookup, next http.Han
 	// with it, so there is no fallthrough between the two schemes.
 	if strings.HasPrefix(tokenString, APITokenPrefix) {
 		if lookupAPIToken != nil {
-			if name, ok := lookupAPIToken(tokenString); ok {
-				user := models.User{Username: "token:" + name, Role: "admin"}
+			if name, scope, ok := lookupAPIToken(tokenString); ok {
+				scope = NormalizeAPITokenScope(scope)
+				if scope == APITokenScopeRead && isMutatingRequest(r) {
+					http.Error(w, "This API token is read-only and cannot perform this operation", http.StatusForbidden)
+					return
+				}
+				user := models.User{Username: "token:" + name, Role: scope}
 				ctx := context.WithValue(r.Context(), UserContextKey, user)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
@@ -83,4 +88,15 @@ func validateAndServe(svc *Service, lookupAPIToken APITokenLookup, next http.Han
 	user := GetUserFromClaims(claims)
 	ctx := context.WithValue(r.Context(), UserContextKey, user)
 	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// isMutatingRequest reports whether a request mutates state. Anything other
+// than GET/HEAD/OPTIONS mutates; the container exec endpoint is GET because
+// it upgrades to a websocket, but it spawns a shell so it also mutates.
+func isMutatingRequest(r *http.Request) bool {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return strings.HasSuffix(r.URL.Path, "/exec")
+	}
+	return true
 }

--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -90,13 +90,27 @@ func validateAndServe(svc *Service, lookupAPIToken APITokenLookup, next http.Han
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// isMutatingRequest reports whether a request mutates state. Anything other
-// than GET/HEAD/OPTIONS mutates; the container exec endpoint is GET because
-// it upgrades to a websocket, but it spawns a shell so it also mutates.
+// isMutatingRequest reports whether a request mutates state: anything other
+// than GET/HEAD/OPTIONS. GET routes that are nonetheless off-limits to read
+// tokens (exec, container env, settings) attach DenyReadScope explicitly.
 func isMutatingRequest(r *http.Request) bool {
 	switch r.Method {
 	case http.MethodGet, http.MethodHead, http.MethodOptions:
-		return strings.HasSuffix(r.URL.Path, "/exec")
+		return false
 	}
 	return true
+}
+
+// DenyReadScope is a route middleware that rejects requests authenticated by
+// a read-scoped API token. Attach it to routes that are read-shaped but
+// sensitive or mutating (exec, container env, settings). JWT session users
+// always carry the admin role, so they pass through unaffected.
+func DenyReadScope(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if user, ok := r.Context().Value(UserContextKey).(models.User); ok && user.Role == APITokenScopeRead {
+			http.Error(w, "This API token is read-only and cannot perform this operation", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/server/internal/auth/middleware_test.go
+++ b/server/internal/auth/middleware_test.go
@@ -41,11 +41,11 @@ func TestDynamicMiddlewareAcceptsAPIToken(t *testing.T) {
 		t.Fatalf("GenerateAPIToken failed: %v", err)
 	}
 
-	lookup := func(presented string) (string, bool) {
+	lookup := func(presented string) (string, string, bool) {
 		if HashAPIToken(presented) == hash {
-			return "ci", true
+			return "ci", "", true
 		}
-		return "", false
+		return "", "", false
 	}
 
 	var gotUser models.User
@@ -62,11 +62,69 @@ func TestDynamicMiddlewareAcceptsAPIToken(t *testing.T) {
 	if gotUser.Username != "token:ci" {
 		t.Errorf("expected context user %q, got %q", "token:ci", gotUser.Username)
 	}
+	if gotUser.Role != "admin" {
+		t.Errorf("expected legacy token (no scope) to get role %q, got %q", "admin", gotUser.Role)
+	}
+}
+
+func TestDynamicMiddlewareLegacyTokenAllowsMutations(t *testing.T) {
+	svc := testService(t)
+	// Empty scope simulates a token stored before scopes existed.
+	lookup := func(string) (string, string, bool) { return "legacy", "", true }
+
+	var gotUser models.User
+	handler := DynamicMiddleware(func() *Service { return svc }, lookup)(echoUserHandler(&gotUser))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/containers/abc/restart", nil)
+	r.Header.Set("Authorization", "Bearer "+APITokenPrefix+"legacy")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for legacy token on mutating route, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicMiddlewareReadScopeToken(t *testing.T) {
+	svc := testService(t)
+	lookup := func(string) (string, string, bool) { return "agent", APITokenScopeRead, true }
+
+	cases := []struct {
+		name     string
+		method   string
+		path     string
+		wantCode int
+	}{
+		{"GET allowed", "GET", "/api/v1/containers", http.StatusOK},
+		{"log streaming websocket allowed", "GET", "/api/v1/containers/abc/logs/parsed", http.StatusOK},
+		{"POST denied", "POST", "/api/v1/containers/abc/restart", http.StatusForbidden},
+		{"PUT denied", "PUT", "/api/v1/containers/abc/env", http.StatusForbidden},
+		{"DELETE denied", "DELETE", "/api/v1/settings/api-tokens/ldk_abcd1234", http.StatusForbidden},
+		{"exec websocket denied despite GET", "GET", "/api/v1/containers/abc/exec", http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotUser models.User
+			handler := DynamicMiddleware(func() *Service { return svc }, lookup)(echoUserHandler(&gotUser))
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(tc.method, tc.path, nil)
+			r.Header.Set("Authorization", "Bearer "+APITokenPrefix+"read-token")
+			handler.ServeHTTP(w, r)
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("expected %d, got %d: %s", tc.wantCode, w.Code, w.Body.String())
+			}
+			if tc.wantCode == http.StatusOK && gotUser.Role != APITokenScopeRead {
+				t.Errorf("expected role %q, got %q", APITokenScopeRead, gotUser.Role)
+			}
+		})
+	}
 }
 
 func TestDynamicMiddlewareRejectsUnknownAPIToken(t *testing.T) {
 	svc := testService(t)
-	lookup := func(string) (string, bool) { return "", false }
+	lookup := func(string) (string, string, bool) { return "", "", false }
 
 	var gotUser models.User
 	handler := DynamicMiddleware(func() *Service { return svc }, lookup)(echoUserHandler(&gotUser))
@@ -83,7 +141,7 @@ func TestDynamicMiddlewareRejectsUnknownAPIToken(t *testing.T) {
 
 func TestDynamicMiddlewareStillAcceptsJWT(t *testing.T) {
 	svc := testService(t)
-	lookup := func(string) (string, bool) { return "", false }
+	lookup := func(string) (string, string, bool) { return "", "", false }
 
 	jwtToken, err := svc.GenerateToken("admin")
 	if err != nil {

--- a/server/internal/auth/middleware_test.go
+++ b/server/internal/auth/middleware_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,7 +101,9 @@ func TestDynamicMiddlewareReadScopeToken(t *testing.T) {
 		{"POST denied", "POST", "/api/v1/containers/abc/restart", http.StatusForbidden},
 		{"PUT denied", "PUT", "/api/v1/containers/abc/env", http.StatusForbidden},
 		{"DELETE denied", "DELETE", "/api/v1/settings/api-tokens/ldk_abcd1234", http.StatusForbidden},
-		{"exec websocket denied despite GET", "GET", "/api/v1/containers/abc/exec", http.StatusForbidden},
+		// Exec denial is route-scoped (DenyReadScope), not path-based, so a
+		// container legitimately named "exec" passes the auth middleware.
+		{"GET on container named exec allowed", "GET", "/api/v1/containers/exec", http.StatusOK},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -117,6 +120,56 @@ func TestDynamicMiddlewareReadScopeToken(t *testing.T) {
 			}
 			if tc.wantCode == http.StatusOK && gotUser.Role != APITokenScopeRead {
 				t.Errorf("expected role %q, got %q", APITokenScopeRead, gotUser.Role)
+			}
+		})
+	}
+}
+
+func TestDynamicMiddlewareUnknownScopeFailsClosed(t *testing.T) {
+	svc := testService(t)
+	// A hand-edited config with an unrecognized scope must not grant admin.
+	lookup := func(string) (string, string, bool) { return "typo", "readonly", true }
+
+	var gotUser models.User
+	handler := DynamicMiddleware(func() *Service { return svc }, lookup)(echoUserHandler(&gotUser))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api/v1/containers/abc/restart", nil)
+	r.Header.Set("Authorization", "Bearer "+APITokenPrefix+"typo-token")
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unknown-scope token on mutating route, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDenyReadScope(t *testing.T) {
+	cases := []struct {
+		name     string
+		user     *models.User
+		wantCode int
+	}{
+		{"read token denied", &models.User{Username: "token:agent", Role: APITokenScopeRead}, http.StatusForbidden},
+		{"admin token allowed", &models.User{Username: "token:ci", Role: APITokenScopeAdmin}, http.StatusOK},
+		{"jwt session user allowed", &models.User{Username: "admin", Role: "admin"}, http.StatusOK},
+		{"no user (auth disabled) allowed", nil, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := DenyReadScope(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/api/v1/containers/abc/exec", nil)
+			if tc.user != nil {
+				ctx := context.WithValue(r.Context(), UserContextKey, *tc.user)
+				r = r.WithContext(ctx)
+			}
+			handler.ServeHTTP(w, r)
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("expected %d, got %d: %s", tc.wantCode, w.Code, w.Body.String())
 			}
 		})
 	}

--- a/server/internal/config/manager.go
+++ b/server/internal/config/manager.go
@@ -25,6 +25,9 @@ type APIToken struct {
 	Hash      string `json:"hash"`
 	Prefix    string `json:"prefix"`
 	CreatedAt string `json:"createdAt"`
+	// Scope is "admin" or "read". Tokens created before scopes existed have
+	// no scope and are treated as admin.
+	Scope string `json:"scope,omitempty"`
 }
 
 // FileAuthConfig represents auth settings in the config file.


### PR DESCRIPTION
## Summary

API tokens now carry a scope: **admin** (full access, the previous behavior) or **read** (read-only). A read token is intended for CI jobs or AI agents that should be able to read logs, stats, events, and container details but never mutate anything.

### Enforcement
- Read tokens are limited to GET/HEAD/OPTIONS in the auth middleware; all mutating routes return 403 with a clear message.
- A route-scoped `DenyReadScope` middleware additionally blocks read tokens from:
  - the exec terminal websocket (GET-upgraded but spawns a shell),
  - `GET /containers/{id}/env` (container environments typically hold real secrets),
  - the entire `/settings` group (host topology, token inventory).
- JWT sessions are unaffected; legacy tokens without a scope remain admin.
- Unknown scope values in a hand-edited config fail **closed** to read, not open to admin.

### UI / docs
- Settings > API Access: scope selector on the create form (defaults to Admin) and a scope badge in the token list.
- CLI docs updated to describe what read tokens can and cannot do.

### Testing
- Go: middleware and router-level tests cover the allow/deny matrix, legacy tokens, unknown scopes, and a container literally named "exec" (allowed for reads). Full `go build ./... && go vet ./... && go test ./...` green.
- Frontend: 77/77 vitest, biome, tsc clean.
- Live-verified against a running server on Podman: full curl matrix for read/admin/JWT (reads 200, env/settings/exec/mutations 403 for read tokens).
- Adversarially reviewed by a multi-agent workflow; all confirmed findings fixed in the second commit.

Note for review: denying `/env` and `/settings` to read tokens was a judgment call (the alternative was documenting the exposure) — easy to loosen if preferred.

https://claude.ai/code/session_01BNuavDshHAEjeUcqMrSjE5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API token scopes: **Admin** and **Read-only**.
  * Read-only tokens can access logs, statistics, container details, and events, but cannot modify resources, use the web terminal, or view sensitive settings and environment variables.
  * Added scope selection and visibility in API token settings.

* **Documentation**
  * Updated CLI and API token documentation with scope behavior and authentication details.
  * Existing tokens without a scope continue to receive Admin access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->