### PR TITLE
feat: container health status in the UI

### DIFF
--- a/frontend/src/features/containers/components/container-utils.ts
+++ b/frontend/src/features/containers/components/container-utils.ts
@@ -73,6 +73,19 @@ export function getStateBadgeClass(state: string) {
 	}
 }
 
+export function getHealthBadgeClass(health: string) {
+	switch (health) {
+		case "healthy":
+			return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
+		case "unhealthy":
+			return "bg-rose-500/10 text-rose-700 dark:text-rose-400";
+		case "starting":
+			return "bg-amber-500/10 text-amber-700 dark:text-amber-400";
+		default:
+			return "bg-muted text-muted-foreground";
+	}
+}
+
 export function groupByCompose(
 	containers: ContainerInfo[],
 ): GroupedContainers[] {

--- a/frontend/src/features/containers/components/container-utils.ts
+++ b/frontend/src/features/containers/components/container-utils.ts
@@ -43,6 +43,17 @@ export function formatContainerName(names: string[]) {
 	return primary.startsWith("/") ? primary.slice(1) : primary;
 }
 
+export function formatImageName(image: string) {
+	const segments = image.split("/");
+	if (segments.length > 1 && /[.:]/.test(segments[0])) {
+		segments.shift();
+	}
+	if (segments.length > 1 && segments[0] === "library") {
+		segments.shift();
+	}
+	return segments.join("/");
+}
+
 export function formatCreatedDate(createdSeconds: number) {
 	const createdDate = new Date(createdSeconds * 1000);
 	return createdDate.toLocaleString(undefined, {

--- a/frontend/src/features/containers/components/containers-logs-sheet.tsx
+++ b/frontend/src/features/containers/components/containers-logs-sheet.tsx
@@ -22,6 +22,7 @@ import {
 	formatContainerName,
 	formatCreatedDate,
 	getContainerUrlIdentifier,
+	getHealthBadgeClass,
 	getStateBadgeClass,
 	isCoolifyManaged,
 	toTitleCase,
@@ -135,6 +136,18 @@ export function ContainersLogsSheet({
 												</Badge>
 											</span>
 										</div>
+										{container.health && (
+											<div className="grid grid-cols-3 gap-4">
+												<span className="text-muted-foreground">Health</span>
+												<span className="col-span-2">
+													<Badge
+														className={`${getHealthBadgeClass(container.health)} border-0`}
+													>
+														{toTitleCase(container.health)}
+													</Badge>
+												</span>
+											</div>
+										)}
 										<div className="grid grid-cols-3 gap-4">
 											<span className="text-muted-foreground">Status</span>
 											<span className="col-span-2 font-medium">

--- a/frontend/src/features/containers/components/containers-table.tsx
+++ b/frontend/src/features/containers/components/containers-table.tsx
@@ -38,6 +38,7 @@ import {
 	formatContainerName,
 	formatCPUPercent,
 	formatCreatedDate,
+	formatImageName,
 	formatMemoryStats,
 	getComposeProject,
 	getHealthBadgeClass,
@@ -173,7 +174,16 @@ export function ContainersTable({
 					</div>
 				</TableCell>
 				<TableCell className="h-16 px-4 text-sm text-muted-foreground">
-					{container.image}
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span className="block cursor-help truncate max-w-[240px]">
+									{formatImageName(container.image)}
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>{container.image}</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
 				</TableCell>
 				<TableCell className="h-16 px-4">
 					<div className="flex items-center gap-1.5">
@@ -224,20 +234,6 @@ export function ContainersTable({
 				</TableCell>
 				<TableCell className="h-16 px-4 text-sm text-muted-foreground">
 					{formatCreatedDate(container.created)}
-				</TableCell>
-				<TableCell className="h-16 px-4 max-w-[300px] text-sm text-muted-foreground">
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<span className="block cursor-help truncate">
-									{container.command}
-								</span>
-							</TooltipTrigger>
-							<TooltipContent className="max-w-md">
-								{container.command}
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
 				</TableCell>
 				<TableCell className="h-16 px-4">
 					<TooltipProvider>
@@ -308,7 +304,7 @@ export function ContainersTable({
 		if (isLoading) {
 			return (
 				<TableRow>
-					<TableCell colSpan={8} className="h-32">
+					<TableCell colSpan={7} className="h-32">
 						<div className="flex items-center justify-center text-sm text-muted-foreground">
 							<Spinner className="mr-2" />
 							Loading containers…
@@ -321,7 +317,7 @@ export function ContainersTable({
 		if (isError) {
 			return (
 				<TableRow>
-					<TableCell colSpan={8} className="h-32">
+					<TableCell colSpan={7} className="h-32">
 						<div className="flex flex-col items-center gap-3 text-center">
 							<p className="text-sm text-muted-foreground">
 								{(error instanceof Error && error.message) ||
@@ -339,7 +335,7 @@ export function ContainersTable({
 		if (filteredContainers.length === 0) {
 			return (
 				<TableRow>
-					<TableCell colSpan={8} className="h-32">
+					<TableCell colSpan={7} className="h-32">
 						<div className="text-center text-sm text-muted-foreground">
 							No containers found.
 						</div>
@@ -353,7 +349,7 @@ export function ContainersTable({
 				<Fragment key={group.project}>
 					<TableRow className="bg-muted/30 hover:bg-muted/30">
 						<TableCell
-							colSpan={8}
+							colSpan={7}
 							className="h-10 px-4 text-xs font-medium text-muted-foreground"
 						>
 							<div className="flex items-center justify-between">
@@ -432,7 +428,6 @@ export function ContainersTable({
 						</TableHead>
 						<TableHead className="h-12 px-4 font-medium">Uptime</TableHead>
 						<TableHead className="h-12 px-4 font-medium">Created</TableHead>
-						<TableHead className="h-12 px-4 font-medium">Command</TableHead>
 						<TableHead className="h-12 px-4 font-medium w-[120px]">
 							Actions
 						</TableHead>

--- a/frontend/src/features/containers/components/containers-table.tsx
+++ b/frontend/src/features/containers/components/containers-table.tsx
@@ -40,6 +40,7 @@ import {
 	formatCreatedDate,
 	formatMemoryStats,
 	getComposeProject,
+	getHealthBadgeClass,
 	getStateBadgeClass,
 	isCoolifyManaged,
 	toTitleCase,
@@ -175,9 +176,20 @@ export function ContainersTable({
 					{container.image}
 				</TableCell>
 				<TableCell className="h-16 px-4">
-					<Badge className={`${getStateBadgeClass(container.state)} border-0`}>
-						{toTitleCase(container.state)}
-					</Badge>
+					<div className="flex items-center gap-1.5">
+						<Badge
+							className={`${getStateBadgeClass(container.state)} border-0`}
+						>
+							{toTitleCase(container.state)}
+						</Badge>
+						{container.health && (
+							<Badge
+								className={`${getHealthBadgeClass(container.health)} border-0`}
+							>
+								{toTitleCase(container.health)}
+							</Badge>
+						)}
+					</div>
 				</TableCell>
 				<TableCell className="h-16 px-4 text-sm">
 					{state !== "running" ? (

--- a/frontend/src/features/containers/types.ts
+++ b/frontend/src/features/containers/types.ts
@@ -12,6 +12,7 @@ export interface ContainerInfo {
 	created: number;
 	state: string;
 	status: string;
+	health?: string;
 	labels?: Record<string, string>;
 	host: string;
 }

--- a/frontend/src/routes/containers/$containerId/logs.tsx
+++ b/frontend/src/routes/containers/$containerId/logs.tsx
@@ -22,6 +22,7 @@ import {
 	formatCPUPercent,
 	formatCreatedDate,
 	formatMemoryStats,
+	getHealthBadgeClass,
 	getStateBadgeClass,
 	isCoolifyManaged,
 	toTitleCase,
@@ -161,11 +162,20 @@ function ContainerLogsPage() {
 											<span className="text-muted-foreground block mb-1">
 												State
 											</span>
-											<Badge
-												className={`${getStateBadgeClass(container.state)} border-0`}
-											>
-												{toTitleCase(container.state)}
-											</Badge>
+											<div className="flex items-center gap-1.5">
+												<Badge
+													className={`${getStateBadgeClass(container.state)} border-0`}
+												>
+													{toTitleCase(container.state)}
+												</Badge>
+												{container.health && (
+													<Badge
+														className={`${getHealthBadgeClass(container.health)} border-0`}
+													>
+														{toTitleCase(container.health)}
+													</Badge>
+												)}
+											</div>
 										</div>
 										<div>
 											<span className="text-muted-foreground block mb-1">

--- a/server/internal/docker/client.go
+++ b/server/internal/docker/client.go
@@ -73,6 +73,22 @@ type HostError struct {
 	Err      error
 }
 
+// healthFromStatus extracts the healthcheck state from a container list Status
+// string, e.g. "Up 3 hours (healthy)". Docker and Podman's compat API both
+// embed it this way. Returns "" for containers without a healthcheck.
+func healthFromStatus(status string) string {
+	switch {
+	case strings.HasSuffix(status, "(healthy)"):
+		return "healthy"
+	case strings.HasSuffix(status, "(unhealthy)"):
+		return "unhealthy"
+	case strings.HasSuffix(status, "(health: starting)"):
+		return "starting"
+	default:
+		return ""
+	}
+}
+
 func (c *MultiHostClient) ListContainersAllHosts(ctx context.Context) (map[string][]models.ContainerInfo, []HostError, error) {
 	result := make(map[string][]models.ContainerInfo)
 	var hostErrors []HostError
@@ -104,6 +120,7 @@ func (c *MultiHostClient) ListContainersAllHosts(ctx context.Context) (map[strin
 					Created: ctr.Created,
 					State:   ctr.State,
 					Status:  ctr.Status,
+					Health:  healthFromStatus(ctr.Status),
 					Labels:  ctr.Labels,
 					Host:    name,
 				})

--- a/server/internal/docker/client.go
+++ b/server/internal/docker/client.go
@@ -74,8 +74,10 @@ type HostError struct {
 }
 
 // healthFromStatus extracts the healthcheck state from a container list Status
-// string, e.g. "Up 3 hours (healthy)". Docker and Podman's compat API both
-// embed it this way. Returns "" for containers without a healthcheck.
+// string. Docker embeds "(healthy)", "(unhealthy)", or "(health: starting)" in
+// the list Status string, e.g. "Up 3 hours (healthy)"; Podman's Docker-compat
+// list API does not, so on Podman the field is absent. Returns "" when no
+// health suffix is present.
 func healthFromStatus(status string) string {
 	switch {
 	case strings.HasSuffix(status, "(healthy)"):

--- a/server/internal/docker/client_test.go
+++ b/server/internal/docker/client_test.go
@@ -1,0 +1,26 @@
+package docker
+
+import "testing"
+
+func TestHealthFromStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{"healthy", "Up 3 hours (healthy)", "healthy"},
+		{"unhealthy", "Up 2 minutes (unhealthy)", "unhealthy"},
+		{"starting", "Up 5 seconds (health: starting)", "starting"},
+		{"no healthcheck running", "Up 3 hours", ""},
+		{"no healthcheck exited", "Exited (0) 2 hours ago", ""},
+		{"empty status", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := healthFromStatus(tt.status); got != tt.want {
+				t.Errorf("healthFromStatus(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/docker/events.go
+++ b/server/internal/docker/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ var watchedContainerActions = []string{
 	"unpause",
 	"destroy",
 	"rename",
+	"health_status",
 }
 
 const (
@@ -46,8 +48,11 @@ func mapContainerEvent(hostName string, msg events.Message) (models.ContainerEve
 		return models.ContainerEvent{}, false
 	}
 
+	// Some actions arrive suffixed with detail, e.g. "health_status: healthy";
+	// match the watched set against the base action before ": ".
 	action := string(msg.Action)
-	if !slices.Contains(watchedContainerActions, action) {
+	base, _, _ := strings.Cut(action, ": ")
+	if !slices.Contains(watchedContainerActions, base) {
 		return models.ContainerEvent{}, false
 	}
 

--- a/server/internal/docker/events_test.go
+++ b/server/internal/docker/events_test.go
@@ -51,7 +51,7 @@ func TestMapContainerEventSkipsNonContainerTypes(t *testing.T) {
 }
 
 func TestMapContainerEventSkipsUnwatchedActions(t *testing.T) {
-	for _, action := range []events.Action{"exec_start: bash", "attach", "health_status: healthy"} {
+	for _, action := range []events.Action{"exec_start: bash", "attach"} {
 		msg := events.Message{
 			Type:   events.ContainerEventType,
 			Action: action,
@@ -61,6 +61,26 @@ func TestMapContainerEventSkipsUnwatchedActions(t *testing.T) {
 		if _, ok := mapContainerEvent("local", msg); ok {
 			t.Fatalf("expected action %q to be skipped", action)
 		}
+	}
+}
+
+func TestMapContainerEventMapsHealthStatusActions(t *testing.T) {
+	msg := events.Message{
+		Type:   events.ContainerEventType,
+		Action: "health_status: healthy",
+		Actor: events.Actor{
+			ID:         "abc123",
+			Attributes: map[string]string{"name": "web"},
+		},
+		Time: 1700000000,
+	}
+
+	event, ok := mapContainerEvent("local", msg)
+	if !ok {
+		t.Fatal("expected health_status event to be mapped")
+	}
+	if event.Action != "health_status: healthy" {
+		t.Fatalf("expected action %q, got %q", "health_status: healthy", event.Action)
 	}
 }
 

--- a/server/internal/models/container.go
+++ b/server/internal/models/container.go
@@ -10,6 +10,7 @@ type ContainerInfo struct {
 	Created int64             `json:"created"`
 	State   string            `json:"state"`
 	Status  string            `json:"status"`
+	Health  string            `json:"health,omitempty"`
 	Labels  map[string]string `json:"labels,omitempty"`
 	Host    string            `json:"host"`
 }


### PR DESCRIPTION
## Summary

Surfaces Docker/Podman healthcheck status (healthy / unhealthy / starting) as badges next to the state badge in the containers table, the logs sheet, and the per-container logs page. Containers without a healthcheck are unchanged.

### How it works
- Health is parsed from the list endpoint's `Status` string suffix ("(healthy)", "(unhealthy)", "(health: starting)") — no per-container inspect fan-out, so the list stays one API call per host. The field flows through multi-host aggregation with no special-casing and is `omitempty` on the JSON.
- `health_status` events are now watched (prefix-safe matching handles Docker's "health_status: healthy" and Podman's bare "health_status"), so badges refresh on health transitions instead of waiting for the next poll.
- The detail endpoint already returned the full inspect `State.Health` struct; no change needed there.

### Engine compatibility (live-verified)
- Docker: badges work end-to-end.
- Podman 6.0.1: the Docker-compat **list** API omits the health suffix entirely, so list badges are Docker-only for now; on Podman the field is simply absent and nothing breaks. Podman inspect returns full health (detail view works), and Podman does emit health_status events and honors the event filter.

### Also in this PR
- Containers table no longer scrolls horizontally on laptop widths: the command column was removed (still on the detail page) and images display as `name:tag` with the full reference in a tooltip.

### Testing
- Go: new `TestHealthFromStatus` covering real Docker status formats; events tests updated for health_status. Full suite green.
- Frontend: 77/77 vitest, biome, tsc clean.
- Live-verified on both engines with throwaway healthcheck containers (healthy and failing).
- Adversarially reviewed by a multi-agent workflow; confirmed findings fixed in the follow-up commits.

https://claude.ai/code/session_01BNuavDshHAEjeUcqMrSjE5