### PR TITLE
feat: alerting (event rules, log rules, webhook, history)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -221,7 +221,7 @@ logdeck alerts test                           # send a test delivery; exits 1 on
 logdeck alerts history --limit 20             # recently fired alerts, newest first
 ```
 
-Targeting flags (`--host`, `--container`, `--project`, all repeatable) narrow which containers a rule watches; an untargeted rule watches everything. `--window` and `--cooldown` accept Go durations (`60s`, `5m`) or bare seconds.
+Targeting flags (`--host`, `--container`, `--project`, all repeatable) narrow which containers a rule watches; an untargeted rule watches everything. `--window` and `--cooldown` accept Go durations (`60s`, `5m`) or bare seconds. When `--cooldown` is 0 or omitted, the server applies its default cooldown of 300 seconds between deliveries for the same rule and container.
 
 ## Using with AI Agents
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -207,6 +207,22 @@ logdeck volumes
 logdeck networks
 ```
 
+### alerts
+
+Manage alerting: rules, the webhook destination, and fired-alert history. Rules match container events (`die`, `oom`) or log lines (by minimum level and/or regex pattern), optionally firing only after a threshold of matches within a time window. Alerts are delivered to a single webhook URL.
+
+```bash
+logdeck alerts rules                          # list rules
+logdeck alerts rules create --type event --name oom-watch --events oom
+logdeck alerts rules create --type log --name errors --min-level ERROR --threshold 5 --window 60s
+logdeck alerts rules disable <id>             # or enable / delete
+logdeck alerts webhook set https://hooks.example.com/logdeck
+logdeck alerts test                           # send a test delivery; exits 1 on failure
+logdeck alerts history --limit 20             # recently fired alerts, newest first
+```
+
+Targeting flags (`--host`, `--container`, `--project`, all repeatable) narrow which containers a rule watches; an untargeted rule watches everything. `--window` and `--cooldown` accept Go durations (`60s`, `5m`) or bare seconds.
+
 ## Using with AI Agents
 
 The CLI is designed so an agent can debug containerized services without a browser. A typical investigation:

--- a/frontend/src/features/settings/api/clear-alert-history.ts
+++ b/frontend/src/features/settings/api/clear-alert-history.ts
@@ -1,0 +1,16 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/history`;
+
+export async function clearAlertHistory(): Promise<string> {
+	const response = await authenticatedFetch(ENDPOINT, { method: "DELETE" });
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to clear alert history");
+	}
+
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "Alert history cleared";
+}

--- a/frontend/src/features/settings/api/create-alert-rule.ts
+++ b/frontend/src/features/settings/api/create-alert-rule.ts
@@ -1,0 +1,25 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+import type { AlertRule } from "./get-alert-rules";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/rules`;
+
+export type AlertRulePayload = Omit<AlertRule, "id" | "createdAt">;
+
+export async function createAlertRule(
+	rule: AlertRulePayload,
+): Promise<AlertRule> {
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(rule),
+	});
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to create alert rule");
+	}
+
+	return (await response.json()) as AlertRule;
+}

--- a/frontend/src/features/settings/api/delete-alert-rule.ts
+++ b/frontend/src/features/settings/api/delete-alert-rule.ts
@@ -1,0 +1,19 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/rules`;
+
+export async function deleteAlertRule(id: string): Promise<string> {
+	const response = await authenticatedFetch(
+		`${ENDPOINT}/${encodeURIComponent(id)}`,
+		{ method: "DELETE" },
+	);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to delete alert rule");
+	}
+
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "Alert rule deleted";
+}

--- a/frontend/src/features/settings/api/get-alert-history.ts
+++ b/frontend/src/features/settings/api/get-alert-history.ts
@@ -1,0 +1,46 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+import type { AlertRuleType } from "./get-alert-rules";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/history`;
+
+export interface AlertDelivery {
+	status: string;
+	httpStatus?: number;
+	error?: string;
+}
+
+export interface AlertHistoryEntry {
+	id: string;
+	ruleId: string;
+	ruleName: string;
+	type: AlertRuleType;
+	host: string;
+	containerId: string;
+	containerName: string;
+	reason: string;
+	sample?: string;
+	count: number;
+	suppressed: number;
+	firedAt: string;
+	delivery?: AlertDelivery;
+}
+
+export interface AlertHistoryResponse {
+	alerts: AlertHistoryEntry[];
+	count: number;
+}
+
+export async function getAlertHistory(
+	limit: number,
+): Promise<AlertHistoryResponse> {
+	const response = await authenticatedFetch(`${ENDPOINT}?limit=${limit}`);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to load alert history");
+	}
+
+	return (await response.json()) as AlertHistoryResponse;
+}

--- a/frontend/src/features/settings/api/get-alert-rules.ts
+++ b/frontend/src/features/settings/api/get-alert-rules.ts
@@ -1,0 +1,39 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/rules`;
+
+export type AlertRuleType = "event" | "log";
+export type AlertEventKind = "die" | "oom";
+
+export interface AlertRule {
+	id: string;
+	name: string;
+	enabled: boolean;
+	type: AlertRuleType;
+	hosts?: string[];
+	containers?: string[];
+	projects?: string[];
+	events?: AlertEventKind[];
+	minLevel?: string;
+	pattern?: string;
+	threshold: number;
+	windowSeconds?: number;
+	cooldownSeconds?: number;
+	createdAt: string;
+}
+
+export interface AlertRulesResponse {
+	rules: AlertRule[];
+}
+
+export async function getAlertRules(): Promise<AlertRulesResponse> {
+	const response = await authenticatedFetch(ENDPOINT);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to load alert rules");
+	}
+
+	return (await response.json()) as AlertRulesResponse;
+}

--- a/frontend/src/features/settings/api/get-alert-webhook.ts
+++ b/frontend/src/features/settings/api/get-alert-webhook.ts
@@ -1,0 +1,19 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/webhook`;
+
+export interface AlertWebhookResponse {
+	url: string;
+}
+
+export async function getAlertWebhook(): Promise<AlertWebhookResponse> {
+	const response = await authenticatedFetch(ENDPOINT);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to load alert webhook");
+	}
+
+	return (await response.json()) as AlertWebhookResponse;
+}

--- a/frontend/src/features/settings/api/test-alert-webhook.ts
+++ b/frontend/src/features/settings/api/test-alert-webhook.ts
@@ -1,0 +1,21 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/test`;
+
+export interface AlertTestResult {
+	status: "ok" | "failed";
+	httpStatus?: number;
+	error?: string;
+}
+
+export async function testAlertWebhook(): Promise<AlertTestResult> {
+	const response = await authenticatedFetch(ENDPOINT, { method: "POST" });
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to send test alert");
+	}
+
+	return (await response.json()) as AlertTestResult;
+}

--- a/frontend/src/features/settings/api/update-alert-rule.ts
+++ b/frontend/src/features/settings/api/update-alert-rule.ts
@@ -1,0 +1,28 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+import type { AlertRulePayload } from "./create-alert-rule";
+import type { AlertRule } from "./get-alert-rules";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/rules`;
+
+export async function updateAlertRule(
+	id: string,
+	rule: AlertRulePayload,
+): Promise<AlertRule> {
+	const response = await authenticatedFetch(
+		`${ENDPOINT}/${encodeURIComponent(id)}`,
+		{
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(rule),
+		},
+	);
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to update alert rule");
+	}
+
+	return (await response.json()) as AlertRule;
+}

--- a/frontend/src/features/settings/api/update-alert-webhook.ts
+++ b/frontend/src/features/settings/api/update-alert-webhook.ts
@@ -1,0 +1,20 @@
+import { authenticatedFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/types/api";
+
+const ENDPOINT = `${API_BASE_URL}/api/v1/alerts/webhook`;
+
+export async function updateAlertWebhook(url: string): Promise<string> {
+	const response = await authenticatedFetch(ENDPOINT, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ url }),
+	});
+
+	if (!response.ok) {
+		const message = await response.text();
+		throw new Error(message || "Failed to update alert webhook");
+	}
+
+	const data = (await response.json()) as { message?: string };
+	return data.message ?? "Webhook updated";
+}

--- a/frontend/src/features/settings/components/alert-rule-dialog.tsx
+++ b/frontend/src/features/settings/components/alert-rule-dialog.tsx
@@ -9,6 +9,7 @@ import {
 	RotateCcwIcon,
 	SlidersHorizontalIcon,
 	TrendingUpIcon,
+	XIcon,
 } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -663,12 +664,13 @@ function RuleEditor({
 						seconds
 						<Button
 							type="button"
-							variant="link"
-							size="sm"
+							variant="ghost"
+							size="icon"
 							onClick={disableRate}
-							className="h-auto p-0 text-xs text-muted-foreground"
+							aria-label="Remove rate condition"
+							className="ml-0.5 size-6 text-muted-foreground hover:text-foreground"
 						>
-							remove
+							<XIcon className="size-3.5" />
 						</Button>
 					</div>
 				) : (

--- a/frontend/src/features/settings/components/alert-rule-dialog.tsx
+++ b/frontend/src/features/settings/components/alert-rule-dialog.tsx
@@ -2,11 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import {
 	ArrowLeftIcon,
 	CheckIcon,
-	ChevronRightIcon,
 	type LucideIcon,
 	MemoryStickIcon,
 	OctagonXIcon,
-	PlusIcon,
 	RegexIcon,
 	RotateCcwIcon,
 	SlidersHorizontalIcon,
@@ -44,6 +42,7 @@ import { cn } from "@/lib/utils";
 import type { AlertRulePayload } from "../api/create-alert-rule";
 import type { AlertEventKind, AlertRule } from "../api/get-alert-rules";
 import { useCreateAlertRule, useUpdateAlertRule } from "../hooks/use-alerts";
+import { MultiCombobox } from "./multi-combobox";
 
 const LOG_LEVELS = [
 	"TRACE",
@@ -335,111 +334,6 @@ function ToggleChip({
 	);
 }
 
-function TargetPicker({
-	label,
-	placeholder,
-	options,
-	selected,
-	onChange,
-}: {
-	label: string;
-	placeholder: string;
-	options: string[];
-	selected: string[];
-	onChange: (values: string[]) => void;
-}) {
-	const [open, setOpen] = useState(selected.length > 0);
-	const [manual, setManual] = useState("");
-
-	const values = useMemo(() => {
-		const all = new Set([...options, ...selected]);
-		return [...all].sort((a, b) => a.localeCompare(b));
-	}, [options, selected]);
-
-	function toggle(value: string) {
-		if (selected.includes(value)) {
-			onChange(selected.filter((v) => v !== value));
-		} else {
-			onChange([...selected, value]);
-		}
-	}
-
-	function addManual() {
-		const value = manual.trim();
-		if (!value) return;
-		if (!selected.includes(value)) onChange([...selected, value]);
-		setManual("");
-	}
-
-	return (
-		<div>
-			<button
-				type="button"
-				aria-expanded={open}
-				onClick={() => setOpen((prev) => !prev)}
-				className={cn(
-					"flex h-9 w-full items-center gap-1.5 text-sm font-medium transition-colors hover:text-foreground",
-					HIT_AREA,
-					open ? "text-foreground" : "text-muted-foreground",
-				)}
-			>
-				<ChevronRightIcon
-					className={cn(
-						"size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
-						open && "rotate-90",
-					)}
-				/>
-				{label}
-				{selected.length > 0 && (
-					<span className="text-xs font-normal text-muted-foreground tabular-nums">
-						({selected.length})
-					</span>
-				)}
-			</button>
-			{open && (
-				<div className="space-y-2.5 pt-1 pb-2 pl-5">
-					{values.length > 0 && (
-						<div className="flex flex-wrap gap-1.5">
-							{values.map((value) => (
-								<ToggleChip
-									key={value}
-									label={value}
-									pressed={selected.includes(value)}
-									onToggle={() => toggle(value)}
-								/>
-							))}
-						</div>
-					)}
-					<div className="flex items-center gap-1.5">
-						<Input
-							value={manual}
-							onChange={(e) => setManual(e.target.value)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter") {
-									e.preventDefault();
-									addManual();
-								}
-							}}
-							placeholder={placeholder}
-							className="h-8 max-w-56 text-xs"
-						/>
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							disabled={!manual.trim()}
-							onClick={addManual}
-						>
-							<PlusIcon className="size-3.5" />
-							Add
-						</Button>
-					</div>
-				</div>
-			)}
-		</div>
-	);
-}
-
 function InlineNumberInput({
 	id,
 	value,
@@ -510,7 +404,15 @@ export function AlertRuleDialog({
 }: AlertRuleDialogProps) {
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+			<DialogContent
+				className="max-h-[85vh] overflow-y-auto sm:max-w-xl"
+				onEscapeKeyDown={(e) => {
+					// Escape while a target combobox list is open should close the
+					// list (handled by the combobox itself), not dismiss the dialog.
+					const target = e.target as HTMLElement | null;
+					if (target?.closest("[data-combobox-open]")) e.preventDefault();
+				}}
+			>
 				{open && <RuleEditor rule={rule} onClose={() => onOpenChange(false)} />}
 			</DialogContent>
 		</Dialog>
@@ -786,7 +688,7 @@ function RuleEditor({
 			</div>
 
 			{/* Where */}
-			<div className="space-y-1">
+			<div className="space-y-3">
 				<div className="space-y-1.5">
 					<SectionLabel>Where</SectionLabel>
 					{form.containers.length === 0 &&
@@ -797,27 +699,36 @@ function RuleEditor({
 							</p>
 						)}
 				</div>
-				<TargetPicker
-					label="Containers"
-					placeholder="container name"
-					options={targetOptions.containers}
-					selected={form.containers}
-					onChange={(values) => set("containers", values)}
-				/>
-				<TargetPicker
-					label="Compose projects"
-					placeholder="project name"
-					options={targetOptions.projects}
-					selected={form.projects}
-					onChange={(values) => set("projects", values)}
-				/>
-				<TargetPicker
-					label="Hosts"
-					placeholder="host name"
-					options={targetOptions.hosts}
-					selected={form.hosts}
-					onChange={(values) => set("hosts", values)}
-				/>
+				<div className="space-y-1.5">
+					<Label htmlFor="alert-rule-containers">Containers</Label>
+					<MultiCombobox
+						id="alert-rule-containers"
+						placeholder="Add container..."
+						options={targetOptions.containers}
+						selected={form.containers}
+						onChange={(values) => set("containers", values)}
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor="alert-rule-projects">Compose projects</Label>
+					<MultiCombobox
+						id="alert-rule-projects"
+						placeholder="Add compose project..."
+						options={targetOptions.projects}
+						selected={form.projects}
+						onChange={(values) => set("projects", values)}
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor="alert-rule-hosts">Hosts</Label>
+					<MultiCombobox
+						id="alert-rule-hosts"
+						placeholder="Add host..."
+						options={targetOptions.hosts}
+						selected={form.hosts}
+						onChange={(values) => set("hosts", values)}
+					/>
+				</div>
 			</div>
 
 			{/* Then */}

--- a/frontend/src/features/settings/components/alert-rule-dialog.tsx
+++ b/frontend/src/features/settings/components/alert-rule-dialog.tsx
@@ -1,0 +1,889 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	ArrowLeftIcon,
+	CheckIcon,
+	ChevronRightIcon,
+	type LucideIcon,
+	MemoryStickIcon,
+	OctagonXIcon,
+	PlusIcon,
+	RegexIcon,
+	RotateCcwIcon,
+	SlidersHorizontalIcon,
+	TrendingUpIcon,
+} from "lucide-react";
+import { type ReactNode, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Spinner } from "@/components/ui/spinner";
+import { getContainers } from "@/features/containers/api/get-containers";
+import {
+	formatContainerName,
+	getComposeProject,
+} from "@/features/containers/components/container-utils";
+import { cn } from "@/lib/utils";
+
+import type { AlertRulePayload } from "../api/create-alert-rule";
+import type { AlertEventKind, AlertRule } from "../api/get-alert-rules";
+import { useCreateAlertRule, useUpdateAlertRule } from "../hooks/use-alerts";
+
+const LOG_LEVELS = [
+	"TRACE",
+	"DEBUG",
+	"INFO",
+	"WARN",
+	"ERROR",
+	"FATAL",
+	"PANIC",
+];
+
+interface FormState {
+	name: string;
+	type: "log" | "event";
+	minLevel: string;
+	pattern: string;
+	die: boolean;
+	oom: boolean;
+	rateEnabled: boolean;
+	threshold: string;
+	windowSeconds: string;
+	containers: string[];
+	projects: string[];
+	hosts: string[];
+	cooldownValue: string;
+	cooldownUnit: "minutes" | "seconds";
+}
+
+const EMPTY_FORM: FormState = {
+	name: "",
+	type: "log",
+	minLevel: "any",
+	pattern: "",
+	die: false,
+	oom: false,
+	rateEnabled: false,
+	threshold: "1",
+	windowSeconds: "",
+	containers: [],
+	projects: [],
+	hosts: [],
+	cooldownValue: "",
+	cooldownUnit: "minutes",
+};
+
+interface Preset {
+	id: string;
+	icon: LucideIcon;
+	title: string;
+	description: string;
+	form: Partial<FormState>;
+	focus: "pattern" | "name" | null;
+}
+
+const PRESETS: Preset[] = [
+	{
+		id: "crashed",
+		icon: OctagonXIcon,
+		title: "Container crashed",
+		description: "Alert whenever a container dies.",
+		form: { name: "Container crashed", type: "event", die: true },
+		focus: null,
+	},
+	{
+		id: "crash-loop",
+		icon: RotateCcwIcon,
+		title: "Crash looping",
+		description: "A container dies 3 times within 2 minutes.",
+		form: {
+			name: "Crash looping",
+			type: "event",
+			die: true,
+			rateEnabled: true,
+			threshold: "3",
+			windowSeconds: "120",
+		},
+		focus: null,
+	},
+	{
+		id: "oom",
+		icon: MemoryStickIcon,
+		title: "Out of memory",
+		description: "A container is killed for exceeding its memory limit.",
+		form: { name: "Out of memory", type: "event", oom: true },
+		focus: null,
+	},
+	{
+		id: "error-spike",
+		icon: TrendingUpIcon,
+		title: "Error spike",
+		description: "5 lines at ERROR or above within a minute.",
+		form: {
+			name: "Error spike",
+			type: "log",
+			minLevel: "ERROR",
+			rateEnabled: true,
+			threshold: "5",
+			windowSeconds: "60",
+		},
+		focus: null,
+	},
+	{
+		id: "pattern",
+		icon: RegexIcon,
+		title: "Log pattern",
+		description: "A log line matches a regular expression.",
+		form: { name: "Log pattern", type: "log" },
+		focus: "pattern",
+	},
+	{
+		id: "custom",
+		icon: SlidersHorizontalIcon,
+		title: "Custom",
+		description: "Start from a blank rule.",
+		form: {},
+		focus: "name",
+	},
+];
+
+function ruleToForm(rule: AlertRule): FormState {
+	const cooldown = rule.cooldownSeconds ?? 0;
+	return {
+		name: rule.name,
+		type: rule.type,
+		minLevel: rule.minLevel ?? "any",
+		pattern: rule.pattern ?? "",
+		die: rule.events?.includes("die") ?? false,
+		oom: rule.events?.includes("oom") ?? false,
+		rateEnabled: rule.threshold > 1 || Boolean(rule.windowSeconds),
+		threshold: String(rule.threshold),
+		windowSeconds: rule.windowSeconds ? String(rule.windowSeconds) : "",
+		containers: rule.containers ?? [],
+		projects: rule.projects ?? [],
+		hosts: rule.hosts ?? [],
+		cooldownValue:
+			cooldown > 0
+				? String(cooldown % 60 === 0 ? cooldown / 60 : cooldown)
+				: "",
+		cooldownUnit: cooldown > 0 && cooldown % 60 !== 0 ? "seconds" : "minutes",
+	};
+}
+
+function buildPayload(
+	form: FormState,
+): { error: string } | { payload: AlertRulePayload } {
+	const name = form.name.trim();
+	if (!name) return { error: "Rule name is required" };
+
+	const payload: AlertRulePayload = {
+		name,
+		enabled: true,
+		type: form.type,
+		threshold: 1,
+	};
+
+	if (form.type === "log") {
+		const pattern = form.pattern.trim();
+		if (form.minLevel === "any" && !pattern) {
+			return { error: "Log rules need a minimum level or a pattern" };
+		}
+		if (form.minLevel !== "any") payload.minLevel = form.minLevel;
+		if (pattern) payload.pattern = pattern;
+	} else {
+		const events: AlertEventKind[] = [];
+		if (form.die) events.push("die");
+		if (form.oom) events.push("oom");
+		if (events.length === 0) {
+			return { error: "Event rules need at least one event" };
+		}
+		payload.events = events;
+	}
+
+	if (form.rateEnabled) {
+		const threshold = Number.parseInt(form.threshold, 10);
+		if (!Number.isNaN(threshold) && threshold > 0) {
+			payload.threshold = threshold;
+		}
+		const windowSeconds = Number.parseInt(form.windowSeconds, 10);
+		if (!Number.isNaN(windowSeconds) && windowSeconds > 0) {
+			payload.windowSeconds = windowSeconds;
+		}
+	}
+
+	const cooldown = Number.parseInt(form.cooldownValue, 10);
+	if (!Number.isNaN(cooldown) && cooldown > 0) {
+		payload.cooldownSeconds =
+			form.cooldownUnit === "minutes" ? cooldown * 60 : cooldown;
+	}
+
+	if (form.containers.length > 0) payload.containers = form.containers;
+	if (form.projects.length > 0) payload.projects = form.projects;
+	if (form.hosts.length > 0) payload.hosts = form.hosts;
+
+	return { payload };
+}
+
+function formatList(values: string[]): string {
+	if (values.length <= 2) return values.join(" and ");
+	return `${values[0]}, ${values[1]} and ${values.length - 2} more`;
+}
+
+function summarize(form: FormState): string {
+	const targets: string[] = [];
+	if (form.containers.length > 0) targets.push(formatList(form.containers));
+	if (form.projects.length > 0) {
+		targets.push(
+			`${form.projects.length === 1 ? "project" : "projects"} ${formatList(form.projects)}`,
+		);
+	}
+	if (form.hosts.length > 0) targets.push(`on ${formatList(form.hosts)}`);
+	const target = targets.length > 0 ? targets.join(", ") : "any container";
+
+	let condition: string;
+	if (form.type === "log") {
+		const qualifiers = [
+			form.minLevel !== "any" ? `at ${form.minLevel} or above` : "",
+			form.pattern.trim() ? `matching /${form.pattern.trim()}/` : "",
+		]
+			.filter(Boolean)
+			.join(" ");
+		if (form.rateEnabled) {
+			condition = `logs ${form.threshold || "?"} lines${
+				qualifiers ? ` ${qualifiers}` : ""
+			} within ${form.windowSeconds || "?"}s`;
+		} else {
+			condition = `logs a line${qualifiers ? ` ${qualifiers}` : ""}`;
+		}
+	} else {
+		const events =
+			[form.die ? "dies" : "", form.oom ? "runs out of memory" : ""]
+				.filter(Boolean)
+				.join(" or ") || "…";
+		condition = form.rateEnabled
+			? `${events} ${form.threshold || "?"} times within ${form.windowSeconds || "?"}s`
+			: events;
+	}
+
+	let quiet: string;
+	if (form.cooldownValue) {
+		const unit =
+			form.cooldownValue === "1"
+				? form.cooldownUnit.slice(0, -1)
+				: form.cooldownUnit;
+		quiet = `${form.cooldownValue} ${unit}`;
+	} else {
+		quiet = "5 minutes";
+	}
+
+	return `When ${target} ${condition} → alert, then stay quiet for ${quiet}.`;
+}
+
+// Extends the click target above/below the visual bounds so 32-36px controls
+// meet a 40px minimum hit area.
+const HIT_AREA = "relative after:absolute after:inset-x-0 after:-inset-y-1";
+
+function SectionLabel({ children }: { children: ReactNode }) {
+	return (
+		<h4 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+			{children}
+		</h4>
+	);
+}
+
+function ToggleChip({
+	label,
+	pressed,
+	onToggle,
+}: {
+	label: string;
+	pressed: boolean;
+	onToggle: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={pressed}
+			onClick={onToggle}
+			className={cn(
+				"inline-flex h-8 items-center gap-1.5 rounded-md border px-3 text-xs font-medium transition-colors",
+				HIT_AREA,
+				pressed
+					? "border-primary/50 bg-primary/10 text-primary"
+					: "border-input text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+			)}
+		>
+			{pressed && <CheckIcon className="size-3" />}
+			{label}
+		</button>
+	);
+}
+
+function TargetPicker({
+	label,
+	placeholder,
+	options,
+	selected,
+	onChange,
+}: {
+	label: string;
+	placeholder: string;
+	options: string[];
+	selected: string[];
+	onChange: (values: string[]) => void;
+}) {
+	const [open, setOpen] = useState(selected.length > 0);
+	const [manual, setManual] = useState("");
+
+	const values = useMemo(() => {
+		const all = new Set([...options, ...selected]);
+		return [...all].sort((a, b) => a.localeCompare(b));
+	}, [options, selected]);
+
+	function toggle(value: string) {
+		if (selected.includes(value)) {
+			onChange(selected.filter((v) => v !== value));
+		} else {
+			onChange([...selected, value]);
+		}
+	}
+
+	function addManual() {
+		const value = manual.trim();
+		if (!value) return;
+		if (!selected.includes(value)) onChange([...selected, value]);
+		setManual("");
+	}
+
+	return (
+		<div>
+			<button
+				type="button"
+				aria-expanded={open}
+				onClick={() => setOpen((prev) => !prev)}
+				className={cn(
+					"flex h-9 w-full items-center gap-1.5 text-sm font-medium transition-colors hover:text-foreground",
+					HIT_AREA,
+					open ? "text-foreground" : "text-muted-foreground",
+				)}
+			>
+				<ChevronRightIcon
+					className={cn(
+						"size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
+						open && "rotate-90",
+					)}
+				/>
+				{label}
+				{selected.length > 0 && (
+					<span className="text-xs font-normal text-muted-foreground tabular-nums">
+						({selected.length})
+					</span>
+				)}
+			</button>
+			{open && (
+				<div className="space-y-2.5 pt-1 pb-2 pl-5">
+					{values.length > 0 && (
+						<div className="flex flex-wrap gap-1.5">
+							{values.map((value) => (
+								<ToggleChip
+									key={value}
+									label={value}
+									pressed={selected.includes(value)}
+									onToggle={() => toggle(value)}
+								/>
+							))}
+						</div>
+					)}
+					<div className="flex items-center gap-1.5">
+						<Input
+							value={manual}
+							onChange={(e) => setManual(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									addManual();
+								}
+							}}
+							placeholder={placeholder}
+							className="h-8 max-w-56 text-xs"
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							disabled={!manual.trim()}
+							onClick={addManual}
+						>
+							<PlusIcon className="size-3.5" />
+							Add
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function InlineNumberInput({
+	id,
+	value,
+	onChange,
+	min,
+	max,
+	placeholder,
+	ariaLabel,
+}: {
+	id: string;
+	value: string;
+	onChange: (value: string) => void;
+	min: number;
+	max: number;
+	placeholder?: string;
+	ariaLabel: string;
+}) {
+	return (
+		<Input
+			id={id}
+			type="number"
+			min={min}
+			max={max}
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			placeholder={placeholder}
+			aria-label={ariaLabel}
+			className="h-8 w-16 text-center tabular-nums"
+		/>
+	);
+}
+
+function PresetGrid({ onPick }: { onPick: (preset: Preset) => void }) {
+	return (
+		<div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+			{PRESETS.map((preset) => (
+				<button
+					key={preset.id}
+					type="button"
+					onClick={() => onPick(preset)}
+					className="flex items-start gap-3 rounded-xl border p-3 text-left transition-colors hover:border-primary/40 hover:bg-accent/50"
+				>
+					<span className="flex size-9 shrink-0 items-center justify-center rounded-xs border bg-muted/50">
+						<preset.icon className="size-4 text-muted-foreground" />
+					</span>
+					<span className="min-w-0 space-y-0.5">
+						<span className="block text-sm font-medium">{preset.title}</span>
+						<span className="block text-xs text-muted-foreground">
+							{preset.description}
+						</span>
+					</span>
+				</button>
+			))}
+		</div>
+	);
+}
+
+interface AlertRuleDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	rule: AlertRule | null;
+}
+
+export function AlertRuleDialog({
+	open,
+	onOpenChange,
+	rule,
+}: AlertRuleDialogProps) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+				{open && <RuleEditor rule={rule} onClose={() => onOpenChange(false)} />}
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function RuleEditor({
+	rule,
+	onClose,
+}: {
+	rule: AlertRule | null;
+	onClose: () => void;
+}) {
+	const isEdit = rule !== null;
+	const [screen, setScreen] = useState<"presets" | "form">(
+		isEdit ? "form" : "presets",
+	);
+	const [form, setForm] = useState<FormState>(() =>
+		rule ? ruleToForm(rule) : EMPTY_FORM,
+	);
+	const [initialFocus, setInitialFocus] = useState<"pattern" | "name" | null>(
+		null,
+	);
+
+	const createMutation = useCreateAlertRule();
+	const updateMutation = useUpdateAlertRule();
+	const isSaving = createMutation.isPending || updateMutation.isPending;
+
+	const containersQuery = useQuery({
+		queryKey: ["containers"],
+		queryFn: getContainers,
+		staleTime: 30_000,
+	});
+
+	const targetOptions = useMemo(() => {
+		const containers = new Set<string>();
+		const projects = new Set<string>();
+		const hosts = new Set<string>();
+		for (const container of containersQuery.data?.containers ?? []) {
+			const name = formatContainerName(container.names);
+			if (name !== "—") containers.add(name);
+			const project = getComposeProject(container.labels);
+			if (project) projects.add(project);
+			if (container.host) hosts.add(container.host);
+		}
+		for (const host of containersQuery.data?.hosts ?? []) {
+			hosts.add(host.name);
+		}
+		return {
+			containers: [...containers],
+			projects: [...projects],
+			hosts: [...hosts],
+		};
+	}, [containersQuery.data]);
+
+	function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+		setForm((prev) => ({ ...prev, [key]: value }));
+	}
+
+	function applyPreset(preset: Preset) {
+		setForm({ ...EMPTY_FORM, ...preset.form });
+		setInitialFocus(preset.focus);
+		setScreen("form");
+	}
+
+	function enableRate() {
+		setForm((prev) => ({
+			...prev,
+			rateEnabled: true,
+			threshold: Number.parseInt(prev.threshold, 10) > 1 ? prev.threshold : "3",
+			windowSeconds: prev.windowSeconds || "60",
+		}));
+	}
+
+	function disableRate() {
+		setForm((prev) => ({
+			...prev,
+			rateEnabled: false,
+			threshold: "1",
+			windowSeconds: "",
+		}));
+	}
+
+	function handleSave() {
+		const result = buildPayload(form);
+		if ("error" in result) {
+			toast.error(result.error);
+			return;
+		}
+		if (rule) {
+			updateMutation.mutate(
+				{ id: rule.id, rule: { ...result.payload, enabled: rule.enabled } },
+				{
+					onSuccess: (updated) => {
+						toast.success(`Rule "${updated.name}" updated`);
+						onClose();
+					},
+					onError: (err) => toast.error(err.message),
+				},
+			);
+		} else {
+			createMutation.mutate(result.payload, {
+				onSuccess: (created) => {
+					toast.success(`Rule "${created.name}" created`);
+					onClose();
+				},
+				onError: (err) => toast.error(err.message),
+			});
+		}
+	}
+
+	if (screen === "presets") {
+		return (
+			<div className="animate-in fade-in-0 slide-in-from-left-2 space-y-4 duration-200">
+				<DialogHeader>
+					<DialogTitle>New alert rule</DialogTitle>
+					<DialogDescription>
+						Start from a preset, or build a custom rule from scratch.
+					</DialogDescription>
+				</DialogHeader>
+				<PresetGrid onPick={applyPreset} />
+			</div>
+		);
+	}
+
+	return (
+		<div className="animate-in fade-in-0 slide-in-from-right-2 space-y-5 duration-200">
+			<DialogHeader>
+				<DialogTitle className="flex items-center gap-2">
+					{!isEdit && (
+						<button
+							type="button"
+							onClick={() => setScreen("presets")}
+							aria-label="Back to presets"
+							className={cn(
+								"-ml-1 flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+								HIT_AREA,
+							)}
+						>
+							<ArrowLeftIcon className="size-4" />
+						</button>
+					)}
+					{isEdit ? "Edit alert rule" : "New alert rule"}
+				</DialogTitle>
+			</DialogHeader>
+
+			{/* When */}
+			<div className="space-y-3">
+				<SectionLabel>When</SectionLabel>
+				<div className="flex gap-1">
+					<Button
+						type="button"
+						size="sm"
+						variant={form.type === "log" ? "default" : "outline"}
+						onClick={() => set("type", "log")}
+					>
+						Log
+					</Button>
+					<Button
+						type="button"
+						size="sm"
+						variant={form.type === "event" ? "default" : "outline"}
+						onClick={() => set("type", "event")}
+					>
+						Event
+					</Button>
+				</div>
+
+				{form.type === "log" ? (
+					<div className="space-y-3">
+						<div className="flex items-start gap-3">
+							<div className="space-y-1.5">
+								<Label>Minimum level</Label>
+								<Select
+									value={form.minLevel}
+									onValueChange={(v) => set("minLevel", v)}
+								>
+									<SelectTrigger size="sm" className="w-32">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="any">any</SelectItem>
+										{LOG_LEVELS.map((level) => (
+											<SelectItem key={level} value={level}>
+												{level}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="min-w-0 flex-1 space-y-1.5">
+								<Label htmlFor="alert-rule-pattern">
+									Pattern{" "}
+									<span className="font-normal text-muted-foreground">
+										(optional)
+									</span>
+								</Label>
+								<Input
+									id="alert-rule-pattern"
+									value={form.pattern}
+									onChange={(e) => set("pattern", e.target.value)}
+									placeholder="connection refused"
+									className="h-8 font-mono"
+									autoFocus={initialFocus === "pattern"}
+								/>
+								<p className="text-xs text-muted-foreground">
+									Regular expression, matched against the message.
+								</p>
+							</div>
+						</div>
+					</div>
+				) : (
+					<div className="flex items-center gap-2">
+						<ToggleChip
+							label="Container died"
+							pressed={form.die}
+							onToggle={() => set("die", !form.die)}
+						/>
+						<ToggleChip
+							label="Out of memory"
+							pressed={form.oom}
+							onToggle={() => set("oom", !form.oom)}
+						/>
+					</div>
+				)}
+
+				{form.rateEnabled ? (
+					<div className="flex flex-wrap items-center gap-x-1.5 gap-y-2 text-sm">
+						Alert after
+						<InlineNumberInput
+							id="alert-rule-threshold"
+							value={form.threshold}
+							onChange={(v) => set("threshold", v)}
+							min={1}
+							max={1000}
+							ariaLabel="Occurrence threshold"
+						/>
+						occurrences within
+						<InlineNumberInput
+							id="alert-rule-window"
+							value={form.windowSeconds}
+							onChange={(v) => set("windowSeconds", v)}
+							min={5}
+							max={3600}
+							placeholder="60"
+							ariaLabel="Window in seconds"
+						/>
+						seconds
+						<Button
+							type="button"
+							variant="link"
+							size="sm"
+							onClick={disableRate}
+							className="h-auto p-0 text-xs text-muted-foreground"
+						>
+							remove
+						</Button>
+					</div>
+				) : (
+					<p className="text-sm">
+						Alert on the first occurrence.{" "}
+						<Button
+							type="button"
+							variant="link"
+							size="sm"
+							onClick={enableRate}
+							className="h-auto p-0 text-xs"
+						>
+							Add a rate condition
+						</Button>
+					</p>
+				)}
+			</div>
+
+			{/* Where */}
+			<div className="space-y-1">
+				<div className="space-y-1.5">
+					<SectionLabel>Where</SectionLabel>
+					{form.containers.length === 0 &&
+						form.projects.length === 0 &&
+						form.hosts.length === 0 && (
+							<p className="text-xs text-muted-foreground">
+								Applies to all containers. Narrow it down below.
+							</p>
+						)}
+				</div>
+				<TargetPicker
+					label="Containers"
+					placeholder="container name"
+					options={targetOptions.containers}
+					selected={form.containers}
+					onChange={(values) => set("containers", values)}
+				/>
+				<TargetPicker
+					label="Compose projects"
+					placeholder="project name"
+					options={targetOptions.projects}
+					selected={form.projects}
+					onChange={(values) => set("projects", values)}
+				/>
+				<TargetPicker
+					label="Hosts"
+					placeholder="host name"
+					options={targetOptions.hosts}
+					selected={form.hosts}
+					onChange={(values) => set("hosts", values)}
+				/>
+			</div>
+
+			{/* Then */}
+			<div className="space-y-2">
+				<SectionLabel>Then</SectionLabel>
+				<div className="flex flex-wrap items-center gap-x-1.5 gap-y-2 text-sm">
+					After alerting, stay quiet for
+					<InlineNumberInput
+						id="alert-rule-cooldown"
+						value={form.cooldownValue}
+						onChange={(v) => set("cooldownValue", v)}
+						min={0}
+						max={form.cooldownUnit === "minutes" ? 1440 : 86400}
+						placeholder="5"
+						ariaLabel={`Cooldown in ${form.cooldownUnit}`}
+					/>
+					{form.cooldownUnit}
+					{form.cooldownValue === "" && (
+						<span className="text-muted-foreground">(default)</span>
+					)}
+				</div>
+				<p className="text-xs text-muted-foreground">
+					Repeat occurrences during the quiet period are counted and reported on
+					the next alert.
+				</p>
+			</div>
+
+			<Separator />
+
+			<div className="space-y-4">
+				<p className="text-xs text-muted-foreground">{summarize(form)}</p>
+				<div className="space-y-1.5">
+					<Label htmlFor="alert-rule-name">Rule name</Label>
+					<Input
+						id="alert-rule-name"
+						value={form.name}
+						onChange={(e) => set("name", e.target.value)}
+						placeholder="api errors"
+						maxLength={64}
+						className="h-8"
+						autoFocus={initialFocus === "name"}
+					/>
+				</div>
+				<div className="flex justify-end gap-2">
+					<Button type="button" variant="ghost" size="sm" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button
+						type="button"
+						size="sm"
+						disabled={isSaving}
+						onClick={handleSave}
+					>
+						{isSaving ? (
+							<>
+								<Spinner className="size-3" />
+								Saving...
+							</>
+						) : isEdit ? (
+							"Save changes"
+						) : (
+							"Create rule"
+						)}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/features/settings/components/alerts-section.tsx
+++ b/frontend/src/features/settings/components/alerts-section.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "lucide-react";
+import { PencilIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -22,13 +22,6 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
@@ -41,31 +34,20 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 
-import type { AlertRulePayload } from "../api/create-alert-rule";
 import type { AlertHistoryEntry } from "../api/get-alert-history";
-import type { AlertEventKind, AlertRule } from "../api/get-alert-rules";
+import type { AlertRule } from "../api/get-alert-rules";
 import {
 	useAlertHistory,
 	useAlertRules,
 	useAlertWebhook,
 	useClearAlertHistory,
-	useCreateAlertRule,
 	useDeleteAlertRule,
 	useTestAlertWebhook,
 	useUpdateAlertRule,
 	useUpdateAlertWebhook,
 } from "../hooks/use-alerts";
+import { AlertRuleDialog } from "./alert-rule-dialog";
 import { showResultToast } from "./mutation-toast";
-
-const LOG_LEVELS = [
-	"TRACE",
-	"DEBUG",
-	"INFO",
-	"WARN",
-	"ERROR",
-	"FATAL",
-	"PANIC",
-];
 
 const HISTORY_LIMIT = 50;
 
@@ -190,113 +172,6 @@ function WebhookBlock() {
 	);
 }
 
-interface RuleFormState {
-	name: string;
-	type: "log" | "event";
-	minLevel: string;
-	pattern: string;
-	die: boolean;
-	oom: boolean;
-	threshold: string;
-	windowSeconds: string;
-	containers: string;
-	projects: string;
-	hosts: string;
-	cooldownSeconds: string;
-}
-
-const EMPTY_FORM: RuleFormState = {
-	name: "",
-	type: "log",
-	minLevel: "any",
-	pattern: "",
-	die: false,
-	oom: false,
-	threshold: "1",
-	windowSeconds: "",
-	containers: "",
-	projects: "",
-	hosts: "",
-	cooldownSeconds: "",
-};
-
-function splitList(value: string): string[] {
-	return value
-		.split(",")
-		.map((s) => s.trim())
-		.filter(Boolean);
-}
-
-function ruleToForm(rule: AlertRule): RuleFormState {
-	return {
-		name: rule.name,
-		type: rule.type,
-		minLevel: rule.minLevel ?? "any",
-		pattern: rule.pattern ?? "",
-		die: rule.events?.includes("die") ?? false,
-		oom: rule.events?.includes("oom") ?? false,
-		threshold: String(rule.threshold),
-		windowSeconds: rule.windowSeconds ? String(rule.windowSeconds) : "",
-		containers: rule.containers?.join(", ") ?? "",
-		projects: rule.projects?.join(", ") ?? "",
-		hosts: rule.hosts?.join(", ") ?? "",
-		cooldownSeconds: rule.cooldownSeconds ? String(rule.cooldownSeconds) : "",
-	};
-}
-
-function buildPayload(
-	form: RuleFormState,
-): { error: string } | { payload: AlertRulePayload } {
-	const name = form.name.trim();
-	if (!name) return { error: "Rule name is required" };
-
-	const payload: AlertRulePayload = {
-		name,
-		enabled: true,
-		type: form.type,
-		threshold: 1,
-	};
-
-	if (form.type === "log") {
-		const pattern = form.pattern.trim();
-		if (form.minLevel === "any" && !pattern) {
-			return { error: "Log rules need a minimum level or a pattern" };
-		}
-		if (form.minLevel !== "any") payload.minLevel = form.minLevel;
-		if (pattern) payload.pattern = pattern;
-	} else {
-		const events: AlertEventKind[] = [];
-		if (form.die) events.push("die");
-		if (form.oom) events.push("oom");
-		if (events.length === 0) {
-			return { error: "Event rules need at least one event" };
-		}
-		payload.events = events;
-	}
-
-	const threshold = Number.parseInt(form.threshold, 10);
-	if (!Number.isNaN(threshold) && threshold > 0) payload.threshold = threshold;
-
-	const windowSeconds = Number.parseInt(form.windowSeconds, 10);
-	if (!Number.isNaN(windowSeconds) && windowSeconds > 0) {
-		payload.windowSeconds = windowSeconds;
-	}
-
-	const cooldownSeconds = Number.parseInt(form.cooldownSeconds, 10);
-	if (!Number.isNaN(cooldownSeconds) && cooldownSeconds > 0) {
-		payload.cooldownSeconds = cooldownSeconds;
-	}
-
-	const containers = splitList(form.containers);
-	if (containers.length > 0) payload.containers = containers;
-	const projects = splitList(form.projects);
-	if (projects.length > 0) payload.projects = projects;
-	const hosts = splitList(form.hosts);
-	if (hosts.length > 0) payload.hosts = hosts;
-
-	return { payload };
-}
-
 function renderTarget(rule: AlertRule): string {
 	const parts: string[] = [];
 	if (rule.hosts?.length) parts.push(`hosts: ${rule.hosts.join(", ")}`);
@@ -328,94 +203,25 @@ function renderTrigger(rule: AlertRule): string {
 	return parts.filter(Boolean).join(" · ");
 }
 
-function EventCheckbox({
-	label,
-	checked,
-	onToggle,
-}: {
-	label: string;
-	checked: boolean;
-	onToggle: () => void;
-}) {
-	return (
-		<label className="flex items-center gap-2 cursor-pointer text-sm">
-			<button
-				type="button"
-				onClick={onToggle}
-				aria-pressed={checked}
-				className={`size-4 rounded border flex items-center justify-center ${
-					checked ? "bg-primary border-primary" : "border-input"
-				}`}
-			>
-				{checked && <CheckIcon className="size-3 text-primary-foreground" />}
-			</button>
-			{label}
-		</label>
-	);
-}
-
 function RulesBlock() {
 	const { data, isLoading, error } = useAlertRules();
-	const createMutation = useCreateAlertRule();
 	const updateMutation = useUpdateAlertRule();
 	const deleteMutation = useDeleteAlertRule();
 
-	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
 	const [editingRule, setEditingRule] = useState<AlertRule | null>(null);
-	const [form, setForm] = useState<RuleFormState>(EMPTY_FORM);
 	const [ruleToDelete, setRuleToDelete] = useState<AlertRule | null>(null);
 
 	const rules = data?.rules ?? [];
 
-	function set<K extends keyof RuleFormState>(key: K, value: RuleFormState[K]) {
-		setForm((prev) => ({ ...prev, [key]: value }));
-	}
-
 	function openCreate() {
 		setEditingRule(null);
-		setForm(EMPTY_FORM);
-		setIsFormOpen(true);
+		setIsDialogOpen(true);
 	}
 
 	function openEdit(rule: AlertRule) {
 		setEditingRule(rule);
-		setForm(ruleToForm(rule));
-		setIsFormOpen(true);
-	}
-
-	function closeForm() {
-		setIsFormOpen(false);
-		setEditingRule(null);
-		setForm(EMPTY_FORM);
-	}
-
-	function handleSave() {
-		const result = buildPayload(form);
-		if ("error" in result) {
-			toast.error(result.error);
-			return;
-		}
-		if (editingRule) {
-			const payload = { ...result.payload, enabled: editingRule.enabled };
-			updateMutation.mutate(
-				{ id: editingRule.id, rule: payload },
-				{
-					onSuccess: (rule) => {
-						toast.success(`Rule "${rule.name}" updated`);
-						closeForm();
-					},
-					onError: (err) => toast.error(err.message),
-				},
-			);
-		} else {
-			createMutation.mutate(result.payload, {
-				onSuccess: (rule) => {
-					toast.success(`Rule "${rule.name}" created`);
-					closeForm();
-				},
-				onError: (err) => toast.error(err.message),
-			});
-		}
+		setIsDialogOpen(true);
 	}
 
 	function handleToggle(rule: AlertRule, enabled: boolean) {
@@ -438,8 +244,6 @@ function RulesBlock() {
 		deleteMutation.mutate(ruleToDelete.id, showResultToast);
 		setRuleToDelete(null);
 	}
-
-	const isSaving = createMutation.isPending || updateMutation.isPending;
 
 	return (
 		<div className="space-y-3">
@@ -497,8 +301,9 @@ function RulesBlock() {
 											variant="ghost"
 											size="sm"
 											onClick={() => openEdit(rule)}
+											aria-label={`Edit rule ${rule.name}`}
 										>
-											Edit
+											<PencilIcon className="size-3.5" />
 										</Button>
 										<Button
 											variant="ghost"
@@ -517,217 +322,15 @@ function RulesBlock() {
 				</Table>
 			)}
 
-			{isFormOpen ? (
-				<div className="border rounded-md p-3 space-y-3">
-					<div className="flex items-end gap-3">
-						<div className="space-y-1.5 flex-1">
-							<Label htmlFor="alert-rule-name">Name</Label>
-							<Input
-								id="alert-rule-name"
-								value={form.name}
-								onChange={(e) => set("name", e.target.value)}
-								placeholder="api errors"
-								className="h-8"
-								maxLength={64}
-							/>
-						</div>
-						<div className="flex gap-1">
-							<Button
-								type="button"
-								size="sm"
-								variant={form.type === "log" ? "default" : "outline"}
-								onClick={() => set("type", "log")}
-							>
-								Log
-							</Button>
-							<Button
-								type="button"
-								size="sm"
-								variant={form.type === "event" ? "default" : "outline"}
-								onClick={() => set("type", "event")}
-							>
-								Event
-							</Button>
-						</div>
-					</div>
+			<Button variant="outline" size="sm" onClick={openCreate}>
+				Create rule
+			</Button>
 
-					{form.type === "log" ? (
-						<div className="flex items-end gap-3 flex-wrap">
-							<div className="space-y-1.5">
-								<Label>Min level</Label>
-								<Select
-									value={form.minLevel}
-									onValueChange={(v) => set("minLevel", v)}
-								>
-									<SelectTrigger size="sm" className="w-32">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="any">any</SelectItem>
-										{LOG_LEVELS.map((level) => (
-											<SelectItem key={level} value={level}>
-												{level}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							</div>
-							<div className="space-y-1.5 flex-1 min-w-40">
-								<Label htmlFor="alert-rule-pattern">Pattern (regex)</Label>
-								<Input
-									id="alert-rule-pattern"
-									value={form.pattern}
-									onChange={(e) => set("pattern", e.target.value)}
-									placeholder="connection refused"
-									className="h-8 font-mono"
-								/>
-							</div>
-							<div className="space-y-1.5 w-24">
-								<Label htmlFor="alert-rule-threshold">Threshold</Label>
-								<Input
-									id="alert-rule-threshold"
-									type="number"
-									min={1}
-									max={1000}
-									value={form.threshold}
-									onChange={(e) => set("threshold", e.target.value)}
-									className="h-8"
-								/>
-							</div>
-							<div className="space-y-1.5 w-28">
-								<Label htmlFor="alert-rule-window">Window (s)</Label>
-								<Input
-									id="alert-rule-window"
-									type="number"
-									min={5}
-									max={3600}
-									value={form.windowSeconds}
-									onChange={(e) => set("windowSeconds", e.target.value)}
-									placeholder="60"
-									className="h-8"
-								/>
-							</div>
-						</div>
-					) : (
-						<div className="space-y-2">
-							<div className="flex items-end gap-3 flex-wrap">
-								<div className="flex items-center gap-4 h-8">
-									<EventCheckbox
-										label="die"
-										checked={form.die}
-										onToggle={() => set("die", !form.die)}
-									/>
-									<EventCheckbox
-										label="oom"
-										checked={form.oom}
-										onToggle={() => set("oom", !form.oom)}
-									/>
-								</div>
-								<div className="space-y-1.5 w-24">
-									<Label htmlFor="alert-rule-threshold">Threshold</Label>
-									<Input
-										id="alert-rule-threshold"
-										type="number"
-										min={1}
-										max={1000}
-										value={form.threshold}
-										onChange={(e) => set("threshold", e.target.value)}
-										className="h-8"
-									/>
-								</div>
-								<div className="space-y-1.5 w-28">
-									<Label htmlFor="alert-rule-window">Window (s)</Label>
-									<Input
-										id="alert-rule-window"
-										type="number"
-										min={5}
-										max={3600}
-										value={form.windowSeconds}
-										onChange={(e) => set("windowSeconds", e.target.value)}
-										placeholder="120"
-										className="h-8"
-									/>
-								</div>
-							</div>
-							<p className="text-xs text-muted-foreground">
-								Tip: threshold 3 in a 120s window catches crash-loops.
-							</p>
-						</div>
-					)}
-
-					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-						<div className="space-y-1.5">
-							<Label htmlFor="alert-rule-containers">Containers</Label>
-							<Input
-								id="alert-rule-containers"
-								value={form.containers}
-								onChange={(e) => set("containers", e.target.value)}
-								placeholder="api, worker"
-								className="h-8"
-							/>
-						</div>
-						<div className="space-y-1.5">
-							<Label htmlFor="alert-rule-projects">Projects</Label>
-							<Input
-								id="alert-rule-projects"
-								value={form.projects}
-								onChange={(e) => set("projects", e.target.value)}
-								placeholder="myapp"
-								className="h-8"
-							/>
-						</div>
-						<div className="space-y-1.5">
-							<Label htmlFor="alert-rule-hosts">Hosts</Label>
-							<Input
-								id="alert-rule-hosts"
-								value={form.hosts}
-								onChange={(e) => set("hosts", e.target.value)}
-								placeholder="local"
-								className="h-8"
-							/>
-						</div>
-						<div className="space-y-1.5">
-							<Label htmlFor="alert-rule-cooldown">Cooldown (s)</Label>
-							<Input
-								id="alert-rule-cooldown"
-								type="number"
-								min={0}
-								max={86400}
-								value={form.cooldownSeconds}
-								onChange={(e) => set("cooldownSeconds", e.target.value)}
-								placeholder="300 (default)"
-								className="h-8"
-							/>
-						</div>
-					</div>
-					<p className="text-xs text-muted-foreground">
-						Containers, projects, and hosts are comma-separated. Leave empty to
-						match all containers.
-					</p>
-
-					<div className="flex gap-1">
-						<Button size="sm" disabled={isSaving} onClick={handleSave}>
-							{isSaving ? (
-								<>
-									<Spinner className="size-3" />
-									Saving...
-								</>
-							) : editingRule ? (
-								"Save"
-							) : (
-								"Create"
-							)}
-						</Button>
-						<Button size="sm" variant="ghost" onClick={closeForm}>
-							Cancel
-						</Button>
-					</div>
-				</div>
-			) : (
-				<Button variant="outline" size="sm" onClick={openCreate}>
-					Create rule
-				</Button>
-			)}
+			<AlertRuleDialog
+				open={isDialogOpen}
+				onOpenChange={setIsDialogOpen}
+				rule={editingRule}
+			/>
 
 			<AlertDialog
 				open={ruleToDelete !== null}

--- a/frontend/src/features/settings/components/alerts-section.tsx
+++ b/frontend/src/features/settings/components/alerts-section.tsx
@@ -320,7 +320,11 @@ function renderTrigger(rule: AlertRule): string {
 	if (rule.threshold > 1) {
 		parts.push(`${rule.threshold} in ${rule.windowSeconds ?? 0}s`);
 	}
-	if (rule.cooldownSeconds) parts.push(`cooldown ${rule.cooldownSeconds}s`);
+	if (rule.cooldownSeconds) {
+		parts.push(`cooldown ${rule.cooldownSeconds}s`);
+	} else {
+		parts.push("cooldown 300s (default)");
+	}
 	return parts.filter(Boolean).join(" · ");
 }
 
@@ -584,6 +588,7 @@ function RulesBlock() {
 									id="alert-rule-threshold"
 									type="number"
 									min={1}
+									max={1000}
 									value={form.threshold}
 									onChange={(e) => set("threshold", e.target.value)}
 									className="h-8"
@@ -594,7 +599,8 @@ function RulesBlock() {
 								<Input
 									id="alert-rule-window"
 									type="number"
-									min={1}
+									min={5}
+									max={3600}
 									value={form.windowSeconds}
 									onChange={(e) => set("windowSeconds", e.target.value)}
 									placeholder="60"
@@ -623,6 +629,7 @@ function RulesBlock() {
 										id="alert-rule-threshold"
 										type="number"
 										min={1}
+										max={1000}
 										value={form.threshold}
 										onChange={(e) => set("threshold", e.target.value)}
 										className="h-8"
@@ -633,7 +640,8 @@ function RulesBlock() {
 									<Input
 										id="alert-rule-window"
 										type="number"
-										min={1}
+										min={5}
+										max={3600}
 										value={form.windowSeconds}
 										onChange={(e) => set("windowSeconds", e.target.value)}
 										placeholder="120"
@@ -683,10 +691,11 @@ function RulesBlock() {
 							<Input
 								id="alert-rule-cooldown"
 								type="number"
-								min={1}
+								min={0}
+								max={86400}
 								value={form.cooldownSeconds}
 								onChange={(e) => set("cooldownSeconds", e.target.value)}
-								placeholder="300"
+								placeholder="300 (default)"
 								className="h-8"
 							/>
 						</div>

--- a/frontend/src/features/settings/components/alerts-section.tsx
+++ b/frontend/src/features/settings/components/alerts-section.tsx
@@ -828,41 +828,45 @@ function HistoryBlock() {
 			)}
 
 			{alerts.length > 0 && (
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<TableHead>Time</TableHead>
-							<TableHead>Rule</TableHead>
-							<TableHead>Container</TableHead>
-							<TableHead>Reason</TableHead>
-							<TableHead>Delivery</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{alerts.map((entry) => (
-							<TableRow key={entry.id}>
-								<TableCell className="text-xs text-muted-foreground whitespace-nowrap">
-									{new Date(entry.firedAt).toLocaleString()}
-								</TableCell>
-								<TableCell className="font-medium">{entry.ruleName}</TableCell>
-								<TableCell className="text-xs text-muted-foreground font-mono">
-									{entry.containerName}@{entry.host}
-								</TableCell>
-								<TableCell className="text-xs text-muted-foreground">
-									{entry.reason}
-									{entry.suppressed > 0 && (
-										<span className="ml-1.5 text-muted-foreground/70">
-											(+{entry.suppressed} suppressed)
-										</span>
-									)}
-								</TableCell>
-								<TableCell>
-									<DeliveryStatus entry={entry} />
-								</TableCell>
+				<div className="max-h-80 overflow-y-auto rounded-md border">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Time</TableHead>
+								<TableHead>Rule</TableHead>
+								<TableHead>Container</TableHead>
+								<TableHead>Reason</TableHead>
+								<TableHead>Delivery</TableHead>
 							</TableRow>
-						))}
-					</TableBody>
-				</Table>
+						</TableHeader>
+						<TableBody>
+							{alerts.map((entry) => (
+								<TableRow key={entry.id}>
+									<TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+										{new Date(entry.firedAt).toLocaleString()}
+									</TableCell>
+									<TableCell className="font-medium">
+										{entry.ruleName}
+									</TableCell>
+									<TableCell className="text-xs text-muted-foreground font-mono">
+										{entry.containerName}@{entry.host}
+									</TableCell>
+									<TableCell className="text-xs text-muted-foreground">
+										{entry.reason}
+										{entry.suppressed > 0 && (
+											<span className="ml-1.5 text-muted-foreground/70">
+												(+{entry.suppressed} suppressed)
+											</span>
+										)}
+									</TableCell>
+									<TableCell>
+										<DeliveryStatus entry={entry} />
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
 			)}
 
 			<AlertDialog open={isClearOpen} onOpenChange={setIsClearOpen}>

--- a/frontend/src/features/settings/components/alerts-section.tsx
+++ b/frontend/src/features/settings/components/alerts-section.tsx
@@ -1,0 +1,880 @@
+import { CheckIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+import type { AlertRulePayload } from "../api/create-alert-rule";
+import type { AlertHistoryEntry } from "../api/get-alert-history";
+import type { AlertEventKind, AlertRule } from "../api/get-alert-rules";
+import {
+	useAlertHistory,
+	useAlertRules,
+	useAlertWebhook,
+	useClearAlertHistory,
+	useCreateAlertRule,
+	useDeleteAlertRule,
+	useTestAlertWebhook,
+	useUpdateAlertRule,
+	useUpdateAlertWebhook,
+} from "../hooks/use-alerts";
+import { showResultToast } from "./mutation-toast";
+
+const LOG_LEVELS = [
+	"TRACE",
+	"DEBUG",
+	"INFO",
+	"WARN",
+	"ERROR",
+	"FATAL",
+	"PANIC",
+];
+
+const HISTORY_LIMIT = 50;
+
+export function AlertsSection() {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Alerts</CardTitle>
+				<CardDescription>
+					Get notified when containers die, run out of memory, or log errors.
+					Alerts are delivered to a webhook and recorded in the history below.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-6">
+				<WebhookBlock />
+				<Separator />
+				<RulesBlock />
+				<Separator />
+				<HistoryBlock />
+			</CardContent>
+		</Card>
+	);
+}
+
+function WebhookBlock() {
+	const { data, isLoading, error } = useAlertWebhook();
+	const updateMutation = useUpdateAlertWebhook();
+	const testMutation = useTestAlertWebhook();
+
+	const [draft, setDraft] = useState<string | null>(null);
+
+	const savedUrl = data?.url ?? "";
+	const url = draft ?? savedUrl;
+
+	function handleSave() {
+		updateMutation.mutate(url.trim(), {
+			onSuccess: (message) => {
+				toast.success(message);
+				setDraft(null);
+			},
+			onError: (err) => toast.error(err.message),
+		});
+	}
+
+	function handleTest() {
+		testMutation.mutate(undefined, {
+			onSuccess: (result) => {
+				if (result.status === "ok") {
+					toast.success("Test alert delivered");
+				} else {
+					const status = result.httpStatus
+						? ` (HTTP ${result.httpStatus})`
+						: "";
+					const detail = result.error ? `: ${result.error}` : "";
+					toast.error(`Test alert failed${status}${detail}`);
+				}
+			},
+			onError: (err) => toast.error(err.message),
+		});
+	}
+
+	return (
+		<div className="space-y-3">
+			<h3 className="text-sm font-medium">Webhook</h3>
+			{isLoading && <Spinner className="size-4" />}
+			{error && (
+				<p className="text-sm text-destructive">
+					Failed to load webhook: {error.message}
+				</p>
+			)}
+			{!isLoading && !error && (
+				<>
+					<div className="flex items-end gap-2">
+						<div className="space-y-1.5 flex-1">
+							<Label htmlFor="alert-webhook-url">URL</Label>
+							<Input
+								id="alert-webhook-url"
+								value={url}
+								onChange={(e) => setDraft(e.target.value)}
+								placeholder="https://example.com/webhook"
+								className="h-8"
+							/>
+						</div>
+						<Button
+							size="sm"
+							disabled={updateMutation.isPending || draft === null}
+							onClick={handleSave}
+						>
+							{updateMutation.isPending ? (
+								<>
+									<Spinner className="size-3" />
+									Saving...
+								</>
+							) : (
+								"Save"
+							)}
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={testMutation.isPending}
+							onClick={handleTest}
+						>
+							{testMutation.isPending ? (
+								<>
+									<Spinner className="size-3" />
+									Sending...
+								</>
+							) : (
+								"Send test"
+							)}
+						</Button>
+					</div>
+					{savedUrl === "" && (
+						<p className="text-xs text-muted-foreground">
+							(no webhook configured — alerts are recorded in history only)
+						</p>
+					)}
+				</>
+			)}
+		</div>
+	);
+}
+
+interface RuleFormState {
+	name: string;
+	type: "log" | "event";
+	minLevel: string;
+	pattern: string;
+	die: boolean;
+	oom: boolean;
+	threshold: string;
+	windowSeconds: string;
+	containers: string;
+	projects: string;
+	hosts: string;
+	cooldownSeconds: string;
+}
+
+const EMPTY_FORM: RuleFormState = {
+	name: "",
+	type: "log",
+	minLevel: "any",
+	pattern: "",
+	die: false,
+	oom: false,
+	threshold: "1",
+	windowSeconds: "",
+	containers: "",
+	projects: "",
+	hosts: "",
+	cooldownSeconds: "",
+};
+
+function splitList(value: string): string[] {
+	return value
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+function ruleToForm(rule: AlertRule): RuleFormState {
+	return {
+		name: rule.name,
+		type: rule.type,
+		minLevel: rule.minLevel ?? "any",
+		pattern: rule.pattern ?? "",
+		die: rule.events?.includes("die") ?? false,
+		oom: rule.events?.includes("oom") ?? false,
+		threshold: String(rule.threshold),
+		windowSeconds: rule.windowSeconds ? String(rule.windowSeconds) : "",
+		containers: rule.containers?.join(", ") ?? "",
+		projects: rule.projects?.join(", ") ?? "",
+		hosts: rule.hosts?.join(", ") ?? "",
+		cooldownSeconds: rule.cooldownSeconds ? String(rule.cooldownSeconds) : "",
+	};
+}
+
+function buildPayload(
+	form: RuleFormState,
+): { error: string } | { payload: AlertRulePayload } {
+	const name = form.name.trim();
+	if (!name) return { error: "Rule name is required" };
+
+	const payload: AlertRulePayload = {
+		name,
+		enabled: true,
+		type: form.type,
+		threshold: 1,
+	};
+
+	if (form.type === "log") {
+		const pattern = form.pattern.trim();
+		if (form.minLevel === "any" && !pattern) {
+			return { error: "Log rules need a minimum level or a pattern" };
+		}
+		if (form.minLevel !== "any") payload.minLevel = form.minLevel;
+		if (pattern) payload.pattern = pattern;
+	} else {
+		const events: AlertEventKind[] = [];
+		if (form.die) events.push("die");
+		if (form.oom) events.push("oom");
+		if (events.length === 0) {
+			return { error: "Event rules need at least one event" };
+		}
+		payload.events = events;
+	}
+
+	const threshold = Number.parseInt(form.threshold, 10);
+	if (!Number.isNaN(threshold) && threshold > 0) payload.threshold = threshold;
+
+	const windowSeconds = Number.parseInt(form.windowSeconds, 10);
+	if (!Number.isNaN(windowSeconds) && windowSeconds > 0) {
+		payload.windowSeconds = windowSeconds;
+	}
+
+	const cooldownSeconds = Number.parseInt(form.cooldownSeconds, 10);
+	if (!Number.isNaN(cooldownSeconds) && cooldownSeconds > 0) {
+		payload.cooldownSeconds = cooldownSeconds;
+	}
+
+	const containers = splitList(form.containers);
+	if (containers.length > 0) payload.containers = containers;
+	const projects = splitList(form.projects);
+	if (projects.length > 0) payload.projects = projects;
+	const hosts = splitList(form.hosts);
+	if (hosts.length > 0) payload.hosts = hosts;
+
+	return { payload };
+}
+
+function renderTarget(rule: AlertRule): string {
+	const parts: string[] = [];
+	if (rule.hosts?.length) parts.push(`hosts: ${rule.hosts.join(", ")}`);
+	if (rule.containers?.length) {
+		parts.push(`containers: ${rule.containers.join(", ")}`);
+	}
+	if (rule.projects?.length) {
+		parts.push(`projects: ${rule.projects.join(", ")}`);
+	}
+	return parts.length > 0 ? parts.join(" · ") : "all containers";
+}
+
+function renderTrigger(rule: AlertRule): string {
+	const parts: string[] = [];
+	if (rule.type === "log") {
+		if (rule.minLevel) parts.push(`level >= ${rule.minLevel}`);
+		if (rule.pattern) parts.push(`pattern /${rule.pattern}/`);
+	} else {
+		parts.push((rule.events ?? []).join(", "));
+	}
+	if (rule.threshold > 1) {
+		parts.push(`${rule.threshold} in ${rule.windowSeconds ?? 0}s`);
+	}
+	if (rule.cooldownSeconds) parts.push(`cooldown ${rule.cooldownSeconds}s`);
+	return parts.filter(Boolean).join(" · ");
+}
+
+function EventCheckbox({
+	label,
+	checked,
+	onToggle,
+}: {
+	label: string;
+	checked: boolean;
+	onToggle: () => void;
+}) {
+	return (
+		<label className="flex items-center gap-2 cursor-pointer text-sm">
+			<button
+				type="button"
+				onClick={onToggle}
+				aria-pressed={checked}
+				className={`size-4 rounded border flex items-center justify-center ${
+					checked ? "bg-primary border-primary" : "border-input"
+				}`}
+			>
+				{checked && <CheckIcon className="size-3 text-primary-foreground" />}
+			</button>
+			{label}
+		</label>
+	);
+}
+
+function RulesBlock() {
+	const { data, isLoading, error } = useAlertRules();
+	const createMutation = useCreateAlertRule();
+	const updateMutation = useUpdateAlertRule();
+	const deleteMutation = useDeleteAlertRule();
+
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [editingRule, setEditingRule] = useState<AlertRule | null>(null);
+	const [form, setForm] = useState<RuleFormState>(EMPTY_FORM);
+	const [ruleToDelete, setRuleToDelete] = useState<AlertRule | null>(null);
+
+	const rules = data?.rules ?? [];
+
+	function set<K extends keyof RuleFormState>(key: K, value: RuleFormState[K]) {
+		setForm((prev) => ({ ...prev, [key]: value }));
+	}
+
+	function openCreate() {
+		setEditingRule(null);
+		setForm(EMPTY_FORM);
+		setIsFormOpen(true);
+	}
+
+	function openEdit(rule: AlertRule) {
+		setEditingRule(rule);
+		setForm(ruleToForm(rule));
+		setIsFormOpen(true);
+	}
+
+	function closeForm() {
+		setIsFormOpen(false);
+		setEditingRule(null);
+		setForm(EMPTY_FORM);
+	}
+
+	function handleSave() {
+		const result = buildPayload(form);
+		if ("error" in result) {
+			toast.error(result.error);
+			return;
+		}
+		if (editingRule) {
+			const payload = { ...result.payload, enabled: editingRule.enabled };
+			updateMutation.mutate(
+				{ id: editingRule.id, rule: payload },
+				{
+					onSuccess: (rule) => {
+						toast.success(`Rule "${rule.name}" updated`);
+						closeForm();
+					},
+					onError: (err) => toast.error(err.message),
+				},
+			);
+		} else {
+			createMutation.mutate(result.payload, {
+				onSuccess: (rule) => {
+					toast.success(`Rule "${rule.name}" created`);
+					closeForm();
+				},
+				onError: (err) => toast.error(err.message),
+			});
+		}
+	}
+
+	function handleToggle(rule: AlertRule, enabled: boolean) {
+		const { id: _id, createdAt: _createdAt, ...payload } = rule;
+		updateMutation.mutate(
+			{ id: rule.id, rule: { ...payload, enabled } },
+			{
+				onSuccess: (updated) => {
+					toast.success(
+						`Rule "${updated.name}" ${updated.enabled ? "enabled" : "disabled"}`,
+					);
+				},
+				onError: (err) => toast.error(err.message),
+			},
+		);
+	}
+
+	function handleDelete() {
+		if (!ruleToDelete) return;
+		deleteMutation.mutate(ruleToDelete.id, showResultToast);
+		setRuleToDelete(null);
+	}
+
+	const isSaving = createMutation.isPending || updateMutation.isPending;
+
+	return (
+		<div className="space-y-3">
+			<h3 className="text-sm font-medium">Rules</h3>
+
+			{isLoading && <Spinner className="size-4" />}
+			{error && (
+				<p className="text-sm text-destructive">
+					Failed to load alert rules: {error.message}
+				</p>
+			)}
+
+			{!isLoading && !error && rules.length === 0 && (
+				<p className="text-sm text-muted-foreground">
+					No alert rules created yet.
+				</p>
+			)}
+
+			{rules.length > 0 && (
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Name</TableHead>
+							<TableHead>Type</TableHead>
+							<TableHead>Target</TableHead>
+							<TableHead>Trigger</TableHead>
+							<TableHead>Enabled</TableHead>
+							<TableHead className="text-right">Actions</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{rules.map((rule) => (
+							<TableRow key={rule.id}>
+								<TableCell className="font-medium">{rule.name}</TableCell>
+								<TableCell className="text-xs text-muted-foreground">
+									{rule.type}
+								</TableCell>
+								<TableCell className="text-xs text-muted-foreground">
+									{renderTarget(rule)}
+								</TableCell>
+								<TableCell className="text-xs text-muted-foreground font-mono">
+									{renderTrigger(rule)}
+								</TableCell>
+								<TableCell>
+									<Switch
+										checked={rule.enabled}
+										onCheckedChange={(checked) => handleToggle(rule, checked)}
+										disabled={updateMutation.isPending}
+										aria-label={`Toggle rule ${rule.name}`}
+									/>
+								</TableCell>
+								<TableCell className="text-right">
+									<div className="flex items-center justify-end gap-1">
+										<Button
+											variant="ghost"
+											size="sm"
+											onClick={() => openEdit(rule)}
+										>
+											Edit
+										</Button>
+										<Button
+											variant="ghost"
+											size="sm"
+											disabled={deleteMutation.isPending}
+											onClick={() => setRuleToDelete(rule)}
+											className="text-destructive hover:text-destructive"
+										>
+											Delete
+										</Button>
+									</div>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
+
+			{isFormOpen ? (
+				<div className="border rounded-md p-3 space-y-3">
+					<div className="flex items-end gap-3">
+						<div className="space-y-1.5 flex-1">
+							<Label htmlFor="alert-rule-name">Name</Label>
+							<Input
+								id="alert-rule-name"
+								value={form.name}
+								onChange={(e) => set("name", e.target.value)}
+								placeholder="api errors"
+								className="h-8"
+								maxLength={64}
+							/>
+						</div>
+						<div className="flex gap-1">
+							<Button
+								type="button"
+								size="sm"
+								variant={form.type === "log" ? "default" : "outline"}
+								onClick={() => set("type", "log")}
+							>
+								Log
+							</Button>
+							<Button
+								type="button"
+								size="sm"
+								variant={form.type === "event" ? "default" : "outline"}
+								onClick={() => set("type", "event")}
+							>
+								Event
+							</Button>
+						</div>
+					</div>
+
+					{form.type === "log" ? (
+						<div className="flex items-end gap-3 flex-wrap">
+							<div className="space-y-1.5">
+								<Label>Min level</Label>
+								<Select
+									value={form.minLevel}
+									onValueChange={(v) => set("minLevel", v)}
+								>
+									<SelectTrigger size="sm" className="w-32">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="any">any</SelectItem>
+										{LOG_LEVELS.map((level) => (
+											<SelectItem key={level} value={level}>
+												{level}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="space-y-1.5 flex-1 min-w-40">
+								<Label htmlFor="alert-rule-pattern">Pattern (regex)</Label>
+								<Input
+									id="alert-rule-pattern"
+									value={form.pattern}
+									onChange={(e) => set("pattern", e.target.value)}
+									placeholder="connection refused"
+									className="h-8 font-mono"
+								/>
+							</div>
+							<div className="space-y-1.5 w-24">
+								<Label htmlFor="alert-rule-threshold">Threshold</Label>
+								<Input
+									id="alert-rule-threshold"
+									type="number"
+									min={1}
+									value={form.threshold}
+									onChange={(e) => set("threshold", e.target.value)}
+									className="h-8"
+								/>
+							</div>
+							<div className="space-y-1.5 w-28">
+								<Label htmlFor="alert-rule-window">Window (s)</Label>
+								<Input
+									id="alert-rule-window"
+									type="number"
+									min={1}
+									value={form.windowSeconds}
+									onChange={(e) => set("windowSeconds", e.target.value)}
+									placeholder="60"
+									className="h-8"
+								/>
+							</div>
+						</div>
+					) : (
+						<div className="space-y-2">
+							<div className="flex items-end gap-3 flex-wrap">
+								<div className="flex items-center gap-4 h-8">
+									<EventCheckbox
+										label="die"
+										checked={form.die}
+										onToggle={() => set("die", !form.die)}
+									/>
+									<EventCheckbox
+										label="oom"
+										checked={form.oom}
+										onToggle={() => set("oom", !form.oom)}
+									/>
+								</div>
+								<div className="space-y-1.5 w-24">
+									<Label htmlFor="alert-rule-threshold">Threshold</Label>
+									<Input
+										id="alert-rule-threshold"
+										type="number"
+										min={1}
+										value={form.threshold}
+										onChange={(e) => set("threshold", e.target.value)}
+										className="h-8"
+									/>
+								</div>
+								<div className="space-y-1.5 w-28">
+									<Label htmlFor="alert-rule-window">Window (s)</Label>
+									<Input
+										id="alert-rule-window"
+										type="number"
+										min={1}
+										value={form.windowSeconds}
+										onChange={(e) => set("windowSeconds", e.target.value)}
+										placeholder="120"
+										className="h-8"
+									/>
+								</div>
+							</div>
+							<p className="text-xs text-muted-foreground">
+								Tip: threshold 3 in a 120s window catches crash-loops.
+							</p>
+						</div>
+					)}
+
+					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+						<div className="space-y-1.5">
+							<Label htmlFor="alert-rule-containers">Containers</Label>
+							<Input
+								id="alert-rule-containers"
+								value={form.containers}
+								onChange={(e) => set("containers", e.target.value)}
+								placeholder="api, worker"
+								className="h-8"
+							/>
+						</div>
+						<div className="space-y-1.5">
+							<Label htmlFor="alert-rule-projects">Projects</Label>
+							<Input
+								id="alert-rule-projects"
+								value={form.projects}
+								onChange={(e) => set("projects", e.target.value)}
+								placeholder="myapp"
+								className="h-8"
+							/>
+						</div>
+						<div className="space-y-1.5">
+							<Label htmlFor="alert-rule-hosts">Hosts</Label>
+							<Input
+								id="alert-rule-hosts"
+								value={form.hosts}
+								onChange={(e) => set("hosts", e.target.value)}
+								placeholder="local"
+								className="h-8"
+							/>
+						</div>
+						<div className="space-y-1.5">
+							<Label htmlFor="alert-rule-cooldown">Cooldown (s)</Label>
+							<Input
+								id="alert-rule-cooldown"
+								type="number"
+								min={1}
+								value={form.cooldownSeconds}
+								onChange={(e) => set("cooldownSeconds", e.target.value)}
+								placeholder="300"
+								className="h-8"
+							/>
+						</div>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Containers, projects, and hosts are comma-separated. Leave empty to
+						match all containers.
+					</p>
+
+					<div className="flex gap-1">
+						<Button size="sm" disabled={isSaving} onClick={handleSave}>
+							{isSaving ? (
+								<>
+									<Spinner className="size-3" />
+									Saving...
+								</>
+							) : editingRule ? (
+								"Save"
+							) : (
+								"Create"
+							)}
+						</Button>
+						<Button size="sm" variant="ghost" onClick={closeForm}>
+							Cancel
+						</Button>
+					</div>
+				</div>
+			) : (
+				<Button variant="outline" size="sm" onClick={openCreate}>
+					Create rule
+				</Button>
+			)}
+
+			<AlertDialog
+				open={ruleToDelete !== null}
+				onOpenChange={(open) => {
+					if (!open) setRuleToDelete(null);
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete alert rule?</AlertDialogTitle>
+						<AlertDialogDescription>
+							The rule "{ruleToDelete?.name}" will stop firing alerts
+							immediately. This cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleDelete}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}
+
+function DeliveryStatus({ entry }: { entry: AlertHistoryEntry }) {
+	if (!entry.delivery) {
+		return <span className="text-xs text-muted-foreground">—</span>;
+	}
+	const ok = entry.delivery.status === "ok";
+	const detail = ok
+		? undefined
+		: [
+				entry.delivery.httpStatus ? `HTTP ${entry.delivery.httpStatus}` : null,
+				entry.delivery.error,
+			]
+				.filter(Boolean)
+				.join(": ");
+	return (
+		<span
+			title={detail}
+			className={`inline-flex items-center gap-1.5 text-xs ${
+				ok
+					? "text-green-600 dark:text-green-400"
+					: "text-red-600 dark:text-red-400"
+			}`}
+		>
+			<span
+				className={`size-1.5 rounded-full ${ok ? "bg-green-500" : "bg-red-500"}`}
+			/>
+			{entry.delivery.status}
+		</span>
+	);
+}
+
+function HistoryBlock() {
+	const { data, isLoading, error } = useAlertHistory(HISTORY_LIMIT);
+	const clearMutation = useClearAlertHistory();
+	const [isClearOpen, setIsClearOpen] = useState(false);
+
+	const alerts = data?.alerts ?? [];
+
+	function handleClear() {
+		clearMutation.mutate(undefined, showResultToast);
+		setIsClearOpen(false);
+	}
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-center justify-between">
+				<h3 className="text-sm font-medium">History</h3>
+				{alerts.length > 0 && (
+					<Button
+						variant="ghost"
+						size="sm"
+						disabled={clearMutation.isPending}
+						onClick={() => setIsClearOpen(true)}
+					>
+						Clear
+					</Button>
+				)}
+			</div>
+
+			{isLoading && <Spinner className="size-4" />}
+			{error && (
+				<p className="text-sm text-destructive">
+					Failed to load alert history: {error.message}
+				</p>
+			)}
+
+			{!isLoading && !error && alerts.length === 0 && (
+				<p className="text-sm text-muted-foreground">No alerts fired yet.</p>
+			)}
+
+			{alerts.length > 0 && (
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Time</TableHead>
+							<TableHead>Rule</TableHead>
+							<TableHead>Container</TableHead>
+							<TableHead>Reason</TableHead>
+							<TableHead>Delivery</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{alerts.map((entry) => (
+							<TableRow key={entry.id}>
+								<TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+									{new Date(entry.firedAt).toLocaleString()}
+								</TableCell>
+								<TableCell className="font-medium">{entry.ruleName}</TableCell>
+								<TableCell className="text-xs text-muted-foreground font-mono">
+									{entry.containerName}@{entry.host}
+								</TableCell>
+								<TableCell className="text-xs text-muted-foreground">
+									{entry.reason}
+									{entry.suppressed > 0 && (
+										<span className="ml-1.5 text-muted-foreground/70">
+											(+{entry.suppressed} suppressed)
+										</span>
+									)}
+								</TableCell>
+								<TableCell>
+									<DeliveryStatus entry={entry} />
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
+
+			<AlertDialog open={isClearOpen} onOpenChange={setIsClearOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Clear alert history?</AlertDialogTitle>
+						<AlertDialogDescription>
+							All recorded alerts will be removed. This cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleClear}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Clear
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}

--- a/frontend/src/features/settings/components/multi-combobox.tsx
+++ b/frontend/src/features/settings/components/multi-combobox.tsx
@@ -1,0 +1,164 @@
+import { XIcon } from "lucide-react";
+import { useId, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface MultiComboboxProps {
+	id?: string;
+	placeholder: string;
+	options: string[];
+	selected: string[];
+	onChange: (values: string[]) => void;
+}
+
+/**
+ * A multi-select combobox: type to filter live suggestions, or enter
+ * arbitrary free text. Selected values render as removable token chips.
+ *
+ * While the list is open the root carries `data-combobox-open`, which the
+ * parent dialog uses to keep Escape from dismissing the whole dialog.
+ */
+export function MultiCombobox({
+	id,
+	placeholder,
+	options,
+	selected,
+	onChange,
+}: MultiComboboxProps) {
+	const listId = useId();
+	const [query, setQuery] = useState("");
+	const [open, setOpen] = useState(false);
+	const [highlight, setHighlight] = useState(0);
+
+	const trimmed = query.trim();
+
+	const items = useMemo(() => {
+		const lower = trimmed.toLowerCase();
+		const matches = options
+			.filter(
+				(option) =>
+					!selected.includes(option) && option.toLowerCase().includes(lower),
+			)
+			.map((value) => ({ value, isNew: false }));
+		const exists =
+			options.some((option) => option.toLowerCase() === lower) ||
+			selected.some((value) => value.toLowerCase() === lower);
+		if (trimmed && !exists) matches.push({ value: trimmed, isNew: true });
+		return matches;
+	}, [options, selected, trimmed]);
+
+	const showList = open && items.length > 0;
+	const activeIndex = Math.min(highlight, items.length - 1);
+
+	function add(value: string) {
+		const next = value.trim();
+		if (!next) return;
+		if (!selected.includes(next)) onChange([...selected, next]);
+		setQuery("");
+		setHighlight(0);
+	}
+
+	function remove(value: string) {
+		onChange(selected.filter((v) => v !== value));
+	}
+
+	function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			setOpen(true);
+			setHighlight((i) => Math.min(i + 1, items.length - 1));
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			setHighlight((i) => Math.max(i - 1, 0));
+		} else if (e.key === "Enter") {
+			e.preventDefault();
+			if (showList && items[activeIndex]) {
+				add(items[activeIndex].value);
+			} else if (trimmed) {
+				add(trimmed);
+			}
+		} else if (e.key === "Escape" && showList) {
+			setOpen(false);
+		}
+	}
+
+	return (
+		<div className="space-y-1.5" data-combobox-open={showList || undefined}>
+			{selected.length > 0 && (
+				<div className="flex flex-wrap gap-1.5">
+					{selected.map((value) => (
+						<Badge
+							key={value}
+							variant="secondary"
+							className="gap-1 overflow-visible pr-1"
+						>
+							{value}
+							<button
+								type="button"
+								aria-label={`Remove ${value}`}
+								onClick={() => remove(value)}
+								className="relative flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors after:absolute after:-inset-3 hover:text-foreground"
+							>
+								<XIcon className="size-3" />
+							</button>
+						</Badge>
+					))}
+				</div>
+			)}
+			<div className="relative">
+				<Input
+					id={id}
+					role="combobox"
+					aria-expanded={showList}
+					aria-controls={listId}
+					aria-activedescendant={
+						showList ? `${listId}-${activeIndex}` : undefined
+					}
+					aria-autocomplete="list"
+					autoComplete="off"
+					value={query}
+					onChange={(e) => {
+						setQuery(e.target.value);
+						setHighlight(0);
+						setOpen(true);
+					}}
+					onFocus={() => setOpen(true)}
+					onBlur={() => setOpen(false)}
+					onKeyDown={handleKeyDown}
+					placeholder={placeholder}
+					className="h-8 text-xs"
+				/>
+				{showList && (
+					<div
+						role="listbox"
+						id={listId}
+						aria-label={placeholder}
+						className="absolute top-full left-0 z-50 mt-1 max-h-48 w-full overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+					>
+						{items.map((item, index) => (
+							// biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled on the input via aria-activedescendant
+							<div
+								key={item.value}
+								id={`${listId}-${index}`}
+								role="option"
+								tabIndex={-1}
+								aria-selected={index === activeIndex}
+								onMouseDown={(e) => e.preventDefault()}
+								onClick={() => add(item.value)}
+								onMouseEnter={() => setHighlight(index)}
+								className={cn(
+									"cursor-default rounded-sm px-2 py-1.5 text-sm",
+									index === activeIndex && "bg-accent text-accent-foreground",
+								)}
+							>
+								{item.isNew ? `Add "${item.value}"` : item.value}
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/features/settings/components/settings-page.tsx
+++ b/frontend/src/features/settings/components/settings-page.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from "@/components/ui/spinner";
 
 import { useSettings } from "../hooks/use-settings";
+import { AlertsSection } from "./alerts-section";
 import { ApiTokensSection } from "./api-tokens-section";
 import { AuthSection } from "./auth-section";
 import { CoolifyHostsSection } from "./coolify-hosts-section";
@@ -54,6 +55,7 @@ export function SettingsPage() {
 				config={data.auth}
 			/>
 			<ApiTokensSection />
+			<AlertsSection />
 		</div>
 	);
 }

--- a/frontend/src/features/settings/hooks/use-alerts.ts
+++ b/frontend/src/features/settings/hooks/use-alerts.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { clearAlertHistory } from "../api/clear-alert-history";
+import {
+	type AlertRulePayload,
+	createAlertRule,
+} from "../api/create-alert-rule";
+import { deleteAlertRule } from "../api/delete-alert-rule";
+import { getAlertHistory } from "../api/get-alert-history";
+import { getAlertRules } from "../api/get-alert-rules";
+import { getAlertWebhook } from "../api/get-alert-webhook";
+import { testAlertWebhook } from "../api/test-alert-webhook";
+import { updateAlertRule } from "../api/update-alert-rule";
+import { updateAlertWebhook } from "../api/update-alert-webhook";
+
+const RULES_KEY = ["alerts", "rules"] as const;
+const WEBHOOK_KEY = ["alerts", "webhook"] as const;
+const HISTORY_KEY = ["alerts", "history"] as const;
+
+export function useAlertRules() {
+	return useQuery({
+		queryKey: RULES_KEY,
+		queryFn: getAlertRules,
+		staleTime: 30_000,
+	});
+}
+
+export function useCreateAlertRule() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (rule: AlertRulePayload) => createAlertRule(rule),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: RULES_KEY });
+		},
+	});
+}
+
+export function useUpdateAlertRule() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ id, rule }: { id: string; rule: AlertRulePayload }) =>
+			updateAlertRule(id, rule),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: RULES_KEY });
+		},
+	});
+}
+
+export function useDeleteAlertRule() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (id: string) => deleteAlertRule(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: RULES_KEY });
+		},
+	});
+}
+
+export function useAlertWebhook() {
+	return useQuery({
+		queryKey: WEBHOOK_KEY,
+		queryFn: getAlertWebhook,
+		staleTime: 30_000,
+	});
+}
+
+export function useUpdateAlertWebhook() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (url: string) => updateAlertWebhook(url),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: WEBHOOK_KEY });
+		},
+	});
+}
+
+export function useTestAlertWebhook() {
+	return useMutation({
+		mutationFn: () => testAlertWebhook(),
+	});
+}
+
+export function useAlertHistory(limit: number) {
+	return useQuery({
+		queryKey: HISTORY_KEY,
+		queryFn: () => getAlertHistory(limit),
+		refetchInterval: 30_000,
+		refetchOnWindowFocus: true,
+	});
+}
+
+export function useClearAlertHistory() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () => clearAlertHistory(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: HISTORY_KEY });
+		},
+	});
+}

--- a/frontend/src/features/settings/hooks/use-alerts.ts
+++ b/frontend/src/features/settings/hooks/use-alerts.ts
@@ -82,7 +82,7 @@ export function useTestAlertWebhook() {
 
 export function useAlertHistory(limit: number) {
 	return useQuery({
-		queryKey: HISTORY_KEY,
+		queryKey: [...HISTORY_KEY, limit],
 		queryFn: () => getAlertHistory(limit),
 		refetchInterval: 30_000,
 		refetchOnWindowFocus: true,

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -8,11 +8,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/AmoabaKelvin/logdeck/internal/alerts"
 	"github.com/AmoabaKelvin/logdeck/internal/api"
 	"github.com/AmoabaKelvin/logdeck/internal/auth"
 	"github.com/AmoabaKelvin/logdeck/internal/config"
 	"github.com/AmoabaKelvin/logdeck/internal/coolify"
 	"github.com/AmoabaKelvin/logdeck/internal/docker"
+	"github.com/AmoabaKelvin/logdeck/internal/logstream"
 	"github.com/AmoabaKelvin/logdeck/internal/services"
 	"github.com/AmoabaKelvin/logdeck/internal/system"
 )
@@ -63,6 +65,9 @@ func main() {
 
 	registry := services.NewRegistry(multiHostClient, coolifyClient, authService, cfg)
 
+	logHub := logstream.New(registry)
+	alertEngine := alerts.NewEngine(registry, manager, logHub)
+
 	// Register hot-reload callback.
 	manager.OnChange(func(newCfg *config.Config) {
 		registry.UpdateConfig(newCfg)
@@ -79,6 +84,8 @@ func main() {
 				time.Sleep(30 * time.Second)
 				old.Close()
 			}()
+			// The client set changed; re-evaluate alert watch targets.
+			alertEngine.Reconcile()
 		}
 
 		// Recreate Coolify clients.
@@ -93,7 +100,7 @@ func main() {
 		log.Println("Configuration reloaded successfully")
 	})
 
-	apiRouter := api.NewRouter(registry, manager, version)
+	apiRouter := api.NewRouter(registry, manager, alertEngine, version)
 
 	// No WriteTimeout/IdleTimeout: log streaming and terminal WebSockets are
 	// long-lived connections and would be killed by them. ReadTimeout only
@@ -108,6 +115,9 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	go logHub.Run(ctx)
+	alertEngine.Start(ctx)
 
 	go func() {
 		log.Println("Server starting on :8080")
@@ -124,4 +134,9 @@ func main() {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Printf("Graceful shutdown failed: %v", err)
 	}
+
+	// Drain the alerting engine and the shared log tails after the server has
+	// stopped accepting requests.
+	alertEngine.Wait()
+	logHub.Wait()
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -117,6 +117,12 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	// Once the first signal starts the graceful shutdown, restore default
+	// signal handling so a second Ctrl-C terminates the process immediately.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
 
 	go logHub.Run(ctx)
 	alertEngine.Start(ctx)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -84,8 +84,10 @@ func main() {
 				time.Sleep(30 * time.Second)
 				old.Close()
 			}()
-			// The client set changed; re-evaluate alert watch targets.
+			// The client set changed; re-evaluate alert watch targets and
+			// converge the shared log tails onto the new client.
 			alertEngine.Reconcile()
+			logHub.Reconcile()
 		}
 
 		// Recreate Coolify clients.

--- a/server/internal/alerts/engine.go
+++ b/server/internal/alerts/engine.go
@@ -1,0 +1,68 @@
+// Package alerts contains the alerting engine: it watches container events
+// and log streams, matches them against the configured rules, and delivers
+// webhook notifications. This file defines the exported surface; rule
+// evaluation, windowing, and delivery land in the alerting territories.
+package alerts
+
+import (
+	"context"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+	"github.com/AmoabaKelvin/logdeck/internal/logstream"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// DockerProvider yields the current Docker client set; reading through it on
+// every use keeps the engine correct across hot-swapped config updates.
+type DockerProvider interface {
+	Docker() *docker.MultiHostClient
+}
+
+// Engine evaluates alert rules against engine events and log records and
+// records fired alerts in an in-memory history.
+type Engine struct {
+	provider DockerProvider
+	manager  *config.Manager
+	hub      *logstream.Hub
+}
+
+// NewEngine creates an alerting engine that reads rules through manager,
+// watches events through the provider's Docker clients, and subscribes to
+// log records through hub.
+func NewEngine(provider DockerProvider, manager *config.Manager, hub *logstream.Hub) *Engine {
+	return &Engine{
+		provider: provider,
+		manager:  manager,
+		hub:      hub,
+	}
+}
+
+// Start launches the engine's background loops (event watching and rule
+// evaluation) tied to ctx. It returns immediately; use Wait to block until
+// shutdown completes.
+func (e *Engine) Start(ctx context.Context) {}
+
+// Wait blocks until the engine's background loops have stopped after the
+// Start context was cancelled.
+func (e *Engine) Wait() {}
+
+// Reconcile re-reads the rule set and the current Docker client set and
+// adjusts event watches and log subscriptions to match. Called on rule
+// changes and after the Docker clients are hot-swapped.
+func (e *Engine) Reconcile() {}
+
+// TestWebhook sends a test notification to the configured webhook URL and
+// reports the delivery outcome.
+func (e *Engine) TestWebhook(ctx context.Context) models.DeliveryResult {
+	return models.DeliveryResult{}
+}
+
+// History returns the most recent fired alerts, newest first, capped at
+// limit (or all entries when limit <= 0). Always returns a non-nil slice.
+func (e *Engine) History(limit int) []models.Alert {
+	return []models.Alert{}
+}
+
+// ClearHistory removes all recorded alert history entries.
+func (e *Engine) ClearHistory() {}

--- a/server/internal/alerts/engine.go
+++ b/server/internal/alerts/engine.go
@@ -1,16 +1,48 @@
 // Package alerts contains the alerting engine: it watches container events
 // and log streams, matches them against the configured rules, and delivers
-// webhook notifications. This file defines the exported surface; rule
-// evaluation, windowing, and delivery land in the alerting territories.
+// webhook notifications.
+//
+// Concurrency model: a single run goroutine owns all mutable state (compiled
+// rules, subscription handles, rate/cooldown windows, the event-stream child
+// context). Log-rule sinks run on the hub's delivery goroutines and only push
+// non-blocking match messages onto firedCh. A single dispatcher goroutine
+// consumes fired alerts, delivers webhooks, and appends to history. Helper
+// goroutines exist only for single container-inspect exit-code lookups.
 package alerts
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/config"
 	"github.com/AmoabaKelvin/logdeck/internal/docker"
 	"github.com/AmoabaKelvin/logdeck/internal/logstream"
 	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+const (
+	firedBuffer    = 1024
+	inspectBuffer  = 64
+	dispatchBuffer = 128
+
+	defaultResyncInterval = 60 * time.Second
+	inspectTimeout        = 5 * time.Second
+	// deliverBudget bounds one delivery cycle (attempt + retry wait +
+	// attempt) so shutdown cannot hang on an unresponsive webhook.
+	deliverBudget = 30 * time.Second
+	// windowIdleTTL is how long a (rule, host, container) key may go without
+	// a match before its window state is pruned.
+	windowIdleTTL = 24 * time.Hour
 )
 
 // DockerProvider yields the current Docker client set; reading through it on
@@ -19,50 +51,600 @@ type DockerProvider interface {
 	Docker() *docker.MultiHostClient
 }
 
+// engineHub is the slice of logstream.Hub the engine uses; tests inject
+// fakes. *logstream.Hub satisfies it directly.
+type engineHub interface {
+	Subscribe(spec logstream.ContainerSpec, opts models.LogOptions, sink func(logstream.Record)) func()
+}
+
+// eventClient is the engine's view of the Docker client set. Implementations
+// must be comparable so client hot-swaps are detectable by value comparison.
+type eventClient interface {
+	streamEvents(ctx context.Context) <-chan docker.EngineEvent
+	inspectExit(ctx context.Context, host, containerID string) (exitCode string, oomKilled bool, err error)
+}
+
+// dockerEventAdapter adapts *docker.MultiHostClient to eventClient. It is a
+// comparable value type: two adapters are equal iff they wrap the same client
+// pointer.
+type dockerEventAdapter struct {
+	c *docker.MultiHostClient
+}
+
+func (a dockerEventAdapter) streamEvents(ctx context.Context) <-chan docker.EngineEvent {
+	return a.c.StreamEngineEvents(ctx)
+}
+
+func (a dockerEventAdapter) inspectExit(ctx context.Context, host, containerID string) (string, bool, error) {
+	resp, err := a.c.GetContainer(ctx, host, containerID)
+	if err != nil {
+		return "", false, err
+	}
+	if resp.State == nil {
+		return "", false, fmt.Errorf("inspect response has no state")
+	}
+	return strconv.Itoa(resp.State.ExitCode), resp.State.OOMKilled, nil
+}
+
+// matchMsg is one log-rule match pushed from a sink to the run loop.
+type matchMsg struct {
+	gen           uint64
+	rule          *compiledRule
+	host          string
+	containerID   string
+	containerName string
+	sample        string
+}
+
+// inspectResult is the outcome of a die-event exit-code lookup posted back to
+// the run loop.
+type inspectResult struct {
+	ev       docker.EngineEvent
+	exitCode string
+	fire     bool
+}
+
 // Engine evaluates alert rules against engine events and log records and
 // records fired alerts in an in-memory history.
 type Engine struct {
-	provider DockerProvider
-	manager  *config.Manager
-	hub      *logstream.Hub
+	hub      engineHub
+	source   func() eventClient
+	alertsFn func() config.AlertsConfig
+
+	hist  *history
+	notif *notifier
+
+	reconcileCh chan struct{}
+	firedCh     chan matchMsg
+	inspectCh   chan inspectResult
+	dispatchCh  chan models.Alert
+	flushStop   chan struct{}
+
+	// deliverCtx survives Start-context cancellation so in-flight deliveries
+	// can finish during shutdown; skipRetry aborts retry waits once shutdown
+	// begins. Both are set in Start before any goroutine reads them.
+	deliverCtx context.Context
+	skipRetry  <-chan struct{}
+
+	resyncInterval time.Duration
+	now            func() time.Time
+	wg             sync.WaitGroup
+
+	matchDrops  atomic.Uint64
+	loggedDrops uint64 // owned by the run loop
 }
 
 // NewEngine creates an alerting engine that reads rules through manager,
 // watches events through the provider's Docker clients, and subscribes to
 // log records through hub.
 func NewEngine(provider DockerProvider, manager *config.Manager, hub *logstream.Hub) *Engine {
+	alertsFn := func() config.AlertsConfig {
+		fc := manager.FileConfigSnapshot()
+		if fc.Alerts == nil {
+			return config.AlertsConfig{}
+		}
+		return *fc.Alerts
+	}
+	historyPath := filepath.Join(filepath.Dir(manager.ConfigFilePath()), "alerts-history.json")
+	return newEngine(hub, func() eventClient { return dockerEventAdapter{c: provider.Docker()} }, alertsFn, historyPath)
+}
+
+// newEngine is the internal constructor; tests inject fakes here.
+func newEngine(hub engineHub, source func() eventClient, alertsFn func() config.AlertsConfig, historyPath string) *Engine {
 	return &Engine{
-		provider: provider,
-		manager:  manager,
-		hub:      hub,
+		hub:            hub,
+		source:         source,
+		alertsFn:       alertsFn,
+		hist:           newHistory(historyPath, historyCap),
+		notif:          newNotifier(),
+		reconcileCh:    make(chan struct{}, 1),
+		firedCh:        make(chan matchMsg, firedBuffer),
+		inspectCh:      make(chan inspectResult, inspectBuffer),
+		dispatchCh:     make(chan models.Alert, dispatchBuffer),
+		flushStop:      make(chan struct{}),
+		resyncInterval: defaultResyncInterval,
+		now:            time.Now,
 	}
 }
 
 // Start launches the engine's background loops (event watching and rule
 // evaluation) tied to ctx. It returns immediately; use Wait to block until
 // shutdown completes.
-func (e *Engine) Start(ctx context.Context) {}
+func (e *Engine) Start(ctx context.Context) {
+	e.hist.load()
+	e.deliverCtx = context.WithoutCancel(ctx)
+	e.skipRetry = ctx.Done()
+	e.wg.Add(3)
+	go func() {
+		defer e.wg.Done()
+		e.run(ctx)
+	}()
+	go func() {
+		defer e.wg.Done()
+		e.dispatchLoop()
+	}()
+	go func() {
+		defer e.wg.Done()
+		e.hist.flushLoop(e.flushStop)
+	}()
+}
 
 // Wait blocks until the engine's background loops have stopped after the
 // Start context was cancelled.
-func (e *Engine) Wait() {}
+func (e *Engine) Wait() {
+	e.wg.Wait()
+}
 
 // Reconcile re-reads the rule set and the current Docker client set and
 // adjusts event watches and log subscriptions to match. Called on rule
-// changes and after the Docker clients are hot-swapped.
-func (e *Engine) Reconcile() {}
+// changes and after the Docker clients are hot-swapped. Non-blocking; pokes
+// coalesce.
+func (e *Engine) Reconcile() {
+	select {
+	case e.reconcileCh <- struct{}{}:
+	default:
+	}
+}
 
 // TestWebhook sends a test notification to the configured webhook URL and
-// reports the delivery outcome.
+// reports the delivery outcome. The test alert is not recorded in history.
 func (e *Engine) TestWebhook(ctx context.Context) models.DeliveryResult {
-	return models.DeliveryResult{}
+	url := e.alertsFn().WebhookURL
+	if url == "" {
+		return models.DeliveryResult{Status: "failed", Error: "no webhook configured"}
+	}
+	alert := models.Alert{
+		ID:       newAlertID(),
+		RuleName: "Test webhook",
+		Type:     "test",
+		Reason:   "test notification from LogDeck",
+		Count:    1,
+		FiredAt:  e.now().UTC().Format(time.RFC3339),
+	}
+	return e.notif.deliver(ctx, url, alert, ctx.Done())
 }
 
 // History returns the most recent fired alerts, newest first, capped at
-// limit (or all entries when limit <= 0). Always returns a non-nil slice.
+// limit (limit <= 0 falls back to a default). Always returns a non-nil slice.
 func (e *Engine) History(limit int) []models.Alert {
-	return []models.Alert{}
+	return e.hist.list(limit)
 }
 
 // ClearHistory removes all recorded alert history entries.
-func (e *Engine) ClearHistory() {}
+func (e *Engine) ClearHistory() {
+	e.hist.clear()
+}
+
+// activeSub pairs a live hub subscription with the compiled rule and the
+// generation stamped into its sink; matches carrying a different generation
+// for the same rule ID are stale and discarded.
+type activeSub struct {
+	rule  *compiledRule
+	gen   uint64
+	unsub func()
+}
+
+// runState is the mutable state owned exclusively by the run goroutine.
+type runState struct {
+	ctx context.Context
+	gen uint64
+
+	subs       map[string]*activeSub // live log-rule subscriptions by rule ID
+	eventRules []*compiledRule
+	windows    map[string]*ruleWindow // by ruleID|host|containerName
+
+	events       <-chan docker.EngineEvent
+	eventsCancel context.CancelFunc
+	eventsClient eventClient
+}
+
+// run is the engine's run loop: the single owner of all rule and window
+// state.
+func (e *Engine) run(ctx context.Context) {
+	st := &runState{
+		ctx:     ctx,
+		subs:    make(map[string]*activeSub),
+		windows: make(map[string]*ruleWindow),
+	}
+	e.openEvents(st, e.source())
+	e.reconcile(st)
+
+	ticker := time.NewTicker(e.resyncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			e.shutdownRun(st)
+			return
+		case <-e.reconcileCh:
+			e.checkEventClient(st)
+			e.reconcile(st)
+		case <-ticker.C:
+			e.checkEventClient(st)
+			e.pruneWindows(st)
+			e.logDrops()
+		case m := <-e.firedCh:
+			e.handleMatch(st, m)
+		case ev, ok := <-st.events:
+			if !ok {
+				// All host watchers stopped (e.g. the client was closed after
+				// a hot swap). Reopen on the current client.
+				st.events = nil
+				e.checkEventClient(st)
+				continue
+			}
+			e.handleEvent(st, ev)
+		case r := <-e.inspectCh:
+			e.handleInspect(st, r)
+		}
+	}
+}
+
+// openEvents (re)opens the engine event stream on client under a child
+// context of the run context.
+func (e *Engine) openEvents(st *runState, client eventClient) {
+	ctx, cancel := context.WithCancel(st.ctx)
+	st.eventsCancel = cancel
+	st.events = client.streamEvents(ctx)
+	st.eventsClient = client
+}
+
+// checkEventClient reopens the event stream when the provider's client set
+// was hot-swapped (or the stream closed), so watches never stay bound to a
+// closed client.
+func (e *Engine) checkEventClient(st *runState) {
+	if current := e.source(); st.events == nil || current != st.eventsClient {
+		st.eventsCancel()
+		e.openEvents(st, current)
+	}
+}
+
+// reconcile recompiles the rule set and diffs log-rule subscriptions:
+// unchanged rules keep their subscription (and generation); removed or
+// changed rules are unsubscribed and, if still present, resubscribed with a
+// fresh compiled snapshot. Window state for removed or changed rules is
+// dropped.
+func (e *Engine) reconcile(st *runState) {
+	compiled := compileRules(e.alertsFn())
+
+	newLog := make(map[string]*compiledRule)
+	var newEvent []*compiledRule
+	for _, r := range compiled {
+		if r.typ == "log" {
+			newLog[r.id] = r
+		} else {
+			newEvent = append(newEvent, r)
+		}
+	}
+
+	stale := make(map[string]bool)
+
+	for id, sub := range st.subs {
+		if nr, ok := newLog[id]; ok && reflect.DeepEqual(nr.src, sub.rule.src) {
+			delete(newLog, id) // unchanged: keep the existing subscription
+			continue
+		}
+		sub.unsub()
+		delete(st.subs, id)
+		stale[id] = true
+	}
+	for _, r := range newLog {
+		e.subscribeRule(st, r)
+	}
+
+	oldEvent := make(map[string]config.AlertRule, len(st.eventRules))
+	for _, r := range st.eventRules {
+		oldEvent[r.id] = r.src
+	}
+	for _, r := range newEvent {
+		if old, ok := oldEvent[r.id]; !ok || !reflect.DeepEqual(old, r.src) {
+			stale[r.id] = true
+		}
+		delete(oldEvent, r.id)
+	}
+	for id := range oldEvent {
+		stale[id] = true
+	}
+	st.eventRules = newEvent
+
+	if len(stale) > 0 {
+		for key := range st.windows {
+			if id, _, _ := strings.Cut(key, "|"); stale[id] {
+				delete(st.windows, key)
+			}
+		}
+	}
+}
+
+// subscribeRule registers a hub subscription for one log rule. The sink runs
+// on the hub's delivery goroutine: it filters against the captured immutable
+// rule snapshot and pushes matches non-blockingly; it never touches engine
+// state and never blocks.
+func (e *Engine) subscribeRule(st *runState, rule *compiledRule) {
+	st.gen++
+	gen := st.gen
+	spec := logstream.ContainerSpec{Hosts: rule.hosts, Containers: rule.containers, Projects: rule.projects}
+	opts := models.LogOptions{Timestamps: true, Tail: "0", ShowStdout: true, ShowStderr: true}
+	sink := func(rec logstream.Record) {
+		if !rule.matchesEntry(rec.Entry) {
+			return
+		}
+		m := matchMsg{
+			gen:           gen,
+			rule:          rule,
+			host:          rec.Host,
+			containerID:   rec.ContainerID,
+			containerName: rec.ContainerName,
+			sample:        entrySample(rec.Entry),
+		}
+		select {
+		case e.firedCh <- m:
+		default:
+			e.matchDrops.Add(1)
+		}
+	}
+	unsub := e.hub.Subscribe(spec, opts, sink)
+	st.subs[rule.id] = &activeSub{rule: rule, gen: gen, unsub: unsub}
+}
+
+// handleMatch applies rate limiting and cooldown to one log-rule match.
+func (e *Engine) handleMatch(st *runState, m matchMsg) {
+	sub, ok := st.subs[m.rule.id]
+	if !ok || sub.gen != m.gen {
+		return // stale: the rule was removed or resubscribed since this match
+	}
+	key := m.rule.id + "|" + m.host + "|" + m.containerName
+	res := e.window(st, key, m.rule).observe(e.now())
+	if !res.fire {
+		return
+	}
+	e.emit(m.rule, m.host, m.containerID, m.containerName, logReason(m.rule), m.sample, res.suppressed)
+}
+
+// handleEvent routes one engine event. Only die and oom can fire rules; the
+// other watched actions exist for the log hub and are ignored here.
+func (e *Engine) handleEvent(st *runState, ev docker.EngineEvent) {
+	base, _, _ := strings.Cut(ev.Action, ": ")
+	switch base {
+	case "die":
+		switch ev.ExitCode {
+		case "":
+			e.spawnInspect(st, ev)
+		case "0":
+			// Clean exit: not an alert condition.
+		default:
+			e.recordEventMatch(st, ev, "die", ev.ExitCode)
+		}
+	case "oom":
+		e.recordEventMatch(st, ev, "oom", "")
+	}
+}
+
+// spawnInspect looks up the exit code for a die event that arrived without
+// one (single inspect, bounded timeout) and posts the result back to the run
+// loop. A container that is already gone still fires with exit "unknown";
+// die events are never silently skipped on lookup failure.
+func (e *Engine) spawnInspect(st *runState, ev docker.EngineEvent) {
+	client := st.eventsClient
+	runCtx := st.ctx
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		ictx, cancel := context.WithTimeout(runCtx, inspectTimeout)
+		defer cancel()
+		res := inspectResult{ev: ev}
+		exitCode, oomKilled, err := client.inspectExit(ictx, ev.Host, ev.ContainerID)
+		if err != nil {
+			res.exitCode = "unknown"
+			res.fire = true
+		} else {
+			res.exitCode = exitCode
+			res.fire = exitCode != "0" || oomKilled
+		}
+		select {
+		case e.inspectCh <- res:
+		case <-runCtx.Done():
+		}
+	}()
+}
+
+// handleInspect completes a die event whose exit code needed an inspect.
+func (e *Engine) handleInspect(st *runState, r inspectResult) {
+	if !r.fire {
+		return
+	}
+	e.recordEventMatch(st, r.ev, "die", r.exitCode)
+}
+
+// recordEventMatch runs one die/oom occurrence through every matching event
+// rule's window.
+func (e *Engine) recordEventMatch(st *runState, ev docker.EngineEvent, action, exitCode string) {
+	name := strings.TrimPrefix(ev.ContainerName, "/")
+	for _, rule := range st.eventRules {
+		if !rule.hasEvent(action) || !rule.matchesTarget(ev.Host, name, ev.Labels) {
+			continue
+		}
+		key := rule.id + "|" + ev.Host + "|" + name
+		res := e.window(st, key, rule).observe(e.now())
+		if !res.fire {
+			continue
+		}
+		e.emit(rule, ev.Host, ev.ContainerID, name, eventReason(rule, action, exitCode), eventSample(action, exitCode), res.suppressed)
+	}
+}
+
+// window returns the rate/cooldown state for key, creating it from the
+// rule's normalized parameters on first use.
+func (e *Engine) window(st *runState, key string, rule *compiledRule) *ruleWindow {
+	w, ok := st.windows[key]
+	if !ok {
+		w = newRuleWindow(rule.threshold, rule.window, rule.cooldown)
+		st.windows[key] = w
+	}
+	return w
+}
+
+// emit builds the alert and hands it to the dispatcher without blocking the
+// run loop; a full dispatch queue drops the alert with a log line.
+func (e *Engine) emit(rule *compiledRule, host, containerID, containerName, reason, sample string, suppressed int) {
+	alert := models.Alert{
+		ID:            newAlertID(),
+		RuleID:        rule.id,
+		RuleName:      rule.name,
+		Type:          rule.typ,
+		Host:          host,
+		ContainerID:   containerID,
+		ContainerName: containerName,
+		Reason:        reason,
+		Sample:        sample,
+		Count:         rule.threshold,
+		Suppressed:    suppressed,
+		FiredAt:       e.now().UTC().Format(time.RFC3339),
+	}
+	select {
+	case e.dispatchCh <- alert:
+	default:
+		log.Printf("alerts: dispatch queue full, dropping alert %s (rule %q)", alert.ID, rule.name)
+	}
+}
+
+// pruneWindows drops rate/cooldown state for keys with no match in
+// windowIdleTTL.
+func (e *Engine) pruneWindows(st *runState) {
+	now := e.now()
+	for key, w := range st.windows {
+		if w.idleSince(now) > windowIdleTTL {
+			delete(st.windows, key)
+		}
+	}
+}
+
+// logDrops reports sink-side match drops accumulated since the last resync.
+func (e *Engine) logDrops() {
+	if d := e.matchDrops.Load(); d > e.loggedDrops {
+		log.Printf("alerts: dropped %d rule matches since last report (evaluation backlog)", d-e.loggedDrops)
+		e.loggedDrops = d
+	}
+}
+
+// shutdownRun tears down run-loop state: unsubscribe all hub subscriptions,
+// cancel the event stream (which also aborts pending inspects via the run
+// context), discard buffered matches, and close the dispatch channel so the
+// dispatcher can drain and finish.
+func (e *Engine) shutdownRun(st *runState) {
+	for id, sub := range st.subs {
+		sub.unsub()
+		delete(st.subs, id)
+	}
+	st.eventsCancel()
+	for {
+		select {
+		case <-e.firedCh:
+			// Discarded: window state is in-memory and dies with the process,
+			// so partial matches at shutdown cannot fire later anyway.
+		case <-e.inspectCh:
+		default:
+			close(e.dispatchCh)
+			return
+		}
+	}
+}
+
+// dispatchLoop consumes fired alerts: it delivers to the webhook (read live
+// from config; empty means history-only) and appends the result to history.
+// It exits when the run loop closes dispatchCh, then stops the history
+// flusher, which performs the final synchronous flush.
+func (e *Engine) dispatchLoop() {
+	defer close(e.flushStop)
+	for alert := range e.dispatchCh {
+		if url := e.alertsFn().WebhookURL; url != "" {
+			ctx, cancel := context.WithTimeout(e.deliverCtx, deliverBudget)
+			result := e.notif.deliver(ctx, url, alert, e.skipRetry)
+			cancel()
+			alert.Delivery = &result
+		}
+		e.hist.append(alert)
+	}
+}
+
+// logReason renders the human-readable reason for a fired log rule, e.g.
+// "5 matches (level >= ERROR) within 60s".
+func logReason(rule *compiledRule) string {
+	unit := "matches"
+	if rule.threshold == 1 {
+		unit = "match"
+	}
+	var conds []string
+	if rule.minLevel != "" {
+		conds = append(conds, "level >= "+rule.minLevel)
+	}
+	if rule.pattern != nil {
+		conds = append(conds, fmt.Sprintf("pattern %q", rule.pattern.String()))
+	}
+	cond := ""
+	if len(conds) > 0 {
+		cond = " (" + strings.Join(conds, ", ") + ")"
+	}
+	return fmt.Sprintf("%d %s%s within %ds", rule.threshold, unit, cond, int(rule.window.Seconds()))
+}
+
+// eventReason renders the human-readable reason for a fired event rule, e.g.
+// "container died (exit 137)".
+func eventReason(rule *compiledRule, action, exitCode string) string {
+	if rule.threshold <= 1 {
+		if action == "oom" {
+			return "container OOM-killed"
+		}
+		return fmt.Sprintf("container died (exit %s)", exitCode)
+	}
+	if action == "oom" {
+		return fmt.Sprintf("%d OOM kills within %ds", rule.threshold, int(rule.window.Seconds()))
+	}
+	return fmt.Sprintf("%d container deaths within %ds (last exit %s)", rule.threshold, int(rule.window.Seconds()), exitCode)
+}
+
+// eventSample renders the sample detail for an event alert.
+func eventSample(action, exitCode string) string {
+	if action == "oom" {
+		return "oom"
+	}
+	return "die (exit " + exitCode + ")"
+}
+
+// entrySample picks the line recorded as the alert's sample.
+func entrySample(entry models.LogEntry) string {
+	if entry.Message != "" {
+		return entry.Message
+	}
+	return entry.Raw
+}
+
+// newAlertID returns an 8-hex-char random alert ID.
+func newAlertID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%08x", uint32(time.Now().UnixNano()))
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/server/internal/alerts/engine.go
+++ b/server/internal/alerts/engine.go
@@ -6,7 +6,8 @@
 // rules, subscription handles, rate/cooldown windows, the event-stream child
 // context). Log-rule sinks run on the hub's delivery goroutines and only push
 // non-blocking match messages onto firedCh. A single dispatcher goroutine
-// consumes fired alerts, delivers webhooks, and appends to history. Helper
+// consumes fired alerts, appends them to history, delivers webhooks, and
+// records each delivery outcome on the history entry. Helper
 // goroutines exist only for single container-inspect exit-code lookups.
 package alerts
 
@@ -38,8 +39,17 @@ const (
 	defaultResyncInterval = 60 * time.Second
 	inspectTimeout        = 5 * time.Second
 	// deliverBudget bounds one delivery cycle (attempt + retry wait +
-	// attempt) so shutdown cannot hang on an unresponsive webhook.
+	// attempt).
 	deliverBudget = 30 * time.Second
+	// shutdownDrainBudget bounds the entire dispatch-queue drain after the
+	// Start context is cancelled: once it expires, remaining alerts are
+	// recorded as failed ("shutdown") instead of waiting out their delivery
+	// timeouts one by one.
+	shutdownDrainBudget = 30 * time.Second
+	// oomDieWindow is how long after an "oom" event a "die" for the same
+	// container is treated as part of the same incident by rules watching
+	// both actions.
+	oomDieWindow = 10 * time.Second
 	// windowIdleTTL is how long a (rule, host, container) key may go without
 	// a match before its window state is pruned.
 	windowIdleTTL = 24 * time.Hour
@@ -121,8 +131,9 @@ type Engine struct {
 	flushStop   chan struct{}
 
 	// deliverCtx survives Start-context cancellation so in-flight deliveries
-	// can finish during shutdown; skipRetry aborts retry waits once shutdown
-	// begins. Both are set in Start before any goroutine reads them.
+	// can finish during shutdown, but is cancelled once shutdownDrainBudget
+	// elapses after shutdown begins; skipRetry aborts retry waits once
+	// shutdown begins. Both are set in Start before any goroutine reads them.
 	deliverCtx context.Context
 	skipRetry  <-chan struct{}
 
@@ -172,9 +183,10 @@ func newEngine(hub engineHub, source func() eventClient, alertsFn func() config.
 // shutdown completes.
 func (e *Engine) Start(ctx context.Context) {
 	e.hist.load()
-	e.deliverCtx = context.WithoutCancel(ctx)
+	drainCtx, drainCancel := context.WithCancel(context.WithoutCancel(ctx))
+	e.deliverCtx = drainCtx
 	e.skipRetry = ctx.Done()
-	e.wg.Add(3)
+	e.wg.Add(4)
 	go func() {
 		defer e.wg.Done()
 		e.run(ctx)
@@ -186,6 +198,20 @@ func (e *Engine) Start(ctx context.Context) {
 	go func() {
 		defer e.wg.Done()
 		e.hist.flushLoop(e.flushStop)
+	}()
+	// The whole post-shutdown dispatch drain shares one budget: deliverCtx is
+	// cancelled shutdownDrainBudget after the Start context, so a queue of
+	// alerts against an unresponsive webhook cannot stall shutdown.
+	go func() {
+		defer e.wg.Done()
+		defer drainCancel()
+		<-ctx.Done()
+		timer := time.NewTimer(shutdownDrainBudget)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-e.flushStop: // drain finished within the budget
+		}
 	}()
 }
 
@@ -252,6 +278,7 @@ type runState struct {
 	subs       map[string]*activeSub // live log-rule subscriptions by rule ID
 	eventRules []*compiledRule
 	windows    map[string]*ruleWindow // by ruleID|host|containerName
+	lastOOM    map[string]time.Time   // last oom event by host|containerID
 
 	events       <-chan docker.EngineEvent
 	eventsCancel context.CancelFunc
@@ -265,6 +292,7 @@ func (e *Engine) run(ctx context.Context) {
 		ctx:     ctx,
 		subs:    make(map[string]*activeSub),
 		windows: make(map[string]*ruleWindow),
+		lastOOM: make(map[string]time.Time),
 	}
 	e.openEvents(st, e.source())
 	e.reconcile(st)
@@ -384,7 +412,7 @@ func (e *Engine) reconcile(st *runState) {
 func (e *Engine) subscribeRule(st *runState, rule *compiledRule) {
 	st.gen++
 	gen := st.gen
-	spec := logstream.ContainerSpec{Hosts: rule.hosts, Containers: rule.containers, Projects: rule.projects}
+	spec := rule.spec
 	opts := models.LogOptions{Timestamps: true, Tail: "0", ShowStdout: true, ShowStderr: true}
 	sink := func(rec logstream.Record) {
 		if !rule.matchesEntry(rec.Entry) {
@@ -481,9 +509,22 @@ func (e *Engine) handleInspect(st *runState, r inspectResult) {
 // rule's window.
 func (e *Engine) recordEventMatch(st *runState, ev docker.EngineEvent, action, exitCode string) {
 	name := strings.TrimPrefix(ev.ContainerName, "/")
+	oomKey := ev.Host + "|" + ev.ContainerID
+	if action == "oom" {
+		st.lastOOM[oomKey] = e.now()
+	}
 	for _, rule := range st.eventRules {
-		if !rule.hasEvent(action) || !rule.matchesTarget(ev.Host, name, ev.Labels) {
+		if !rule.hasEvent(action) || !rule.spec.Matches(ev.Host, name, ev.Labels) {
 			continue
+		}
+		// An OOM kill emits "oom" followed by "die" (137): for a rule that
+		// watches both actions the pair is one incident, so the die is
+		// skipped when this container OOMed just before. Rules watching only
+		// die still observe it.
+		if action == "die" && rule.hasEvent("oom") {
+			if t, ok := st.lastOOM[oomKey]; ok && e.now().Sub(t) <= oomDieWindow {
+				continue
+			}
 		}
 		key := rule.id + "|" + ev.Host + "|" + name
 		res := e.window(st, key, rule).observe(e.now())
@@ -530,12 +571,17 @@ func (e *Engine) emit(rule *compiledRule, host, containerID, containerName, reas
 }
 
 // pruneWindows drops rate/cooldown state for keys with no match in
-// windowIdleTTL.
+// windowIdleTTL, and oom timestamps too old to suppress a paired die.
 func (e *Engine) pruneWindows(st *runState) {
 	now := e.now()
 	for key, w := range st.windows {
 		if w.idleSince(now) > windowIdleTTL {
 			delete(st.windows, key)
+		}
+	}
+	for key, t := range st.lastOOM {
+		if now.Sub(t) > oomDieWindow {
+			delete(st.lastOOM, key)
 		}
 	}
 }
@@ -571,20 +617,30 @@ func (e *Engine) shutdownRun(st *runState) {
 	}
 }
 
-// dispatchLoop consumes fired alerts: it delivers to the webhook (read live
-// from config; empty means history-only) and appends the result to history.
-// It exits when the run loop closes dispatchCh, then stops the history
-// flusher, which performs the final synchronous flush.
+// dispatchLoop consumes fired alerts: each alert is appended to history first
+// (Delivery nil) so a hung webhook can never lose it, then delivered to the
+// webhook (read live from config; empty means history-only) and its history
+// entry updated with the result. It exits when the run loop closes
+// dispatchCh, then stops the history flusher, which performs the final
+// synchronous flush. Once the shutdown drain budget has expired, remaining
+// alerts are recorded as failed ("shutdown") without a delivery attempt.
 func (e *Engine) dispatchLoop() {
 	defer close(e.flushStop)
 	for alert := range e.dispatchCh {
-		if url := e.alertsFn().WebhookURL; url != "" {
-			ctx, cancel := context.WithTimeout(e.deliverCtx, deliverBudget)
-			result := e.notif.deliver(ctx, url, alert, e.skipRetry)
-			cancel()
-			alert.Delivery = &result
-		}
 		e.hist.append(alert)
+		url := e.alertsFn().WebhookURL
+		if url == "" {
+			continue
+		}
+		var result models.DeliveryResult
+		if e.deliverCtx.Err() != nil {
+			result = models.DeliveryResult{Status: "failed", Error: "shutdown"}
+		} else {
+			ctx, cancel := context.WithTimeout(e.deliverCtx, deliverBudget)
+			result = e.notif.deliver(ctx, url, alert, e.skipRetry)
+			cancel()
+		}
+		e.hist.setDelivery(alert.ID, result)
 	}
 }
 

--- a/server/internal/alerts/engine_test.go
+++ b/server/internal/alerts/engine_test.go
@@ -289,6 +289,67 @@ func TestOOMEventFires(t *testing.T) {
 	}
 }
 
+func TestOOMThenDieCountsOnceForRuleWatchingBoth(t *testing.T) {
+	both := config.AlertRule{ID: "both", Name: "both", Enabled: true, Type: "event", Events: []string{"die", "oom"}, Threshold: 2, WindowSeconds: 60}
+	dieOnly := config.AlertRule{ID: "die-only", Name: "die only", Enabled: true, Type: "event", Events: []string{"die"}, Threshold: 1}
+	te := startTestEngine(t, both, dieOnly)
+
+	// One OOM kill: the daemon emits "oom" followed by "die" (exit 137).
+	te.events.ch <- docker.EngineEvent{Host: "local", ContainerID: "c1", ContainerName: "web", Action: "oom"}
+	te.events.ch <- docker.EngineEvent{Host: "local", ContainerID: "c1", ContainerName: "web", Action: "die", ExitCode: "137"}
+
+	// The die-only rule fires on the die. The both rule must have observed
+	// the incident once (the oom), so at threshold 2 it must not fire yet.
+	waitFor(t, "die-only alert", func() bool { return len(te.e.History(0)) == 1 })
+	time.Sleep(50 * time.Millisecond) // give a wrong double-counted alert time to appear
+	h := te.e.History(0)
+	if len(h) != 1 || h[0].RuleID != "die-only" {
+		t.Fatalf("history = %+v, want only the die-only alert (oom+die pair must count once)", h)
+	}
+
+	// A die outside the oom correlation window is a separate incident: the
+	// both rule's second observation, so it fires.
+	te.clock.advance(11 * time.Second)
+	te.events.ch <- docker.EngineEvent{Host: "local", ContainerID: "c1", ContainerName: "web", Action: "die", ExitCode: "1"}
+	waitFor(t, "both-rule alert", func() bool { return len(te.e.History(0)) == 2 })
+	if got := te.e.History(0)[0].RuleID; got != "both" {
+		t.Fatalf("newest alert rule = %q, want both", got)
+	}
+}
+
+func TestAlertInHistoryWhileDeliveryHangs(t *testing.T) {
+	unblock := make(chan struct{})
+	var once sync.Once
+	release := func() { once.Do(func() { close(unblock) }) }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-unblock // hang until the test releases the webhook
+	}))
+	defer srv.Close()
+	defer release()
+
+	te := startTestEngine(t, config.AlertRule{ID: "r1", Name: "boom", Enabled: true, Type: "log", Pattern: "boom", Threshold: 1})
+	te.conf.set(config.AlertsConfig{WebhookURL: srv.URL, Rules: te.conf.get().Rules})
+	waitFor(t, "subscription", func() bool { return te.hub.liveCount() == 1 })
+
+	te.hub.emit(record(models.LogLevelError, "boom"))
+
+	// The alert must reach history while the webhook is still hanging.
+	waitFor(t, "alert in history during delivery", func() bool { return len(te.e.History(0)) == 1 })
+	if d := te.e.History(0)[0].Delivery; d != nil {
+		t.Fatalf("delivery = %+v, want nil while the webhook hangs", d)
+	}
+
+	// Once the webhook responds, the stored entry gains the delivery result.
+	release()
+	waitFor(t, "delivery recorded", func() bool {
+		h := te.e.History(0)
+		return len(h) == 1 && h[0].Delivery != nil
+	})
+	if d := te.e.History(0)[0].Delivery; d.Status != "ok" {
+		t.Fatalf("delivery = %+v, want ok", d)
+	}
+}
+
 func TestDieEventEmptyExitCodeFailingInspectFiresUnknown(t *testing.T) {
 	te := startTestEngine(t, config.AlertRule{
 		ID: "e1", Name: "Container died", Enabled: true, Type: "event", Events: []string{"die"}, Threshold: 1,

--- a/server/internal/alerts/engine_test.go
+++ b/server/internal/alerts/engine_test.go
@@ -1,0 +1,458 @@
+package alerts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+	"github.com/AmoabaKelvin/logdeck/internal/logstream"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// fakeHub records subscriptions and lets tests feed records to live sinks.
+type fakeHub struct {
+	mu   sync.Mutex
+	subs []*fakeHubSub
+}
+
+type fakeHubSub struct {
+	spec    logstream.ContainerSpec
+	opts    models.LogOptions
+	sink    func(logstream.Record)
+	removed bool
+}
+
+func (f *fakeHub) Subscribe(spec logstream.ContainerSpec, opts models.LogOptions, sink func(logstream.Record)) func() {
+	s := &fakeHubSub{spec: spec, opts: opts, sink: sink}
+	f.mu.Lock()
+	f.subs = append(f.subs, s)
+	f.mu.Unlock()
+	return func() {
+		f.mu.Lock()
+		s.removed = true
+		f.mu.Unlock()
+	}
+}
+
+// emit delivers a record to every live sink, in subscription order, like the
+// hub's per-subscription delivery goroutines would.
+func (f *fakeHub) emit(rec logstream.Record) {
+	f.mu.Lock()
+	var sinks []func(logstream.Record)
+	for _, s := range f.subs {
+		if !s.removed {
+			sinks = append(sinks, s.sink)
+		}
+	}
+	f.mu.Unlock()
+	for _, sink := range sinks {
+		sink(rec)
+	}
+}
+
+func (f *fakeHub) liveCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, s := range f.subs {
+		if !s.removed {
+			n++
+		}
+	}
+	return n
+}
+
+func (f *fakeHub) firstLive() *fakeHubSub {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, s := range f.subs {
+		if !s.removed {
+			return s
+		}
+	}
+	return nil
+}
+
+// fakeEvents is a comparable eventClient backed by a test-fed channel. The
+// inspect fields are set before events are fed, never mutated concurrently.
+type fakeEvents struct {
+	ch              chan docker.EngineEvent
+	inspectExitCode string
+	inspectOOM      bool
+	inspectErr      error
+}
+
+func newFakeEvents() *fakeEvents {
+	return &fakeEvents{ch: make(chan docker.EngineEvent, 8)}
+}
+
+func (f *fakeEvents) streamEvents(ctx context.Context) <-chan docker.EngineEvent {
+	return f.ch
+}
+
+func (f *fakeEvents) inspectExit(ctx context.Context, host, containerID string) (string, bool, error) {
+	return f.inspectExitCode, f.inspectOOM, f.inspectErr
+}
+
+// fakeConf is a mutable alerts config source.
+type fakeConf struct {
+	mu  sync.Mutex
+	cfg config.AlertsConfig
+}
+
+func (f *fakeConf) get() config.AlertsConfig {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cfg
+}
+
+func (f *fakeConf) set(cfg config.AlertsConfig) {
+	f.mu.Lock()
+	f.cfg = cfg
+	f.mu.Unlock()
+}
+
+// fakeClock is a manually advanced clock safe for cross-goroutine reads.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+type testEngine struct {
+	e      *Engine
+	hub    *fakeHub
+	events *fakeEvents
+	conf   *fakeConf
+	clock  *fakeClock
+	cancel context.CancelFunc
+	path   string
+}
+
+func startTestEngine(t *testing.T, rules ...config.AlertRule) *testEngine {
+	t.Helper()
+	te := &testEngine{
+		hub:    &fakeHub{},
+		events: newFakeEvents(),
+		conf:   &fakeConf{cfg: config.AlertsConfig{Rules: rules}},
+		clock:  &fakeClock{t: t0},
+		path:   filepath.Join(t.TempDir(), "alerts-history.json"),
+	}
+	te.e = newEngine(te.hub, func() eventClient { return te.events }, te.conf.get, te.path)
+	te.e.now = te.clock.now
+
+	ctx, cancel := context.WithCancel(context.Background())
+	te.cancel = cancel
+	te.e.Start(ctx)
+	t.Cleanup(func() {
+		cancel()
+		te.e.Wait()
+	})
+	return te
+}
+
+func waitFor(t *testing.T, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", desc)
+}
+
+func record(level models.LogLevel, msg string) logstream.Record {
+	return logstream.Record{
+		Host:          "local",
+		ContainerID:   "abc123",
+		ContainerName: "web",
+		Entry:         models.LogEntry{Level: level, Message: msg, Raw: msg},
+	}
+}
+
+func TestLogRuleFiresOnceWithCountAndFields(t *testing.T) {
+	te := startTestEngine(t, config.AlertRule{
+		ID: "r1", Name: "High error rate", Enabled: true, Type: "log",
+		MinLevel: "ERROR", Threshold: 3, WindowSeconds: 60,
+	})
+
+	waitFor(t, "subscription", func() bool { return te.hub.liveCount() == 1 })
+	sub := te.hub.firstLive()
+	if sub.opts.Tail != "0" || !sub.opts.ShowStdout || !sub.opts.ShowStderr || !sub.opts.Timestamps {
+		t.Fatalf("subscription opts = %+v, want Tail 0 with stdout+stderr+timestamps", sub.opts)
+	}
+
+	te.hub.emit(record(models.LogLevelInfo, "just info")) // filtered by MinLevel
+	for range 3 {
+		te.hub.emit(record(models.LogLevelError, "boom"))
+	}
+
+	waitFor(t, "alert in history", func() bool { return len(te.e.History(0)) == 1 })
+	a := te.e.History(0)[0]
+	if a.RuleID != "r1" || a.Type != "log" || a.Host != "local" || a.ContainerName != "web" || a.ContainerID != "abc123" {
+		t.Fatalf("alert identity wrong: %+v", a)
+	}
+	if a.Count != 3 || a.Suppressed != 0 || a.Sample != "boom" {
+		t.Fatalf("alert count/sample wrong: %+v", a)
+	}
+	if !strings.Contains(a.Reason, "3 matches (level >= ERROR) within 60s") {
+		t.Fatalf("reason = %q", a.Reason)
+	}
+	if len(a.ID) != 8 {
+		t.Fatalf("alert ID = %q, want 8 hex chars", a.ID)
+	}
+	if a.Delivery != nil {
+		t.Fatalf("no webhook configured but Delivery = %+v, want nil (history-only)", a.Delivery)
+	}
+}
+
+func TestCooldownSuppressedAccumulatesAndSurfaces(t *testing.T) {
+	boom := config.AlertRule{ID: "r1", Name: "boom", Enabled: true, Type: "log", Pattern: "boom", Threshold: 1}
+	flush := config.AlertRule{ID: "r2", Name: "flush", Enabled: true, Type: "log", Pattern: "flushmarker", Threshold: 1}
+	te := startTestEngine(t, boom, flush)
+	waitFor(t, "subscriptions", func() bool { return te.hub.liveCount() == 2 })
+
+	te.hub.emit(record(models.LogLevelError, "boom"))
+	waitFor(t, "first alert", func() bool { return len(te.e.History(0)) == 1 })
+
+	// A burst inside the (default 300s) cooldown is suppressed.
+	for range 3 {
+		te.hub.emit(record(models.LogLevelError, "boom"))
+	}
+	// The flush rule proves the run loop has consumed the suppressed matches
+	// (firedCh is FIFO) before the clock advances.
+	te.hub.emit(record(models.LogLevelError, "flushmarker"))
+	waitFor(t, "flush alert", func() bool { return len(te.e.History(0)) == 2 })
+
+	te.clock.advance(301 * time.Second)
+	te.hub.emit(record(models.LogLevelError, "boom"))
+	waitFor(t, "post-cooldown alert", func() bool { return len(te.e.History(0)) == 3 })
+
+	newest := te.e.History(0)[0]
+	if newest.RuleID != "r1" || newest.Suppressed != 3 {
+		t.Fatalf("post-cooldown alert = %+v, want rule r1 with Suppressed 3", newest)
+	}
+}
+
+func TestDieEventFires(t *testing.T) {
+	te := startTestEngine(t, config.AlertRule{
+		ID: "e1", Name: "Container died", Enabled: true, Type: "event", Events: []string{"die"}, Threshold: 1,
+	})
+
+	te.events.ch <- docker.EngineEvent{
+		Host: "local", ContainerID: "c1", ContainerName: "web", Action: "die", ExitCode: "137",
+	}
+
+	waitFor(t, "die alert", func() bool { return len(te.e.History(0)) == 1 })
+	a := te.e.History(0)[0]
+	if a.Type != "event" || a.RuleID != "e1" || a.Reason != "container died (exit 137)" {
+		t.Fatalf("alert = %+v", a)
+	}
+	if a.Sample != "die (exit 137)" {
+		t.Fatalf("sample = %q", a.Sample)
+	}
+}
+
+func TestOOMEventFires(t *testing.T) {
+	te := startTestEngine(t, config.AlertRule{
+		ID: "e1", Name: "OOM", Enabled: true, Type: "event", Events: []string{"oom"}, Threshold: 1,
+	})
+
+	te.events.ch <- docker.EngineEvent{Host: "local", ContainerID: "c1", ContainerName: "web", Action: "oom"}
+
+	waitFor(t, "oom alert", func() bool { return len(te.e.History(0)) == 1 })
+	if got := te.e.History(0)[0].Reason; got != "container OOM-killed" {
+		t.Fatalf("reason = %q", got)
+	}
+}
+
+func TestDieEventEmptyExitCodeFailingInspectFiresUnknown(t *testing.T) {
+	te := startTestEngine(t, config.AlertRule{
+		ID: "e1", Name: "Container died", Enabled: true, Type: "event", Events: []string{"die"}, Threshold: 1,
+	})
+	te.events.inspectErr = errors.New("no such container")
+
+	te.events.ch <- docker.EngineEvent{Host: "local", ContainerID: "c1", ContainerName: "web", Action: "die"}
+
+	waitFor(t, "unknown-exit alert", func() bool { return len(te.e.History(0)) == 1 })
+	if got := te.e.History(0)[0].Reason; got != "container died (exit unknown)" {
+		t.Fatalf("reason = %q", got)
+	}
+}
+
+func TestDieEventCleanExitViaInspectDoesNotFire(t *testing.T) {
+	te := startTestEngine(t, config.AlertRule{
+		ID: "e1", Name: "Container died", Enabled: true, Type: "event", Events: []string{"die"}, Threshold: 1,
+	})
+	te.events.inspectExitCode = "0"
+
+	te.events.ch <- docker.EngineEvent{Host: "local", ContainerID: "c1", ContainerName: "clean", Action: "die"}
+	te.events.ch <- docker.EngineEvent{Host: "local", ContainerID: "c2", ContainerName: "web", Action: "die", ExitCode: "1"}
+
+	waitFor(t, "non-clean alert", func() bool { return len(te.e.History(0)) >= 1 })
+	time.Sleep(50 * time.Millisecond) // give a wrong clean-exit alert time to appear
+	alerts := te.e.History(0)
+	if len(alerts) != 1 || alerts[0].ContainerName != "web" {
+		t.Fatalf("alerts = %+v, want only the exit-1 container", alerts)
+	}
+}
+
+func TestReconcileUnsubscribesDisabledRule(t *testing.T) {
+	rule := config.AlertRule{ID: "r1", Name: "boom", Enabled: true, Type: "log", Pattern: "boom", Threshold: 1}
+	te := startTestEngine(t, rule)
+	waitFor(t, "subscription", func() bool { return te.hub.liveCount() == 1 })
+
+	rule.Enabled = false
+	te.conf.set(config.AlertsConfig{Rules: []config.AlertRule{rule}})
+	te.e.Reconcile()
+
+	waitFor(t, "unsubscribe", func() bool { return te.hub.liveCount() == 0 })
+}
+
+func TestStaleGenerationMatchDiscarded(t *testing.T) {
+	r1 := config.AlertRule{ID: "r1", Name: "old", Enabled: true, Type: "log", Pattern: "boom", Threshold: 1}
+	te := startTestEngine(t, r1)
+	waitFor(t, "subscription", func() bool { return te.hub.liveCount() == 1 })
+	oldSink := te.hub.firstLive().sink
+
+	r2 := config.AlertRule{ID: "r2", Name: "new", Enabled: true, Type: "log", Pattern: "second", Threshold: 1}
+	te.conf.set(config.AlertsConfig{Rules: []config.AlertRule{r2}})
+	te.e.Reconcile()
+	waitFor(t, "resubscribe", func() bool {
+		te.hub.mu.Lock()
+		defer te.hub.mu.Unlock()
+		return len(te.hub.subs) == 2 && te.hub.subs[0].removed && !te.hub.subs[1].removed
+	})
+
+	// Simulate a record that was already in flight on the old delivery
+	// goroutine: its match carries the old generation and must be discarded.
+	oldSink(record(models.LogLevelError, "boom"))
+	// FIFO on firedCh: once the r2 alert lands, the stale match has been
+	// processed (and discarded) too.
+	te.hub.emit(record(models.LogLevelError, "second"))
+
+	waitFor(t, "new-rule alert", func() bool { return len(te.e.History(0)) == 1 })
+	if got := te.e.History(0)[0].RuleID; got != "r2" {
+		t.Fatalf("alert rule = %q, want r2 (stale r1 match must be discarded)", got)
+	}
+}
+
+func TestEngineDeliversToWebhook(t *testing.T) {
+	var mu sync.Mutex
+	var payloads []webhookPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p webhookPayload
+		json.NewDecoder(r.Body).Decode(&p)
+		mu.Lock()
+		payloads = append(payloads, p)
+		mu.Unlock()
+	}))
+	defer srv.Close()
+
+	te := startTestEngine(t, config.AlertRule{ID: "r1", Name: "boom", Enabled: true, Type: "log", Pattern: "boom", Threshold: 1})
+	te.conf.set(config.AlertsConfig{WebhookURL: srv.URL, Rules: te.conf.get().Rules})
+	waitFor(t, "subscription", func() bool { return te.hub.liveCount() == 1 })
+
+	te.hub.emit(record(models.LogLevelError, "boom"))
+
+	waitFor(t, "delivered alert", func() bool {
+		h := te.e.History(0)
+		return len(h) == 1 && h[0].Delivery != nil
+	})
+	if d := te.e.History(0)[0].Delivery; d.Status != "ok" || d.HTTPStatus != http.StatusOK {
+		t.Fatalf("delivery = %+v, want ok/200", d)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(payloads) != 1 || payloads[0].Alert.RuleID != "r1" {
+		t.Fatalf("webhook payloads = %+v", payloads)
+	}
+}
+
+func TestTestWebhookNoURLAndDelivery(t *testing.T) {
+	te := startTestEngine(t)
+
+	res := te.e.TestWebhook(context.Background())
+	if res.Status != "failed" || res.Error != "no webhook configured" {
+		t.Fatalf("result = %+v, want failed/no webhook configured", res)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	te.conf.set(config.AlertsConfig{WebhookURL: srv.URL})
+
+	res = te.e.TestWebhook(context.Background())
+	if res.Status != "ok" {
+		t.Fatalf("result = %+v, want ok", res)
+	}
+	if h := te.e.History(0); len(h) != 0 {
+		t.Fatalf("test webhook must not be recorded in history, got %+v", h)
+	}
+}
+
+func TestShutdownIsPromptAndFlushesHistory(t *testing.T) {
+	te := startTestEngine(t, config.AlertRule{ID: "r1", Name: "boom", Enabled: true, Type: "log", Pattern: "boom", Threshold: 1})
+	waitFor(t, "subscription", func() bool { return te.hub.liveCount() == 1 })
+
+	te.hub.emit(record(models.LogLevelError, "boom"))
+	waitFor(t, "alert", func() bool { return len(te.e.History(0)) == 1 })
+
+	te.cancel()
+	done := make(chan struct{})
+	go func() {
+		te.e.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Wait did not return promptly after cancel")
+	}
+
+	if te.hub.liveCount() != 0 {
+		t.Fatal("hub subscriptions not removed on shutdown")
+	}
+	data, err := os.ReadFile(te.path)
+	if err != nil {
+		t.Fatalf("history not flushed on shutdown: %v", err)
+	}
+	var onDisk []models.Alert
+	if err := json.Unmarshal(data, &onDisk); err != nil || len(onDisk) != 1 {
+		t.Fatalf("flushed history = %q (err %v), want 1 entry", data, err)
+	}
+}
+
+func TestClearHistoryThroughEngine(t *testing.T) {
+	te := startTestEngine(t, config.AlertRule{ID: "r1", Name: "boom", Enabled: true, Type: "log", Pattern: "boom", Threshold: 1})
+	waitFor(t, "subscription", func() bool { return te.hub.liveCount() == 1 })
+	te.hub.emit(record(models.LogLevelError, "boom"))
+	waitFor(t, "alert", func() bool { return len(te.e.History(0)) == 1 })
+
+	te.e.ClearHistory()
+	if h := te.e.History(0); h == nil || len(h) != 0 {
+		t.Fatalf("after ClearHistory History = %#v, want non-nil empty", h)
+	}
+}

--- a/server/internal/alerts/history.go
+++ b/server/internal/alerts/history.go
@@ -1,0 +1,15 @@
+package alerts
+
+import (
+	"sync"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// history is a bounded in-memory store of fired alerts, newest first. The
+// alert history territory fills in the implementation.
+type history struct {
+	mu      sync.Mutex
+	max     int
+	entries []models.Alert
+}

--- a/server/internal/alerts/history.go
+++ b/server/internal/alerts/history.go
@@ -71,6 +71,21 @@ func (h *history) append(a models.Alert) {
 	h.dirty = true
 }
 
+// setDelivery records the delivery result on the entry with the given alert
+// ID and marks the store dirty. An ID that is no longer present (evicted past
+// the cap or cleared) is ignored.
+func (h *history) setDelivery(id string, result models.DeliveryResult) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := range h.entries {
+		if h.entries[i].ID == id {
+			h.entries[i].Delivery = &result
+			h.dirty = true
+			return
+		}
+	}
+}
+
 // list returns up to limit entries, newest first. limit <= 0 falls back to
 // defaultHistoryLimit. The result is always a non-nil copy.
 func (h *history) list(limit int) []models.Alert {
@@ -98,23 +113,20 @@ func (h *history) clear() {
 
 // flushIfDirty writes the current entries to disk when there are unpersisted
 // changes. On write failure the store stays dirty so the next flush retries.
+// h.mu is held across the entire write (the payload is at most historyCap
+// small structs) so concurrent flushes cannot interleave on the shared tmp
+// file and a stale snapshot can never win the rename over a newer one.
 func (h *history) flushIfDirty() {
 	h.mu.Lock()
+	defer h.mu.Unlock()
 	if !h.dirty {
-		h.mu.Unlock()
 		return
 	}
-	snapshot := make([]models.Alert, len(h.entries))
-	copy(snapshot, h.entries)
-	h.dirty = false
-	h.mu.Unlock()
-
-	if err := writeHistoryFile(h.path, snapshot); err != nil {
+	if err := writeHistoryFile(h.path, h.entries); err != nil {
 		log.Printf("alerts: failed to persist alert history: %v", err)
-		h.mu.Lock()
-		h.dirty = true
-		h.mu.Unlock()
+		return
 	}
+	h.dirty = false
 }
 
 // flushLoop persists dirty state at most every historyFlushEvery until stop

--- a/server/internal/alerts/history.go
+++ b/server/internal/alerts/history.go
@@ -1,15 +1,156 @@
 package alerts
 
 import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
 )
 
-// history is a bounded in-memory store of fired alerts, newest first. The
-// alert history territory fills in the implementation.
+const (
+	historyCap          = 500
+	historyFlushEvery   = 2 * time.Second
+	defaultHistoryLimit = 100
+)
+
+// history is a bounded in-memory store of fired alerts, newest first,
+// mirrored to a JSON file next to the config file. Appends mark the store
+// dirty; flushLoop persists at most every historyFlushEvery via an atomic
+// tmp+rename write and flushes synchronously once more on shutdown.
 type history struct {
+	path string
+	max  int
+
 	mu      sync.Mutex
-	max     int
-	entries []models.Alert
+	entries []models.Alert // newest first
+	dirty   bool
+}
+
+func newHistory(path string, max int) *history {
+	return &history{path: path, max: max}
+}
+
+// load reads the persisted history from disk. A missing file yields an empty
+// history; a corrupt file logs a warning and starts empty. Never fatal.
+func (h *history) load() {
+	data, err := os.ReadFile(h.path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("alerts: failed to read history file %s: %v", h.path, err)
+		}
+		return
+	}
+	var entries []models.Alert
+	if err := json.Unmarshal(data, &entries); err != nil {
+		log.Printf("alerts: history file %s is corrupt, starting empty: %v", h.path, err)
+		return
+	}
+	if len(entries) > h.max {
+		entries = entries[:h.max]
+	}
+	h.mu.Lock()
+	h.entries = entries
+	h.mu.Unlock()
+}
+
+// append inserts an alert at the front (newest first), evicting the oldest
+// entry beyond the cap, and marks the store dirty.
+func (h *history) append(a models.Alert) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.entries = append(h.entries, models.Alert{})
+	copy(h.entries[1:], h.entries)
+	h.entries[0] = a
+	if len(h.entries) > h.max {
+		h.entries = h.entries[:h.max]
+	}
+	h.dirty = true
+}
+
+// list returns up to limit entries, newest first. limit <= 0 falls back to
+// defaultHistoryLimit. The result is always a non-nil copy.
+func (h *history) list(limit int) []models.Alert {
+	if limit <= 0 {
+		limit = defaultHistoryLimit
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if limit > len(h.entries) {
+		limit = len(h.entries)
+	}
+	out := make([]models.Alert, limit)
+	copy(out, h.entries[:limit])
+	return out
+}
+
+// clear empties the history and persists the empty state immediately.
+func (h *history) clear() {
+	h.mu.Lock()
+	h.entries = nil
+	h.dirty = true
+	h.mu.Unlock()
+	h.flushIfDirty()
+}
+
+// flushIfDirty writes the current entries to disk when there are unpersisted
+// changes. On write failure the store stays dirty so the next flush retries.
+func (h *history) flushIfDirty() {
+	h.mu.Lock()
+	if !h.dirty {
+		h.mu.Unlock()
+		return
+	}
+	snapshot := make([]models.Alert, len(h.entries))
+	copy(snapshot, h.entries)
+	h.dirty = false
+	h.mu.Unlock()
+
+	if err := writeHistoryFile(h.path, snapshot); err != nil {
+		log.Printf("alerts: failed to persist alert history: %v", err)
+		h.mu.Lock()
+		h.dirty = true
+		h.mu.Unlock()
+	}
+}
+
+// flushLoop persists dirty state at most every historyFlushEvery until stop
+// closes, then performs a final synchronous flush.
+func (h *history) flushLoop(stop <-chan struct{}) {
+	ticker := time.NewTicker(historyFlushEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			h.flushIfDirty()
+		case <-stop:
+			h.flushIfDirty()
+			return
+		}
+	}
+}
+
+// writeHistoryFile writes entries as a JSON array (never null) atomically via
+// a temp file and rename.
+func writeHistoryFile(path string, entries []models.Alert) error {
+	if entries == nil {
+		entries = []models.Alert{}
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal alert history: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to write temp history file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to rename history file: %w", err)
+	}
+	return nil
 }

--- a/server/internal/alerts/history_test.go
+++ b/server/internal/alerts/history_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
@@ -93,6 +94,41 @@ func TestHistoryPersistRoundTrip(t *testing.T) {
 	reloaded.load()
 	if got := reloaded.list(0); len(got) != 2 || got[0].ID != "new" {
 		t.Fatalf("reload = %#v, want [new old]", got)
+	}
+}
+
+// TestHistoryClearWithConcurrentFlushNeverPersistsStale hammers clear against
+// concurrent flushes: whatever the interleaving, once clear and every
+// in-flight flush have returned, a stale pre-clear snapshot must never remain
+// on disk (a restart would resurrect cleared alerts).
+func TestHistoryClearWithConcurrentFlushNeverPersistsStale(t *testing.T) {
+	path := historyPath(t)
+	h := newHistory(path, 500)
+
+	for i := 0; i < 100; i++ {
+		h.append(models.Alert{ID: strconv.Itoa(i)})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.flushIfDirty()
+		}()
+		h.clear()
+		wg.Wait()
+		h.flushIfDirty() // no-op unless a flush failed and left the store dirty
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("iteration %d: read history file: %v", i, err)
+		}
+		var onDisk []models.Alert
+		if err := json.Unmarshal(data, &onDisk); err != nil {
+			t.Fatalf("iteration %d: history file corrupt: %v (content %q)", i, err, data)
+		}
+		if len(onDisk) != 0 {
+			t.Fatalf("iteration %d: stale entries persisted after clear: %+v", i, onDisk)
+		}
 	}
 }
 

--- a/server/internal/alerts/history_test.go
+++ b/server/internal/alerts/history_test.go
@@ -1,0 +1,124 @@
+package alerts
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+func historyPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "alerts-history.json")
+}
+
+func TestHistoryCapEviction(t *testing.T) {
+	h := newHistory(historyPath(t), 3)
+	for i := 1; i <= 5; i++ {
+		h.append(models.Alert{ID: strconv.Itoa(i)})
+	}
+	got := h.list(0)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	for i, want := range []string{"5", "4", "3"} {
+		if got[i].ID != want {
+			t.Fatalf("entry %d = %s, want %s (newest first)", i, got[i].ID, want)
+		}
+	}
+}
+
+func TestHistoryListLimitAndNonNil(t *testing.T) {
+	h := newHistory(historyPath(t), 500)
+
+	if got := h.list(0); got == nil || len(got) != 0 {
+		t.Fatalf("empty list = %#v, want non-nil empty slice", got)
+	}
+	if got := h.list(-1); got == nil {
+		t.Fatal("negative limit returned nil")
+	}
+
+	for i := 1; i <= 5; i++ {
+		h.append(models.Alert{ID: strconv.Itoa(i)})
+	}
+	if got := h.list(2); len(got) != 2 || got[0].ID != "5" {
+		t.Fatalf("list(2) = %#v, want 2 newest entries", got)
+	}
+	if got := h.list(0); len(got) != 5 {
+		t.Fatalf("list(0) = %d entries, want all 5 (default limit)", len(got))
+	}
+}
+
+func TestHistoryCorruptFileTolerated(t *testing.T) {
+	path := historyPath(t)
+	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	h := newHistory(path, 500)
+	h.load()
+	if got := h.list(0); len(got) != 0 {
+		t.Fatalf("corrupt file yielded %d entries, want 0", len(got))
+	}
+	// Store still works after a corrupt load.
+	h.append(models.Alert{ID: "a"})
+	h.flushIfDirty()
+	if got := h.list(0); len(got) != 1 {
+		t.Fatalf("append after corrupt load failed: %d entries", len(got))
+	}
+}
+
+func TestHistoryPersistRoundTrip(t *testing.T) {
+	path := historyPath(t)
+	h := newHistory(path, 500)
+	h.append(models.Alert{ID: "old"})
+	h.append(models.Alert{ID: "new"})
+	h.flushIfDirty()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("history file not written: %v", err)
+	}
+	var onDisk []models.Alert
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("history file is not a JSON array: %v", err)
+	}
+	if len(onDisk) != 2 || onDisk[0].ID != "new" {
+		t.Fatalf("on-disk = %#v, want [new old]", onDisk)
+	}
+
+	reloaded := newHistory(path, 500)
+	reloaded.load()
+	if got := reloaded.list(0); len(got) != 2 || got[0].ID != "new" {
+		t.Fatalf("reload = %#v, want [new old]", got)
+	}
+}
+
+func TestHistoryClearPersistsEmptyArray(t *testing.T) {
+	path := historyPath(t)
+	h := newHistory(path, 500)
+	h.append(models.Alert{ID: "a"})
+	h.flushIfDirty()
+
+	h.clear()
+
+	if got := h.list(0); got == nil || len(got) != 0 {
+		t.Fatalf("after clear list = %#v, want non-nil empty", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var onDisk []models.Alert
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("cleared file is not valid JSON: %v (content %q)", err, data)
+	}
+	if len(onDisk) != 0 {
+		t.Fatalf("cleared file has %d entries, want 0", len(onDisk))
+	}
+	if string(data) == "null" {
+		t.Fatal("cleared file serialized as null, want []")
+	}
+}

--- a/server/internal/alerts/notify.go
+++ b/server/internal/alerts/notify.go
@@ -1,0 +1,10 @@
+package alerts
+
+import "net/http"
+
+// notifier delivers alert payloads to the configured webhook URL and reports
+// each attempt as a models.DeliveryResult. The webhook delivery territory
+// fills in the implementation.
+type notifier struct {
+	client *http.Client
+}

--- a/server/internal/alerts/notify.go
+++ b/server/internal/alerts/notify.go
@@ -1,10 +1,114 @@
 package alerts
 
-import "net/http"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+const (
+	deliverTimeout = 10 * time.Second
+	retryDelay     = 5 * time.Second
+)
+
+// webhookPayload is the JSON body POSTed to the configured webhook. Text and
+// Content carry the same human-readable summary so common receivers (Slack,
+// Discord, Mattermost) render it without templates.
+type webhookPayload struct {
+	Source  string       `json:"source"`
+	Version int          `json:"version"`
+	Text    string       `json:"text"`
+	Content string       `json:"content"`
+	Alert   models.Alert `json:"alert"`
+}
 
 // notifier delivers alert payloads to the configured webhook URL and reports
-// each attempt as a models.DeliveryResult. The webhook delivery territory
-// fills in the implementation.
+// each attempt as a models.DeliveryResult.
 type notifier struct {
-	client *http.Client
+	client     *http.Client
+	retryDelay time.Duration
+}
+
+func newNotifier() *notifier {
+	return &notifier{
+		client:     &http.Client{Timeout: deliverTimeout},
+		retryDelay: retryDelay,
+	}
+}
+
+// alertText builds the human-readable summary for an alert.
+func alertText(a models.Alert) string {
+	target := a.Host
+	if a.ContainerName != "" {
+		target += "/" + a.ContainerName
+	}
+	if target != "" {
+		return fmt.Sprintf("LogDeck alert: %s: %s (%s)", a.RuleName, a.Reason, target)
+	}
+	return fmt.Sprintf("LogDeck alert: %s: %s", a.RuleName, a.Reason)
+}
+
+// deliver POSTs the alert to url. Network errors and 5xx responses are
+// retried once after retryDelay; other statuses are permanent. Closing skip
+// (shutdown) or ctx aborts the retry wait and returns the first result.
+func (n *notifier) deliver(ctx context.Context, url string, alert models.Alert, skip <-chan struct{}) models.DeliveryResult {
+	body, err := json.Marshal(webhookPayload{
+		Source:  "logdeck",
+		Version: 1,
+		Text:    alertText(alert),
+		Content: alertText(alert),
+		Alert:   alert,
+	})
+	if err != nil {
+		return models.DeliveryResult{Status: "failed", Error: fmt.Sprintf("failed to marshal payload: %v", err)}
+	}
+
+	result, retryable := n.attempt(ctx, url, body)
+	if !retryable {
+		return result
+	}
+	select {
+	case <-time.After(n.retryDelay):
+	case <-skip:
+		return result
+	case <-ctx.Done():
+		return result
+	}
+	result, _ = n.attempt(ctx, url, body)
+	return result
+}
+
+// attempt performs one POST and classifies the outcome. The bool reports
+// whether the failure is retryable (network error or 5xx).
+func (n *notifier) attempt(ctx context.Context, url string, body []byte) (models.DeliveryResult, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return models.DeliveryResult{Status: "failed", Error: err.Error()}, false
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return models.DeliveryResult{Status: "failed", Error: err.Error()}, true
+	}
+	defer func() {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return models.DeliveryResult{Status: "ok", HTTPStatus: resp.StatusCode}, false
+	}
+	result := models.DeliveryResult{
+		Status:     "failed",
+		HTTPStatus: resp.StatusCode,
+		Error:      fmt.Sprintf("webhook returned %s", resp.Status),
+	}
+	return result, resp.StatusCode >= 500
 }

--- a/server/internal/alerts/notify_test.go
+++ b/server/internal/alerts/notify_test.go
@@ -1,0 +1,125 @@
+package alerts
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+func testAlert() models.Alert {
+	return models.Alert{
+		ID:            "abcd1234",
+		RuleID:        "r1",
+		RuleName:      "High error rate",
+		Type:          "log",
+		Host:          "local",
+		ContainerName: "web",
+		Reason:        "5 matches (level >= ERROR) within 60s",
+		Count:         5,
+		FiredAt:       "2026-07-10T12:00:00Z",
+	}
+}
+
+func TestDeliverPayloadShape(t *testing.T) {
+	var body []byte
+	var contentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType = r.Header.Get("Content-Type")
+		body, _ = io.ReadAll(r.Body)
+	}))
+	defer srv.Close()
+
+	n := newNotifier()
+	res := n.deliver(context.Background(), srv.URL, testAlert(), nil)
+
+	if res.Status != "ok" || res.HTTPStatus != http.StatusOK {
+		t.Fatalf("result = %+v, want ok/200", res)
+	}
+	if contentType != "application/json" {
+		t.Fatalf("Content-Type = %q", contentType)
+	}
+	var payload webhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("payload is not valid JSON: %v", err)
+	}
+	if payload.Source != "logdeck" || payload.Version != 1 {
+		t.Fatalf("source/version = %q/%d, want logdeck/1", payload.Source, payload.Version)
+	}
+	if payload.Text == "" || payload.Text != payload.Content {
+		t.Fatalf("text %q and content %q must be the same non-empty summary", payload.Text, payload.Content)
+	}
+	if payload.Alert.ID != "abcd1234" || payload.Alert.RuleName != "High error rate" {
+		t.Fatalf("embedded alert wrong: %+v", payload.Alert)
+	}
+}
+
+func TestDeliverRetriesOnceOn5xx(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	n := newNotifier()
+	n.retryDelay = 10 * time.Millisecond
+	res := n.deliver(context.Background(), srv.URL, testAlert(), nil)
+
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+	if res.Status != "ok" {
+		t.Fatalf("result = %+v, want ok after retry", res)
+	}
+}
+
+func TestDeliverNoRetryOn4xx(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	n := newNotifier()
+	n.retryDelay = 10 * time.Millisecond
+	res := n.deliver(context.Background(), srv.URL, testAlert(), nil)
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (4xx is permanent)", got)
+	}
+	if res.Status != "failed" || res.HTTPStatus != http.StatusBadRequest || res.Error == "" {
+		t.Fatalf("result = %+v, want failed/400 with error", res)
+	}
+}
+
+func TestDeliverSkipsRetryOnShutdown(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	n := newNotifier()
+	n.retryDelay = time.Minute // would hang the test if the skip is ignored
+	skip := make(chan struct{})
+	close(skip)
+	res := n.deliver(context.Background(), srv.URL, testAlert(), skip)
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (shutdown skips the retry)", got)
+	}
+	if res.Status != "failed" || res.HTTPStatus != http.StatusInternalServerError {
+		t.Fatalf("result = %+v, want failed/500 first-attempt result", res)
+	}
+}

--- a/server/internal/alerts/rules.go
+++ b/server/internal/alerts/rules.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/logstream"
 	"github.com/AmoabaKelvin/logdeck/internal/models"
 )
 
@@ -19,14 +20,6 @@ const (
 	defaultCooldown = 300 * time.Second
 )
 
-// Docker Compose and recent podman-compose both set the com.docker label;
-// older podman-compose releases only set the io.podman one. Mirrors the
-// helper in internal/logstream.
-var composeProjectLabels = []string{
-	"com.docker.compose.project",
-	"io.podman.compose.project",
-}
-
 // compiledRule is an immutable, normalized snapshot of one enabled alert
 // rule. Sink closures capture it by pointer; reconciles build fresh ones and
 // never mutate rules already handed out.
@@ -35,9 +28,9 @@ type compiledRule struct {
 	name string
 	typ  string // "event" | "log"
 
-	hosts      []string
-	containers []string
-	projects   []string
+	// spec is the rule's container targeting; matching is delegated to
+	// logstream.ContainerSpec.Matches.
+	spec logstream.ContainerSpec
 
 	events []string // event rules: "die" | "oom"
 
@@ -70,17 +63,15 @@ func compileRules(cfg config.AlertsConfig) []*compiledRule {
 		}
 
 		c := &compiledRule{
-			id:         rule.ID,
-			name:       rule.Name,
-			typ:        rule.Type,
-			hosts:      rule.Hosts,
-			containers: rule.Containers,
-			projects:   rule.Projects,
-			events:     rule.Events,
-			threshold:  rule.Threshold,
-			window:     time.Duration(rule.WindowSeconds) * time.Second,
-			cooldown:   time.Duration(rule.CooldownSeconds) * time.Second,
-			src:        rule,
+			id:        rule.ID,
+			name:      rule.Name,
+			typ:       rule.Type,
+			spec:      logstream.ContainerSpec{Hosts: rule.Hosts, Containers: rule.Containers, Projects: rule.Projects},
+			events:    rule.Events,
+			threshold: rule.Threshold,
+			window:    time.Duration(rule.WindowSeconds) * time.Second,
+			cooldown:  time.Duration(rule.CooldownSeconds) * time.Second,
+			src:       rule,
 		}
 		if c.threshold < 1 {
 			c.threshold = 1
@@ -113,30 +104,6 @@ func compileRules(cfg config.AlertsConfig) []*compiledRule {
 		compiled = append(compiled, c)
 	}
 	return compiled
-}
-
-// matchesTarget reports whether a container (host, name without the leading
-// "/", labels) is selected by the rule's targeting. All dimensions are
-// optional; hosts are ANDed with the container/project dimension, which is an
-// OR between exact names and compose projects.
-func (r *compiledRule) matchesTarget(host, name string, labels map[string]string) bool {
-	if len(r.hosts) > 0 && !slices.Contains(r.hosts, host) {
-		return false
-	}
-	if len(r.containers) == 0 && len(r.projects) == 0 {
-		return true
-	}
-	if slices.Contains(r.containers, name) {
-		return true
-	}
-	for _, project := range r.projects {
-		for _, label := range composeProjectLabels {
-			if labels[label] == project {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // matchesEntry reports whether a log entry satisfies the rule's level and

--- a/server/internal/alerts/rules.go
+++ b/server/internal/alerts/rules.go
@@ -1,0 +1,157 @@
+package alerts
+
+import (
+	"log"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+const (
+	defaultWindow = 60 * time.Second
+	// defaultCooldown applies when CooldownSeconds is 0. The JSON schema
+	// cannot distinguish an absent field from an explicit 0, so 0 means "use
+	// the default"; a rule that wants effectively no cooldown sets 1.
+	defaultCooldown = 300 * time.Second
+)
+
+// Docker Compose and recent podman-compose both set the com.docker label;
+// older podman-compose releases only set the io.podman one. Mirrors the
+// helper in internal/logstream.
+var composeProjectLabels = []string{
+	"com.docker.compose.project",
+	"io.podman.compose.project",
+}
+
+// compiledRule is an immutable, normalized snapshot of one enabled alert
+// rule. Sink closures capture it by pointer; reconciles build fresh ones and
+// never mutate rules already handed out.
+type compiledRule struct {
+	id   string
+	name string
+	typ  string // "event" | "log"
+
+	hosts      []string
+	containers []string
+	projects   []string
+
+	events []string // event rules: "die" | "oom"
+
+	minLevel    string // normalized upper-case, "" when unset
+	minSeverity int    // >= 1 when minLevel is set; UNKNOWN (0) never passes
+	pattern     *regexp.Regexp
+
+	threshold int
+	window    time.Duration
+	cooldown  time.Duration
+
+	// src is the original rule as configured, kept for change detection
+	// across reconciles.
+	src config.AlertRule
+}
+
+// compileRules turns the configured rules into compiled ones. Disabled rules,
+// rules with an unknown type, and rules with an invalid pattern are skipped
+// (the latter two with a log line). Defaults are normalized here so the rest
+// of the engine never re-checks them.
+func compileRules(cfg config.AlertsConfig) []*compiledRule {
+	compiled := make([]*compiledRule, 0, len(cfg.Rules))
+	for _, rule := range cfg.Rules {
+		if !rule.Enabled {
+			continue
+		}
+		if rule.Type != "event" && rule.Type != "log" {
+			log.Printf("alerts: rule %q (%s): unknown type %q, skipping", rule.Name, rule.ID, rule.Type)
+			continue
+		}
+
+		c := &compiledRule{
+			id:         rule.ID,
+			name:       rule.Name,
+			typ:        rule.Type,
+			hosts:      rule.Hosts,
+			containers: rule.Containers,
+			projects:   rule.Projects,
+			events:     rule.Events,
+			threshold:  rule.Threshold,
+			window:     time.Duration(rule.WindowSeconds) * time.Second,
+			cooldown:   time.Duration(rule.CooldownSeconds) * time.Second,
+			src:        rule,
+		}
+		if c.threshold < 1 {
+			c.threshold = 1
+		}
+		if c.window <= 0 {
+			c.window = defaultWindow
+		}
+		if c.cooldown <= 0 {
+			c.cooldown = defaultCooldown
+		}
+
+		if level := strings.ToUpper(strings.TrimSpace(rule.MinLevel)); level != "" {
+			c.minLevel = level
+			c.minSeverity = models.LevelSeverity(models.LogLevel(level))
+			if c.minSeverity < 1 {
+				// Unrecognized level: require at least TRACE so UNKNOWN
+				// entries (severity 0) still never pass a set MinLevel.
+				c.minSeverity = 1
+			}
+		}
+		if rule.Pattern != "" {
+			re, err := regexp.Compile(rule.Pattern)
+			if err != nil {
+				log.Printf("alerts: rule %q (%s): invalid pattern: %v, skipping", rule.Name, rule.ID, err)
+				continue
+			}
+			c.pattern = re
+		}
+
+		compiled = append(compiled, c)
+	}
+	return compiled
+}
+
+// matchesTarget reports whether a container (host, name without the leading
+// "/", labels) is selected by the rule's targeting. All dimensions are
+// optional; hosts are ANDed with the container/project dimension, which is an
+// OR between exact names and compose projects.
+func (r *compiledRule) matchesTarget(host, name string, labels map[string]string) bool {
+	if len(r.hosts) > 0 && !slices.Contains(r.hosts, host) {
+		return false
+	}
+	if len(r.containers) == 0 && len(r.projects) == 0 {
+		return true
+	}
+	if slices.Contains(r.containers, name) {
+		return true
+	}
+	for _, project := range r.projects {
+		for _, label := range composeProjectLabels {
+			if labels[label] == project {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matchesEntry reports whether a log entry satisfies the rule's level and
+// pattern filters. Both filters are optional and ANDed.
+func (r *compiledRule) matchesEntry(entry models.LogEntry) bool {
+	if r.minSeverity > 0 && models.LevelSeverity(entry.Level) < r.minSeverity {
+		return false
+	}
+	if r.pattern != nil && !r.pattern.MatchString(entry.Message) && !r.pattern.MatchString(entry.Raw) {
+		return false
+	}
+	return true
+}
+
+// hasEvent reports whether the rule watches the given event action.
+func (r *compiledRule) hasEvent(action string) bool {
+	return slices.Contains(r.events, action)
+}

--- a/server/internal/alerts/rules_test.go
+++ b/server/internal/alerts/rules_test.go
@@ -1,0 +1,119 @@
+package alerts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+func TestCompileRulesNormalizationAndSkips(t *testing.T) {
+	cfg := config.AlertsConfig{Rules: []config.AlertRule{
+		{ID: "a", Enabled: true, Type: "log"},
+		{ID: "b", Enabled: false, Type: "log"},
+		{ID: "c", Enabled: true, Type: "log", Pattern: "("},
+		{ID: "d", Enabled: true, Type: "weird"},
+		{ID: "e", Enabled: true, Type: "event", Events: []string{"die"}, Threshold: 5, WindowSeconds: 120, CooldownSeconds: 1},
+	}}
+
+	compiled := compileRules(cfg)
+	if len(compiled) != 2 {
+		t.Fatalf("compiled %d rules, want 2 (disabled, invalid-regex, and unknown-type skipped)", len(compiled))
+	}
+
+	a := compiled[0]
+	if a.id != "a" || a.threshold != 1 || a.window != 60*time.Second || a.cooldown != 300*time.Second {
+		t.Fatalf("rule a defaults not applied: %+v", a)
+	}
+	e := compiled[1]
+	if e.id != "e" || e.threshold != 5 || e.window != 120*time.Second || e.cooldown != time.Second {
+		t.Fatalf("rule e values not preserved: %+v", e)
+	}
+	if !e.hasEvent("die") || e.hasEvent("oom") {
+		t.Fatal("rule e event set wrong")
+	}
+}
+
+func compileOne(t *testing.T, rule config.AlertRule) *compiledRule {
+	t.Helper()
+	rule.Enabled = true
+	compiled := compileRules(config.AlertsConfig{Rules: []config.AlertRule{rule}})
+	if len(compiled) != 1 {
+		t.Fatalf("rule did not compile: %+v", rule)
+	}
+	return compiled[0]
+}
+
+func TestMatchesTargetMatrix(t *testing.T) {
+	dockerLabels := map[string]string{"com.docker.compose.project": "shop"}
+	podmanLabels := map[string]string{"io.podman.compose.project": "shop"}
+
+	tests := []struct {
+		name   string
+		rule   config.AlertRule
+		host   string
+		cname  string
+		labels map[string]string
+		want   bool
+	}{
+		{"all empty matches everything", config.AlertRule{Type: "log"}, "h1", "web", nil, true},
+		{"host match", config.AlertRule{Type: "log", Hosts: []string{"h1"}}, "h1", "web", nil, true},
+		{"host mismatch", config.AlertRule{Type: "log", Hosts: []string{"h1"}}, "h2", "web", nil, false},
+		{"container match", config.AlertRule{Type: "log", Containers: []string{"web"}}, "h1", "web", nil, true},
+		{"container mismatch", config.AlertRule{Type: "log", Containers: []string{"web"}}, "h1", "db", nil, false},
+		{"project via docker label", config.AlertRule{Type: "log", Projects: []string{"shop"}}, "h1", "db", dockerLabels, true},
+		{"project via podman label", config.AlertRule{Type: "log", Projects: []string{"shop"}}, "h1", "db", podmanLabels, true},
+		{"project mismatch", config.AlertRule{Type: "log", Projects: []string{"shop"}}, "h1", "db", map[string]string{"com.docker.compose.project": "other"}, false},
+		{"container OR project: name miss, project hit", config.AlertRule{Type: "log", Containers: []string{"api"}, Projects: []string{"shop"}}, "h1", "db", dockerLabels, true},
+		{"container OR project: both miss", config.AlertRule{Type: "log", Containers: []string{"api"}, Projects: []string{"blog"}}, "h1", "db", dockerLabels, false},
+		{"host AND container: host miss", config.AlertRule{Type: "log", Hosts: []string{"h1"}, Containers: []string{"web"}}, "h2", "web", nil, false},
+		{"host AND container: both hit", config.AlertRule{Type: "log", Hosts: []string{"h1"}, Containers: []string{"web"}}, "h1", "web", nil, true},
+		{"host only: any container on host", config.AlertRule{Type: "log", Hosts: []string{"h1"}}, "h1", "anything", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := compileOne(t, tt.rule)
+			if got := rule.matchesTarget(tt.host, tt.cname, tt.labels); got != tt.want {
+				t.Fatalf("matchesTarget(%s, %s, %v) = %v, want %v", tt.host, tt.cname, tt.labels, got, tt.want)
+			}
+		})
+	}
+}
+
+func entryWith(level models.LogLevel, message string) models.LogEntry {
+	return models.LogEntry{Level: level, Message: message, Raw: message}
+}
+
+func TestMatchesEntry(t *testing.T) {
+	tests := []struct {
+		name  string
+		rule  config.AlertRule
+		entry models.LogEntry
+		want  bool
+	}{
+		{"no filters match everything", config.AlertRule{Type: "log"}, entryWith(models.LogLevelUnknown, "anything"), true},
+		{"minLevel pass at level", config.AlertRule{Type: "log", MinLevel: "ERROR"}, entryWith(models.LogLevelError, "boom"), true},
+		{"minLevel pass above level", config.AlertRule{Type: "log", MinLevel: "ERROR"}, entryWith(models.LogLevelFatal, "boom"), true},
+		{"minLevel fail below level", config.AlertRule{Type: "log", MinLevel: "ERROR"}, entryWith(models.LogLevelWarn, "boom"), false},
+		{"UNKNOWN never passes a set minLevel", config.AlertRule{Type: "log", MinLevel: "TRACE"}, entryWith(models.LogLevelUnknown, "boom"), false},
+		{"unrecognized minLevel still blocks UNKNOWN", config.AlertRule{Type: "log", MinLevel: "NOPE"}, entryWith(models.LogLevelUnknown, "boom"), false},
+		{"unrecognized minLevel passes TRACE", config.AlertRule{Type: "log", MinLevel: "NOPE"}, entryWith(models.LogLevelTrace, "boom"), true},
+		{"lowercase minLevel normalized", config.AlertRule{Type: "log", MinLevel: "error"}, entryWith(models.LogLevelError, "boom"), true},
+		{"pattern match on message", config.AlertRule{Type: "log", Pattern: "time.?out"}, entryWith(models.LogLevelUnknown, "request timeout"), true},
+		{"pattern match on raw only", config.AlertRule{Type: "log", Pattern: "^2026"}, models.LogEntry{Level: models.LogLevelInfo, Message: "started", Raw: "2026-07-10 started"}, true},
+		{"pattern no match", config.AlertRule{Type: "log", Pattern: "timeout"}, entryWith(models.LogLevelError, "connection refused"), false},
+		{"level and pattern both required", config.AlertRule{Type: "log", MinLevel: "ERROR", Pattern: "timeout"}, entryWith(models.LogLevelError, "connection refused"), false},
+		{"level and pattern both pass", config.AlertRule{Type: "log", MinLevel: "ERROR", Pattern: "timeout"}, entryWith(models.LogLevelError, "timeout talking to db"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := compileOne(t, tt.rule)
+			if got := rule.matchesEntry(tt.entry); got != tt.want {
+				t.Fatalf("matchesEntry(%+v) = %v, want %v", tt.entry, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/alerts/rules_test.go
+++ b/server/internal/alerts/rules_test.go
@@ -75,8 +75,8 @@ func TestMatchesTargetMatrix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rule := compileOne(t, tt.rule)
-			if got := rule.matchesTarget(tt.host, tt.cname, tt.labels); got != tt.want {
-				t.Fatalf("matchesTarget(%s, %s, %v) = %v, want %v", tt.host, tt.cname, tt.labels, got, tt.want)
+			if got := rule.spec.Matches(tt.host, tt.cname, tt.labels); got != tt.want {
+				t.Fatalf("spec.Matches(%s, %s, %v) = %v, want %v", tt.host, tt.cname, tt.labels, got, tt.want)
 			}
 		})
 	}

--- a/server/internal/alerts/window.go
+++ b/server/internal/alerts/window.go
@@ -1,0 +1,78 @@
+package alerts
+
+import "time"
+
+// ruleWindow tracks the sliding match window and cooldown state for one
+// (rule, host, container) key. All transitions take explicit now values, so
+// the type is pure and directly unit-testable. It is owned exclusively by the
+// engine's run loop; no locking.
+type ruleWindow struct {
+	threshold int
+	window    time.Duration
+	cooldown  time.Duration
+
+	// times is a ring of the last threshold match times.
+	times []time.Time
+	head  int
+	count int
+
+	fired      bool
+	lastFired  time.Time
+	suppressed int
+	lastSeen   time.Time
+}
+
+// observeResult reports the outcome of one recorded match.
+type observeResult struct {
+	fire bool
+	// suppressed is the number of window trips swallowed by the cooldown
+	// since the previous fire; only meaningful when fire is true.
+	suppressed int
+}
+
+func newRuleWindow(threshold int, window, cooldown time.Duration) *ruleWindow {
+	return &ruleWindow{
+		threshold: threshold,
+		window:    window,
+		cooldown:  cooldown,
+		times:     make([]time.Time, threshold),
+	}
+}
+
+// observe records one rule match at now. The window trips when the ring holds
+// threshold matches no further apart than window. A trip inside the cooldown
+// is counted as suppressed; a trip outside it fires, resets the ring, and
+// surfaces the accumulated suppressed count.
+func (w *ruleWindow) observe(now time.Time) observeResult {
+	w.lastSeen = now
+
+	if w.count == w.threshold {
+		w.times[w.head] = time.Time{}
+		w.head = (w.head + 1) % w.threshold
+		w.count--
+	}
+	w.times[(w.head+w.count)%w.threshold] = now
+	w.count++
+
+	if w.count < w.threshold || now.Sub(w.times[w.head]) > w.window {
+		return observeResult{}
+	}
+	if w.fired && now.Sub(w.lastFired) < w.cooldown {
+		w.suppressed++
+		return observeResult{}
+	}
+
+	res := observeResult{fire: true, suppressed: w.suppressed}
+	w.head = 0
+	w.count = 0
+	w.fired = true
+	w.lastFired = now
+	w.suppressed = 0
+	return res
+}
+
+// idleSince reports how long ago the key last saw a match, used by the run
+// loop to prune long-idle state.
+func (w *ruleWindow) idleSince(now time.Time) time.Duration {
+	return now.Sub(w.lastSeen)
+}

--- a/server/internal/alerts/window_test.go
+++ b/server/internal/alerts/window_test.go
@@ -1,0 +1,123 @@
+package alerts
+
+import (
+	"testing"
+	"time"
+)
+
+var t0 = time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+func at(seconds int) time.Time {
+	return t0.Add(time.Duration(seconds) * time.Second)
+}
+
+func TestWindowTripsAtExactlyThreshold(t *testing.T) {
+	w := newRuleWindow(3, 60*time.Second, 300*time.Second)
+
+	if res := w.observe(at(0)); res.fire {
+		t.Fatal("fired after 1 of 3 matches")
+	}
+	if res := w.observe(at(1)); res.fire {
+		t.Fatal("fired after 2 of 3 matches")
+	}
+	res := w.observe(at(2))
+	if !res.fire {
+		t.Fatal("did not fire at exactly 3 matches inside the window")
+	}
+	if res.suppressed != 0 {
+		t.Fatalf("suppressed = %d, want 0", res.suppressed)
+	}
+}
+
+func TestWindowNoTripBelowThreshold(t *testing.T) {
+	w := newRuleWindow(3, 60*time.Second, 300*time.Second)
+
+	if w.observe(at(0)).fire || w.observe(at(1)).fire {
+		t.Fatal("fired below threshold")
+	}
+}
+
+func TestWindowStraddling(t *testing.T) {
+	w := newRuleWindow(3, 60*time.Second, 300*time.Second)
+
+	w.observe(at(0))
+	w.observe(at(30))
+	if w.observe(at(90)).fire {
+		t.Fatal("fired although the 3 matches span more than the window")
+	}
+	if w.observe(at(100)).fire {
+		t.Fatal("fired although the last 3 matches span 70s > 60s window")
+	}
+	if !w.observe(at(110)).fire {
+		t.Fatal("did not fire once the last 3 matches fit inside the window")
+	}
+}
+
+func TestCooldownSuppressAggregateAndSurface(t *testing.T) {
+	w := newRuleWindow(1, 60*time.Second, 300*time.Second)
+
+	if !w.observe(at(0)).fire {
+		t.Fatal("first match did not fire")
+	}
+	if w.observe(at(10)).fire || w.observe(at(20)).fire {
+		t.Fatal("fired inside the cooldown")
+	}
+
+	res := w.observe(at(301))
+	if !res.fire {
+		t.Fatal("did not fire after the cooldown elapsed")
+	}
+	if res.suppressed != 2 {
+		t.Fatalf("suppressed = %d, want 2", res.suppressed)
+	}
+
+	// Suppression counter resets after surfacing.
+	if w.observe(at(310)).fire {
+		t.Fatal("fired inside the second cooldown")
+	}
+	res = w.observe(at(602))
+	if !res.fire {
+		t.Fatal("did not fire after the second cooldown elapsed")
+	}
+	if res.suppressed != 1 {
+		t.Fatalf("suppressed = %d, want 1", res.suppressed)
+	}
+}
+
+func TestWindowResetsAfterFire(t *testing.T) {
+	w := newRuleWindow(2, 60*time.Second, time.Second)
+
+	w.observe(at(0))
+	if !w.observe(at(1)).fire {
+		t.Fatal("did not fire at threshold")
+	}
+	// The ring was reset: one fresh match must not fire even though the
+	// pre-fire matches were recent and the cooldown has elapsed.
+	if w.observe(at(3)).fire {
+		t.Fatal("fired with only 1 fresh match after reset")
+	}
+	if !w.observe(at(4)).fire {
+		t.Fatal("did not fire once threshold fresh matches accumulated again")
+	}
+}
+
+func TestWindowsAreIndependent(t *testing.T) {
+	a := newRuleWindow(2, 60*time.Second, 300*time.Second)
+	b := newRuleWindow(2, 60*time.Second, 300*time.Second)
+
+	a.observe(at(0))
+	if b.observe(at(1)).fire {
+		t.Fatal("window b fired from window a's match")
+	}
+	if !a.observe(at(2)).fire {
+		t.Fatal("window a did not fire at its own threshold")
+	}
+}
+
+func TestWindowIdleSince(t *testing.T) {
+	w := newRuleWindow(1, 60*time.Second, 300*time.Second)
+	w.observe(at(0))
+	if got := w.idleSince(at(90)); got != 90*time.Second {
+		t.Fatalf("idleSince = %v, want 90s", got)
+	}
+}

--- a/server/internal/api/alerts_handlers.go
+++ b/server/internal/api/alerts_handlers.go
@@ -1,0 +1,55 @@
+package api
+
+import "net/http"
+
+// Alert endpoints are registered ahead of the alerting territories; every
+// handler returns 501 until its implementation lands.
+
+func alertsNotImplemented(w http.ResponseWriter) {
+	WriteJsonResponse(w, http.StatusNotImplemented, map[string]string{"error": "not implemented"})
+}
+
+// ListAlertRules handles GET /api/v1/alerts/rules.
+func (ar *APIRouter) ListAlertRules(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// CreateAlertRule handles POST /api/v1/alerts/rules.
+func (ar *APIRouter) CreateAlertRule(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// UpdateAlertRule handles PUT /api/v1/alerts/rules/{id}.
+func (ar *APIRouter) UpdateAlertRule(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// DeleteAlertRule handles DELETE /api/v1/alerts/rules/{id}.
+func (ar *APIRouter) DeleteAlertRule(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// GetAlertsWebhook handles GET /api/v1/alerts/webhook.
+func (ar *APIRouter) GetAlertsWebhook(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// UpdateAlertsWebhook handles PUT /api/v1/alerts/webhook.
+func (ar *APIRouter) UpdateAlertsWebhook(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// TestAlertsWebhook handles POST /api/v1/alerts/test.
+func (ar *APIRouter) TestAlertsWebhook(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// GetAlertHistory handles GET /api/v1/alerts/history.
+func (ar *APIRouter) GetAlertHistory(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}
+
+// ClearAlertHistory handles DELETE /api/v1/alerts/history.
+func (ar *APIRouter) ClearAlertHistory(w http.ResponseWriter, r *http.Request) {
+	alertsNotImplemented(w)
+}

--- a/server/internal/api/alerts_handlers.go
+++ b/server/internal/api/alerts_handlers.go
@@ -1,55 +1,416 @@
 package api
 
-import "net/http"
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 
-// Alert endpoints are registered ahead of the alerting territories; every
-// handler returns 501 until its implementation lands.
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/go-chi/chi/v5"
+)
 
-func alertsNotImplemented(w http.ResponseWriter) {
-	WriteJsonResponse(w, http.StatusNotImplemented, map[string]string{"error": "not implemented"})
+const (
+	maxAlertRules        = 50
+	maxAlertRuleNameLen  = 64
+	maxAlertThreshold    = 1000
+	minAlertWindowSecs   = 5
+	maxAlertWindowSecs   = 3600
+	maxAlertCooldownSecs = 86400
+
+	defaultAlertHistoryLimit = 100
+	maxAlertHistoryLimit     = 500
+)
+
+var (
+	errAlertRuleLimit    = fmt.Errorf("maximum of %d alert rules reached", maxAlertRules)
+	errAlertRuleNotFound = errors.New("alert rule not found")
+)
+
+// alertRuleRequest is the client-supplied portion of an alert rule. Enabled is
+// a pointer so an omitted value can default to true.
+type alertRuleRequest struct {
+	Name            string   `json:"name"`
+	Enabled         *bool    `json:"enabled"`
+	Type            string   `json:"type"`
+	Hosts           []string `json:"hosts"`
+	Containers      []string `json:"containers"`
+	Projects        []string `json:"projects"`
+	Events          []string `json:"events"`
+	MinLevel        string   `json:"minLevel"`
+	Pattern         string   `json:"pattern"`
+	Threshold       int      `json:"threshold"`
+	WindowSeconds   int      `json:"windowSeconds"`
+	CooldownSeconds int      `json:"cooldownSeconds"`
+}
+
+// validAlertMinLevels are the log levels accepted for a log rule's minLevel.
+// UNKNOWN is deliberately excluded: unclassified lines never satisfy a
+// min-level threshold.
+var validAlertMinLevels = map[string]bool{
+	string(models.LogLevelTrace): true,
+	string(models.LogLevelDebug): true,
+	string(models.LogLevelInfo):  true,
+	string(models.LogLevelWarn):  true,
+	string(models.LogLevelError): true,
+	string(models.LogLevelFatal): true,
+	string(models.LogLevelPanic): true,
+}
+
+var validAlertEvents = map[string]bool{
+	"die": true,
+	"oom": true,
+}
+
+// buildAlertRule validates and normalizes a rule request into a config rule.
+// ID and CreatedAt are left empty for the caller to fill in.
+func buildAlertRule(req alertRuleRequest) (config.AlertRule, error) {
+	rule := config.AlertRule{
+		Name:            strings.TrimSpace(req.Name),
+		Enabled:         true,
+		Type:            req.Type,
+		Hosts:           req.Hosts,
+		Containers:      req.Containers,
+		Projects:        req.Projects,
+		Events:          req.Events,
+		MinLevel:        strings.ToUpper(strings.TrimSpace(req.MinLevel)),
+		Pattern:         strings.TrimSpace(req.Pattern),
+		Threshold:       req.Threshold,
+		WindowSeconds:   req.WindowSeconds,
+		CooldownSeconds: req.CooldownSeconds,
+	}
+	if req.Enabled != nil {
+		rule.Enabled = *req.Enabled
+	}
+
+	if rule.Name == "" {
+		return rule, errors.New("name is required")
+	}
+	if len(rule.Name) > maxAlertRuleNameLen {
+		return rule, fmt.Errorf("name must be at most %d characters", maxAlertRuleNameLen)
+	}
+
+	for _, targets := range []struct {
+		field  string
+		values []string
+	}{
+		{"hosts", rule.Hosts},
+		{"containers", rule.Containers},
+		{"projects", rule.Projects},
+	} {
+		for _, v := range targets.values {
+			if strings.TrimSpace(v) == "" {
+				return rule, fmt.Errorf("%s must not contain empty entries", targets.field)
+			}
+		}
+	}
+
+	switch rule.Type {
+	case "event":
+		if len(rule.Events) == 0 {
+			return rule, errors.New("events is required for an event rule")
+		}
+		for _, ev := range rule.Events {
+			if !validAlertEvents[ev] {
+				return rule, fmt.Errorf("events contains invalid value %q (must be \"die\" or \"oom\")", ev)
+			}
+		}
+		if rule.MinLevel != "" {
+			return rule, errors.New("minLevel must be empty for an event rule")
+		}
+		if rule.Pattern != "" {
+			return rule, errors.New("pattern must be empty for an event rule")
+		}
+	case "log":
+		if len(rule.Events) > 0 {
+			return rule, errors.New("events must be empty for a log rule")
+		}
+		if rule.MinLevel == "" && rule.Pattern == "" {
+			return rule, errors.New("a log rule requires at least one of minLevel or pattern")
+		}
+		if rule.MinLevel != "" && !validAlertMinLevels[rule.MinLevel] {
+			return rule, fmt.Errorf("minLevel %q is not a valid log level", rule.MinLevel)
+		}
+		if rule.Pattern != "" {
+			if _, err := regexp.Compile(rule.Pattern); err != nil {
+				return rule, fmt.Errorf("pattern is not a valid regular expression: %v", err)
+			}
+		}
+	case "":
+		return rule, errors.New("type is required")
+	default:
+		return rule, fmt.Errorf("type %q is invalid (must be \"event\" or \"log\")", rule.Type)
+	}
+
+	if rule.Threshold < 0 {
+		return rule, errors.New("threshold must not be negative")
+	}
+	if rule.Threshold > maxAlertThreshold {
+		return rule, fmt.Errorf("threshold must be at most %d", maxAlertThreshold)
+	}
+	if rule.Threshold == 0 {
+		rule.Threshold = 1
+	}
+
+	if rule.WindowSeconds < 0 {
+		return rule, errors.New("windowSeconds must not be negative")
+	}
+	if rule.WindowSeconds == 0 {
+		rule.WindowSeconds = 60
+	} else if rule.WindowSeconds < minAlertWindowSecs || rule.WindowSeconds > maxAlertWindowSecs {
+		return rule, fmt.Errorf("windowSeconds must be between %d and %d", minAlertWindowSecs, maxAlertWindowSecs)
+	}
+
+	if rule.CooldownSeconds < 0 {
+		return rule, errors.New("cooldownSeconds must not be negative")
+	}
+	if rule.CooldownSeconds > maxAlertCooldownSecs {
+		return rule, fmt.Errorf("cooldownSeconds must be at most %d", maxAlertCooldownSecs)
+	}
+
+	return rule, nil
+}
+
+// generateAlertRuleID returns a random 8-character hex rule identifier.
+func generateAlertRuleID() (string, error) {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// reconcileAlerts nudges the alerting engine after a config change. The engine
+// is nil in some router configurations (e.g. tests), which is safe to skip.
+func (ar *APIRouter) reconcileAlerts() {
+	if ar.engine != nil {
+		ar.engine.Reconcile()
+	}
 }
 
 // ListAlertRules handles GET /api/v1/alerts/rules.
 func (ar *APIRouter) ListAlertRules(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	fc := ar.manager.FileConfigSnapshot()
+	rules := []config.AlertRule{}
+	if fc.Alerts != nil {
+		rules = append(rules, fc.Alerts.Rules...)
+	}
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"rules": rules})
 }
 
 // CreateAlertRule handles POST /api/v1/alerts/rules.
 func (ar *APIRouter) CreateAlertRule(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	var req alertRuleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	rule, err := buildAlertRule(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	id, err := generateAlertRuleID()
+	if err != nil {
+		http.Error(w, "failed to generate rule id", http.StatusInternalServerError)
+		return
+	}
+	rule.ID = id
+	rule.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	err = ar.manager.UpdateAlerts(func(current config.AlertsConfig) (config.AlertsConfig, error) {
+		if len(current.Rules) >= maxAlertRules {
+			return current, errAlertRuleLimit
+		}
+		current.Rules = append(current.Rules, rule)
+		return current, nil
+	})
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errAlertRuleLimit) {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	ar.reconcileAlerts()
+	WriteJsonResponse(w, http.StatusCreated, rule)
 }
 
 // UpdateAlertRule handles PUT /api/v1/alerts/rules/{id}.
 func (ar *APIRouter) UpdateAlertRule(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	id := chi.URLParam(r, "id")
+
+	var req alertRuleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	rule, err := buildAlertRule(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = ar.manager.UpdateAlerts(func(current config.AlertsConfig) (config.AlertsConfig, error) {
+		for i, existing := range current.Rules {
+			if existing.ID == id {
+				rule.ID = existing.ID
+				rule.CreatedAt = existing.CreatedAt
+				current.Rules[i] = rule
+				return current, nil
+			}
+		}
+		return current, errAlertRuleNotFound
+	})
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errAlertRuleNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	ar.reconcileAlerts()
+	WriteJsonResponse(w, http.StatusOK, rule)
 }
 
 // DeleteAlertRule handles DELETE /api/v1/alerts/rules/{id}.
 func (ar *APIRouter) DeleteAlertRule(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	id := chi.URLParam(r, "id")
+
+	err := ar.manager.UpdateAlerts(func(current config.AlertsConfig) (config.AlertsConfig, error) {
+		next := current.Rules[:0]
+		for _, rule := range current.Rules {
+			if rule.ID != id {
+				next = append(next, rule)
+			}
+		}
+		if len(next) == len(current.Rules) {
+			return current, errAlertRuleNotFound
+		}
+		current.Rules = next
+		return current, nil
+	})
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errAlertRuleNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	ar.reconcileAlerts()
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"message": "rule deleted"})
 }
 
 // GetAlertsWebhook handles GET /api/v1/alerts/webhook.
 func (ar *APIRouter) GetAlertsWebhook(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	fc := ar.manager.FileConfigSnapshot()
+	webhookURL := ""
+	if fc.Alerts != nil {
+		webhookURL = fc.Alerts.WebhookURL
+	}
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"url": webhookURL})
 }
 
 // UpdateAlertsWebhook handles PUT /api/v1/alerts/webhook.
 func (ar *APIRouter) UpdateAlertsWebhook(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	var req struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	webhookURL := strings.TrimSpace(req.URL)
+	if webhookURL != "" {
+		parsed, err := url.Parse(webhookURL)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+			http.Error(w, "url must be a valid http or https URL", http.StatusBadRequest)
+			return
+		}
+	}
+
+	err := ar.manager.UpdateAlerts(func(current config.AlertsConfig) (config.AlertsConfig, error) {
+		current.WebhookURL = webhookURL
+		return current, nil
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	ar.reconcileAlerts()
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"url": webhookURL})
 }
 
-// TestAlertsWebhook handles POST /api/v1/alerts/test.
+// TestAlertsWebhook handles POST /api/v1/alerts/test. The delivery result is
+// returned with a 200 whether or not the delivery itself succeeded; the
+// result's status field carries the outcome.
 func (ar *APIRouter) TestAlertsWebhook(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	if ar.engine == nil {
+		http.Error(w, "alerting engine not available", http.StatusInternalServerError)
+		return
+	}
+	result := ar.engine.TestWebhook(r.Context())
+	WriteJsonResponse(w, http.StatusOK, result)
 }
 
 // GetAlertHistory handles GET /api/v1/alerts/history.
 func (ar *APIRouter) GetAlertHistory(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	if ar.engine == nil {
+		http.Error(w, "alerting engine not available", http.StatusInternalServerError)
+		return
+	}
+
+	limit := defaultAlertHistoryLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			http.Error(w, "limit must be an integer", http.StatusBadRequest)
+			return
+		}
+		limit = parsed
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > maxAlertHistoryLimit {
+		limit = maxAlertHistoryLimit
+	}
+
+	alerts := ar.engine.History(limit)
+	if alerts == nil {
+		alerts = []models.Alert{}
+	}
+	WriteJsonResponse(w, http.StatusOK, map[string]any{
+		"alerts": alerts,
+		"count":  len(alerts),
+	})
 }
 
 // ClearAlertHistory handles DELETE /api/v1/alerts/history.
 func (ar *APIRouter) ClearAlertHistory(w http.ResponseWriter, r *http.Request) {
-	alertsNotImplemented(w)
+	if ar.engine == nil {
+		http.Error(w, "alerting engine not available", http.StatusInternalServerError)
+		return
+	}
+	ar.engine.ClearHistory()
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"message": "history cleared"})
 }

--- a/server/internal/api/alerts_handlers.go
+++ b/server/internal/api/alerts_handlers.go
@@ -98,6 +98,12 @@ func buildAlertRule(req alertRuleRequest) (config.AlertRule, error) {
 		return rule, fmt.Errorf("name must be at most %d characters", maxAlertRuleNameLen)
 	}
 
+	// Normalize container names: the engine and hub match against names
+	// without the Docker API's leading "/", so "/web" would never match.
+	for i, c := range rule.Containers {
+		rule.Containers[i] = strings.TrimPrefix(strings.TrimSpace(c), "/")
+	}
+
 	for _, targets := range []struct {
 		field  string
 		values []string
@@ -357,7 +363,11 @@ func (ar *APIRouter) UpdateAlertsWebhook(w http.ResponseWriter, r *http.Request)
 	}
 
 	ar.reconcileAlerts()
-	WriteJsonResponse(w, http.StatusOK, map[string]any{"url": webhookURL})
+	message := "Webhook updated"
+	if webhookURL == "" {
+		message = "Webhook cleared"
+	}
+	WriteJsonResponse(w, http.StatusOK, map[string]any{"message": message})
 }
 
 // TestAlertsWebhook handles POST /api/v1/alerts/test. The delivery result is

--- a/server/internal/api/alerts_handlers_test.go
+++ b/server/internal/api/alerts_handlers_test.go
@@ -1,0 +1,430 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/alerts"
+	"github.com/AmoabaKelvin/logdeck/internal/auth"
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/AmoabaKelvin/logdeck/internal/services"
+)
+
+// newAlertsTestRouter builds a router with a clean env-derived config, the
+// given auth service (nil means auth disabled), and a real alerting engine.
+// It returns the router and the config file path so tests can re-open the
+// persisted config.
+func newAlertsTestRouter(t *testing.T, authSvc *auth.Service) (http.Handler, string) {
+	t.Helper()
+	for _, key := range []string{
+		"JWT_SECRET", "ADMIN_USERNAME", "ADMIN_PASSWORD", "ADMIN_PASSWORD_SALT",
+		"DOCKER_HOSTS", "COOLIFY_CONFIGS", "READONLY_MODE", "CORS_ALLOWED_ORIGINS",
+	} {
+		t.Setenv(key, "")
+	}
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("CONFIG_PATH", configPath)
+
+	manager := config.NewManager()
+	registry := services.NewRegistry(nil, nil, authSvc, manager.Config())
+	engine := alerts.NewEngine(registry, manager, nil)
+	return NewRouter(registry, manager, engine, "test"), configPath
+}
+
+func doAlertsRequest(t *testing.T, router http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *strings.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	} else {
+		reader = strings.NewReader("")
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(method, path, reader)
+	router.ServeHTTP(w, r)
+	return w
+}
+
+func createAlertRule(t *testing.T, router http.Handler, body string) config.AlertRule {
+	t.Helper()
+	w := doAlertsRequest(t, router, "POST", "/api/v1/alerts/rules", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 creating rule, got %d: %s", w.Code, w.Body.String())
+	}
+	var rule config.AlertRule
+	if err := json.Unmarshal(w.Body.Bytes(), &rule); err != nil {
+		t.Fatalf("failed to parse create response: %v", err)
+	}
+	return rule
+}
+
+func listAlertRulesRaw(t *testing.T, router http.Handler) (json.RawMessage, []config.AlertRule) {
+	t.Helper()
+	w := doAlertsRequest(t, router, "GET", "/api/v1/alerts/rules", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 listing rules, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Rules json.RawMessage `json:"rules"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse list response: %v", err)
+	}
+	var rules []config.AlertRule
+	if err := json.Unmarshal(resp.Rules, &rules); err != nil {
+		t.Fatalf("failed to parse rules array: %v", err)
+	}
+	return resp.Rules, rules
+}
+
+func TestListAlertRulesEmptyIsNotNull(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+	raw, _ := listAlertRulesRaw(t, router)
+	if string(raw) != "[]" {
+		t.Errorf("expected rules to be [], got %s", raw)
+	}
+}
+
+func TestAlertRulesCRUDRoundTrip(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+
+	created := createAlertRule(t, router, `{"name":"container crashes","type":"event","events":["die","oom"]}`)
+	if !regexp.MustCompile(`^[0-9a-f]{8}$`).MatchString(created.ID) {
+		t.Errorf("expected 8-hex rule id, got %q", created.ID)
+	}
+	if _, err := time.Parse(time.RFC3339, created.CreatedAt); err != nil {
+		t.Errorf("createdAt %q is not RFC3339: %v", created.CreatedAt, err)
+	}
+	if !created.Enabled {
+		t.Error("expected enabled to default to true")
+	}
+	if created.Threshold != 1 {
+		t.Errorf("expected threshold default 1, got %d", created.Threshold)
+	}
+	if created.WindowSeconds != 60 {
+		t.Errorf("expected windowSeconds default 60, got %d", created.WindowSeconds)
+	}
+	if created.CooldownSeconds != 0 {
+		t.Errorf("expected cooldownSeconds default 0, got %d", created.CooldownSeconds)
+	}
+
+	_, rules := listAlertRulesRaw(t, router)
+	if len(rules) != 1 || rules[0].ID != created.ID || rules[0].Name != "container crashes" {
+		t.Fatalf("unexpected rules after create: %+v", rules)
+	}
+
+	// Full-rule update: ID and CreatedAt must be preserved.
+	w := doAlertsRequest(t, router, "PUT", "/api/v1/alerts/rules/"+created.ID,
+		`{"name":"crashes only","type":"event","events":["die"],"enabled":false,"threshold":3,"windowSeconds":120}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 updating rule, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated config.AlertRule
+	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("failed to parse update response: %v", err)
+	}
+	if updated.ID != created.ID || updated.CreatedAt != created.CreatedAt {
+		t.Errorf("update must preserve id and createdAt: %+v vs %+v", updated, created)
+	}
+	if updated.Name != "crashes only" || updated.Enabled || updated.Threshold != 3 || updated.WindowSeconds != 120 {
+		t.Errorf("unexpected updated rule: %+v", updated)
+	}
+	if len(updated.Events) != 1 || updated.Events[0] != "die" {
+		t.Errorf("unexpected updated events: %v", updated.Events)
+	}
+
+	_, rules = listAlertRulesRaw(t, router)
+	if len(rules) != 1 || rules[0].Name != "crashes only" {
+		t.Fatalf("unexpected rules after update: %+v", rules)
+	}
+
+	w = doAlertsRequest(t, router, "DELETE", "/api/v1/alerts/rules/"+created.ID, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 deleting rule, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "rule deleted") {
+		t.Errorf("unexpected delete response: %s", w.Body.String())
+	}
+
+	raw, rules := listAlertRulesRaw(t, router)
+	if len(rules) != 0 || string(raw) != "[]" {
+		t.Errorf("expected empty [] rules after delete, got %s", raw)
+	}
+}
+
+var alertRuleValidationCases = []struct{ name, body string }{
+	{"invalid json", `{`},
+	{"missing name", `{"type":"log","minLevel":"ERROR"}`},
+	{"whitespace name", `{"name":"   ","type":"log","minLevel":"ERROR"}`},
+	{"name too long", fmt.Sprintf(`{"name":%q,"type":"log","minLevel":"ERROR"}`, strings.Repeat("a", 65))},
+	{"missing type", `{"name":"r"}`},
+	{"invalid type", `{"name":"r","type":"metric"}`},
+	{"event missing events", `{"name":"r","type":"event"}`},
+	{"event empty events", `{"name":"r","type":"event","events":[]}`},
+	{"event invalid event", `{"name":"r","type":"event","events":["start"]}`},
+	{"event with minLevel", `{"name":"r","type":"event","events":["die"],"minLevel":"ERROR"}`},
+	{"event with pattern", `{"name":"r","type":"event","events":["die"],"pattern":"x"}`},
+	{"log without minLevel or pattern", `{"name":"r","type":"log"}`},
+	{"log invalid minLevel", `{"name":"r","type":"log","minLevel":"VERBOSE"}`},
+	{"log minLevel UNKNOWN", `{"name":"r","type":"log","minLevel":"UNKNOWN"}`},
+	{"log invalid pattern", `{"name":"r","type":"log","pattern":"("}`},
+	{"log with events", `{"name":"r","type":"log","minLevel":"ERROR","events":["die"]}`},
+	{"negative threshold", `{"name":"r","type":"log","minLevel":"ERROR","threshold":-1}`},
+	{"threshold too high", `{"name":"r","type":"log","minLevel":"ERROR","threshold":1001}`},
+	{"negative windowSeconds", `{"name":"r","type":"log","minLevel":"ERROR","windowSeconds":-1}`},
+	{"windowSeconds too small", `{"name":"r","type":"log","minLevel":"ERROR","windowSeconds":4}`},
+	{"windowSeconds too large", `{"name":"r","type":"log","minLevel":"ERROR","windowSeconds":3601}`},
+	{"negative cooldownSeconds", `{"name":"r","type":"log","minLevel":"ERROR","cooldownSeconds":-1}`},
+	{"cooldownSeconds too large", `{"name":"r","type":"log","minLevel":"ERROR","cooldownSeconds":86401}`},
+	{"empty hosts entry", `{"name":"r","type":"log","minLevel":"ERROR","hosts":[""]}`},
+	{"blank containers entry", `{"name":"r","type":"log","minLevel":"ERROR","containers":[" "]}`},
+	{"empty projects entry", `{"name":"r","type":"log","minLevel":"ERROR","projects":[""]}`},
+}
+
+func TestCreateAlertRuleValidation(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+	for _, tc := range alertRuleValidationCases {
+		w := doAlertsRequest(t, router, "POST", "/api/v1/alerts/rules", tc.body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d: %s", tc.name, w.Code, w.Body.String())
+		}
+	}
+
+	// No invalid rule may have been persisted.
+	raw, _ := listAlertRulesRaw(t, router)
+	if string(raw) != "[]" {
+		t.Errorf("expected no rules persisted after invalid creates, got %s", raw)
+	}
+}
+
+func TestUpdateAlertRuleValidation(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+	created := createAlertRule(t, router, `{"name":"errors","type":"log","minLevel":"ERROR"}`)
+
+	for _, tc := range alertRuleValidationCases {
+		w := doAlertsRequest(t, router, "PUT", "/api/v1/alerts/rules/"+created.ID, tc.body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d: %s", tc.name, w.Code, w.Body.String())
+		}
+	}
+
+	// The stored rule must be untouched.
+	_, rules := listAlertRulesRaw(t, router)
+	if len(rules) != 1 || rules[0].Name != "errors" {
+		t.Errorf("expected original rule intact after invalid updates, got %+v", rules)
+	}
+}
+
+func TestCreateAlertRuleNormalization(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+	created := createAlertRule(t, router,
+		`{"name":"  noisy errors  ","type":"log","minLevel":" error ","pattern":" boom "}`)
+
+	if created.Name != "noisy errors" {
+		t.Errorf("expected trimmed name, got %q", created.Name)
+	}
+	if created.MinLevel != "ERROR" {
+		t.Errorf("expected minLevel normalized to ERROR, got %q", created.MinLevel)
+	}
+	if created.Pattern != "boom" {
+		t.Errorf("expected trimmed pattern, got %q", created.Pattern)
+	}
+}
+
+func TestCreateAlertRuleExplicitEnabledFalse(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+	created := createAlertRule(t, router, `{"name":"paused","type":"log","minLevel":"WARN","enabled":false}`)
+	if created.Enabled {
+		t.Error("expected enabled false to be respected")
+	}
+}
+
+func TestCreateAlertRuleLimit(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+	for i := 0; i < 50; i++ {
+		createAlertRule(t, router, fmt.Sprintf(`{"name":"rule-%d","type":"log","minLevel":"ERROR"}`, i))
+	}
+
+	w := doAlertsRequest(t, router, "POST", "/api/v1/alerts/rules", `{"name":"one-too-many","type":"log","minLevel":"ERROR"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 when exceeding rule cap, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAndDeleteUnknownAlertRule(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+
+	w := doAlertsRequest(t, router, "PUT", "/api/v1/alerts/rules/deadbeef", `{"name":"r","type":"log","minLevel":"ERROR"}`)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 updating unknown rule, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = doAlertsRequest(t, router, "DELETE", "/api/v1/alerts/rules/deadbeef", "")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 deleting unknown rule, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAlertsWebhookSetAndClear(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+
+	getURL := func() string {
+		t.Helper()
+		w := doAlertsRequest(t, router, "GET", "/api/v1/alerts/webhook", "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 getting webhook, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to parse webhook response: %v", err)
+		}
+		return resp.URL
+	}
+
+	if got := getURL(); got != "" {
+		t.Errorf("expected empty webhook url initially, got %q", got)
+	}
+
+	w := doAlertsRequest(t, router, "PUT", "/api/v1/alerts/webhook", `{"url":"https://example.com/hook"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 setting webhook, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := getURL(); got != "https://example.com/hook" {
+		t.Errorf("expected webhook url to persist, got %q", got)
+	}
+
+	for _, body := range []string{
+		`{"url":"not a url"}`,
+		`{"url":"ftp://example.com/hook"}`,
+		`{"url":"http://"}`,
+		`{`,
+	} {
+		w = doAlertsRequest(t, router, "PUT", "/api/v1/alerts/webhook", body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("body %s: expected 400, got %d: %s", body, w.Code, w.Body.String())
+		}
+	}
+	if got := getURL(); got != "https://example.com/hook" {
+		t.Errorf("invalid updates must not change the webhook, got %q", got)
+	}
+
+	w = doAlertsRequest(t, router, "PUT", "/api/v1/alerts/webhook", `{"url":""}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 clearing webhook, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := getURL(); got != "" {
+		t.Errorf("expected webhook cleared, got %q", got)
+	}
+}
+
+func TestAlertsTestWebhookEndpoint(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+
+	w := doAlertsRequest(t, router, "POST", "/api/v1/alerts/test", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from test webhook, got %d: %s", w.Code, w.Body.String())
+	}
+	var result models.DeliveryResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to parse delivery result: %v", err)
+	}
+}
+
+func TestAlertHistory(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+
+	w := doAlertsRequest(t, router, "GET", "/api/v1/alerts/history", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 getting history, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Alerts json.RawMessage `json:"alerts"`
+		Count  int             `json:"count"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse history response: %v", err)
+	}
+	if string(resp.Alerts) != "[]" {
+		t.Errorf("expected alerts to be [], got %s", resp.Alerts)
+	}
+	if resp.Count != 0 {
+		t.Errorf("expected count 0, got %d", resp.Count)
+	}
+
+	// Non-integer limit is rejected; out-of-range limits are clamped, not errors.
+	w = doAlertsRequest(t, router, "GET", "/api/v1/alerts/history?limit=abc", "")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-integer limit, got %d", w.Code)
+	}
+	for _, limit := range []string{"0", "-5", "1", "500", "9999"} {
+		w = doAlertsRequest(t, router, "GET", "/api/v1/alerts/history?limit="+limit, "")
+		if w.Code != http.StatusOK {
+			t.Errorf("limit=%s: expected 200, got %d: %s", limit, w.Code, w.Body.String())
+		}
+	}
+
+	w = doAlertsRequest(t, router, "DELETE", "/api/v1/alerts/history", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 clearing history, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "history cleared") {
+		t.Errorf("unexpected clear response: %s", w.Body.String())
+	}
+}
+
+func TestAlertRulesPersistAcrossManagerReload(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, nil)
+
+	created := createAlertRule(t, router, `{"name":"persisted","type":"log","minLevel":"ERROR"}`)
+	w := doAlertsRequest(t, router, "PUT", "/api/v1/alerts/webhook", `{"url":"https://example.com/hook"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 setting webhook, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Re-open the config file with a fresh manager (CONFIG_PATH is still set).
+	reloaded := config.NewManager()
+	fc := reloaded.FileConfigSnapshot()
+	if fc.Alerts == nil {
+		t.Fatal("expected alerts config to persist across reload")
+	}
+	if fc.Alerts.WebhookURL != "https://example.com/hook" {
+		t.Errorf("expected webhook url to persist, got %q", fc.Alerts.WebhookURL)
+	}
+	if len(fc.Alerts.Rules) != 1 || fc.Alerts.Rules[0].ID != created.ID || fc.Alerts.Rules[0].Name != "persisted" {
+		t.Errorf("expected created rule to persist, got %+v", fc.Alerts.Rules)
+	}
+}
+
+func TestAlertRoutesRequireAuthWhenEnabled(t *testing.T) {
+	router, _ := newAlertsTestRouter(t, newTestAuthService(t))
+
+	endpoints := []struct{ method, path string }{
+		{"GET", "/api/v1/alerts/rules"},
+		{"POST", "/api/v1/alerts/rules"},
+		{"PUT", "/api/v1/alerts/rules/deadbeef"},
+		{"DELETE", "/api/v1/alerts/rules/deadbeef"},
+		{"GET", "/api/v1/alerts/webhook"},
+		{"PUT", "/api/v1/alerts/webhook"},
+		{"POST", "/api/v1/alerts/test"},
+		{"GET", "/api/v1/alerts/history"},
+		{"DELETE", "/api/v1/alerts/history"},
+	}
+	for _, e := range endpoints {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(e.method, e.path, nil)
+		router.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: expected 401 without token, got %d", e.method, e.path, w.Code)
+		}
+	}
+}

--- a/server/internal/api/alerts_handlers_test.go
+++ b/server/internal/api/alerts_handlers_test.go
@@ -186,6 +186,7 @@ var alertRuleValidationCases = []struct{ name, body string }{
 	{"cooldownSeconds too large", `{"name":"r","type":"log","minLevel":"ERROR","cooldownSeconds":86401}`},
 	{"empty hosts entry", `{"name":"r","type":"log","minLevel":"ERROR","hosts":[""]}`},
 	{"blank containers entry", `{"name":"r","type":"log","minLevel":"ERROR","containers":[" "]}`},
+	{"slash-only containers entry", `{"name":"r","type":"log","minLevel":"ERROR","containers":["/"]}`},
 	{"empty projects entry", `{"name":"r","type":"log","minLevel":"ERROR","projects":[""]}`},
 }
 
@@ -226,7 +227,7 @@ func TestUpdateAlertRuleValidation(t *testing.T) {
 func TestCreateAlertRuleNormalization(t *testing.T) {
 	router, _ := newAlertsTestRouter(t, nil)
 	created := createAlertRule(t, router,
-		`{"name":"  noisy errors  ","type":"log","minLevel":" error ","pattern":" boom "}`)
+		`{"name":"  noisy errors  ","type":"log","minLevel":" error ","pattern":" boom ","containers":["/web"," api "]}`)
 
 	if created.Name != "noisy errors" {
 		t.Errorf("expected trimmed name, got %q", created.Name)
@@ -236,6 +237,11 @@ func TestCreateAlertRuleNormalization(t *testing.T) {
 	}
 	if created.Pattern != "boom" {
 		t.Errorf("expected trimmed pattern, got %q", created.Pattern)
+	}
+	// Container names are matched without the Docker API's leading "/": a
+	// rule created with "/web" must be stored slash-stripped and trimmed.
+	if len(created.Containers) != 2 || created.Containers[0] != "web" || created.Containers[1] != "api" {
+		t.Errorf("expected containers normalized to [web api], got %v", created.Containers)
 	}
 }
 
@@ -299,6 +305,9 @@ func TestAlertsWebhookSetAndClear(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 setting webhook, got %d: %s", w.Code, w.Body.String())
 	}
+	if !strings.Contains(w.Body.String(), "Webhook updated") {
+		t.Errorf("unexpected set response: %s", w.Body.String())
+	}
 	if got := getURL(); got != "https://example.com/hook" {
 		t.Errorf("expected webhook url to persist, got %q", got)
 	}
@@ -321,6 +330,9 @@ func TestAlertsWebhookSetAndClear(t *testing.T) {
 	w = doAlertsRequest(t, router, "PUT", "/api/v1/alerts/webhook", `{"url":""}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 clearing webhook, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Webhook cleared") {
+		t.Errorf("unexpected clear response: %s", w.Body.String())
 	}
 	if got := getURL(); got != "" {
 		t.Errorf("expected webhook cleared, got %q", got)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/AmoabaKelvin/logdeck/internal/alerts"
 	"github.com/AmoabaKelvin/logdeck/internal/api/middleware"
 	"github.com/AmoabaKelvin/logdeck/internal/auth"
 	"github.com/AmoabaKelvin/logdeck/internal/config"
@@ -19,14 +20,16 @@ type APIRouter struct {
 	router   *chi.Mux
 	registry *services.Registry
 	manager  *config.Manager
+	engine   *alerts.Engine
 	version  string
 }
 
-func NewRouter(registry *services.Registry, manager *config.Manager, version string) *chi.Mux {
+func NewRouter(registry *services.Registry, manager *config.Manager, engine *alerts.Engine, version string) *chi.Mux {
 	r := &APIRouter{
 		router:   chi.NewRouter(),
 		registry: registry,
 		manager:  manager,
+		engine:   engine,
 		version:  version,
 	}
 
@@ -75,6 +78,9 @@ func (ar *APIRouter) Routes() *chi.Mux {
 
 		// Settings endpoints (follow same auth pattern as other routes)
 		ar.registerSettingsRoutes(r)
+
+		// Alert endpoints (follow same auth pattern as settings routes)
+		ar.registerAlertRoutes(r)
 
 		// All other routes go through dynamic auth middleware
 		r.Group(func(protected chi.Router) {
@@ -146,6 +152,23 @@ func (ar *APIRouter) registerSettingsRoutes(r chi.Router) {
 		r.Delete("/api-tokens/{prefix}", ar.DeleteAPIToken)
 		r.Post("/test/docker-host", ar.TestDockerHost)
 		r.Post("/test/coolify-host", ar.TestCoolifyHost)
+	})
+}
+
+func (ar *APIRouter) registerAlertRoutes(r chi.Router) {
+	r.Route("/alerts", func(r chi.Router) {
+		// Alerts follow the same auth pattern — protected when auth is enabled
+		r.Use(auth.DynamicMiddleware(ar.registry.Auth, ar.lookupAPIToken))
+
+		r.Get("/rules", ar.ListAlertRules)
+		r.Post("/rules", ar.CreateAlertRule)
+		r.Put("/rules/{id}", ar.UpdateAlertRule)
+		r.Delete("/rules/{id}", ar.DeleteAlertRule)
+		r.Get("/webhook", ar.GetAlertsWebhook)
+		r.Put("/webhook", ar.UpdateAlertsWebhook)
+		r.Post("/test", ar.TestAlertsWebhook)
+		r.Get("/history", ar.GetAlertHistory)
+		r.Delete("/history", ar.ClearAlertHistory)
 	})
 }
 

--- a/server/internal/api/settings_auth_test.go
+++ b/server/internal/api/settings_auth_test.go
@@ -25,7 +25,7 @@ func newTestRouter(t *testing.T, authSvc *auth.Service) http.Handler {
 
 	manager := config.NewManager()
 	registry := services.NewRegistry(nil, nil, authSvc, manager.Config())
-	return NewRouter(registry, manager, "test")
+	return NewRouter(registry, manager, nil, "test")
 }
 
 func newTestAuthService(t *testing.T) *auth.Service {

--- a/server/internal/cli/alerts.go
+++ b/server/internal/cli/alerts.go
@@ -52,7 +52,7 @@ type alertInfo struct {
 	Reason        string        `json:"reason"`
 	Sample        string        `json:"sample"`
 	Count         int           `json:"count"`
-	Suppressed    bool          `json:"suppressed"`
+	Suppressed    int           `json:"suppressed"`
 	FiredAt       time.Time     `json:"firedAt"`
 	Delivery      alertDelivery `json:"delivery"`
 }
@@ -392,7 +392,7 @@ func newAlertHistoryCmd(a *app) *cobra.Command {
 					al.RuleName,
 					al.ContainerName + "@" + al.Host,
 					al.Reason,
-					strconv.FormatBool(al.Suppressed),
+					strconv.Itoa(al.Suppressed),
 					deliverySummary(al.Delivery),
 				})
 			}

--- a/server/internal/cli/alerts.go
+++ b/server/internal/cli/alerts.go
@@ -145,8 +145,8 @@ func ruleTargets(r alertRule) string {
 	return strings.Join(parts, " ")
 }
 
-// ruleTrigger summarizes what fires a rule ("die,oom 3x/120s",
-// "level>=ERROR pattern=timeout").
+// ruleTrigger summarizes what fires a rule and how often it may deliver
+// ("die,oom 3x/120s cooldown 60s", "level>=ERROR cooldown 300s (default)").
 func ruleTrigger(r alertRule) string {
 	var parts []string
 	if r.Type == "event" {
@@ -164,8 +164,11 @@ func ruleTrigger(r alertRule) string {
 	if r.Threshold > 0 {
 		parts = append(parts, fmt.Sprintf("%dx/%ds", r.Threshold, r.WindowSeconds))
 	}
-	if len(parts) == 0 {
-		return "-"
+	if r.CooldownSeconds > 0 {
+		parts = append(parts, fmt.Sprintf("cooldown %ds", r.CooldownSeconds))
+	} else {
+		// The server treats 0/absent as its 300s default.
+		parts = append(parts, "cooldown 300s (default)")
 	}
 	return strings.Join(parts, " ")
 }
@@ -285,7 +288,7 @@ func newAlertRuleCreateCmd(a *app) *cobra.Command {
 	cmd.Flags().StringVar(&pattern, "pattern", "", "regex the log message must match (only with --type log)")
 	cmd.Flags().IntVar(&threshold, "threshold", 0, "fire only after this many matches within --window")
 	cmd.Flags().StringVar(&window, "window", "", "threshold window (e.g. 60s, 5m, or bare seconds)")
-	cmd.Flags().StringVar(&cooldown, "cooldown", "", "minimum time between deliveries (e.g. 5m)")
+	cmd.Flags().StringVar(&cooldown, "cooldown", "", "minimum time between deliveries (e.g. 5m); 0 or omitted uses the server default of 300s")
 	cmd.Flags().BoolVar(&disabled, "disabled", false, "create the rule disabled")
 	return cmd
 }

--- a/server/internal/cli/alerts.go
+++ b/server/internal/cli/alerts.go
@@ -1,0 +1,540 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// API response shapes for /api/v1/alerts. Field names mirror the server's
+// JSON exactly.
+
+// alertRule doubles as the create request body: omitempty keeps fields the
+// user didn't set out of the payload, so the server applies its defaults.
+type alertRule struct {
+	ID              string   `json:"id,omitempty"`
+	Name            string   `json:"name"`
+	Enabled         bool     `json:"enabled"`
+	Type            string   `json:"type"`
+	Hosts           []string `json:"hosts,omitempty"`
+	Containers      []string `json:"containers,omitempty"`
+	Projects        []string `json:"projects,omitempty"`
+	Events          []string `json:"events,omitempty"`
+	MinLevel        string   `json:"minLevel,omitempty"`
+	Pattern         string   `json:"pattern,omitempty"`
+	Threshold       int      `json:"threshold,omitempty"`
+	WindowSeconds   int      `json:"windowSeconds,omitempty"`
+	CooldownSeconds int      `json:"cooldownSeconds,omitempty"`
+}
+
+type alertDelivery struct {
+	Status     string `json:"status"`
+	HTTPStatus int    `json:"httpStatus"`
+	Error      string `json:"error"`
+}
+
+type alertInfo struct {
+	ID            string        `json:"id"`
+	RuleID        string        `json:"ruleId"`
+	RuleName      string        `json:"ruleName"`
+	Type          string        `json:"type"`
+	Host          string        `json:"host"`
+	ContainerID   string        `json:"containerId"`
+	ContainerName string        `json:"containerName"`
+	Reason        string        `json:"reason"`
+	Sample        string        `json:"sample"`
+	Count         int           `json:"count"`
+	Suppressed    bool          `json:"suppressed"`
+	FiredAt       time.Time     `json:"firedAt"`
+	Delivery      alertDelivery `json:"delivery"`
+}
+
+func newAlertsCmd(a *app) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alerts",
+		Short: "Manage alert rules, the webhook, and fired-alert history",
+	}
+	cmd.AddCommand(
+		newAlertRulesCmd(a),
+		newAlertHistoryCmd(a),
+		newAlertWebhookCmd(a),
+		newAlertTestCmd(a),
+	)
+	return cmd
+}
+
+func newAlertRulesCmd(a *app) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rules",
+		Short: "List alert rules",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var resp struct {
+				Rules json.RawMessage `json:"rules"`
+			}
+			if err := a.client.get(cmd.Context(), "/alerts/rules", nil, &resp); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				var rules any
+				if len(resp.Rules) > 0 {
+					if err := json.Unmarshal(resp.Rules, &rules); err != nil {
+						return err
+					}
+				}
+				if rules == nil {
+					rules = []any{}
+				}
+				return a.printJSON(map[string]any{"rules": rules})
+			}
+
+			var rules []alertRule
+			if len(resp.Rules) > 0 {
+				if err := json.Unmarshal(resp.Rules, &rules); err != nil {
+					return err
+				}
+			}
+			rows := make([][]string, 0, len(rules))
+			for _, r := range rules {
+				rows = append(rows, []string{
+					r.ID,
+					r.Name,
+					r.Type,
+					strconv.FormatBool(r.Enabled),
+					ruleTargets(r),
+					ruleTrigger(r),
+				})
+			}
+			renderTable(os.Stdout, []string{"ID", "NAME", "TYPE", "ENABLED", "TARGETS", "TRIGGER"}, rows)
+			return nil
+		}),
+	}
+	cmd.AddCommand(
+		newAlertRuleCreateCmd(a),
+		newAlertRuleDeleteCmd(a),
+		newAlertRuleToggleCmd(a, "enable", "Enable an alert rule", true),
+		newAlertRuleToggleCmd(a, "disable", "Disable an alert rule", false),
+	)
+	return cmd
+}
+
+// ruleTargets summarizes what a rule applies to ("all" when unrestricted).
+func ruleTargets(r alertRule) string {
+	var parts []string
+	if len(r.Hosts) > 0 {
+		parts = append(parts, "hosts="+strings.Join(r.Hosts, ","))
+	}
+	if len(r.Containers) > 0 {
+		parts = append(parts, "containers="+strings.Join(r.Containers, ","))
+	}
+	if len(r.Projects) > 0 {
+		parts = append(parts, "projects="+strings.Join(r.Projects, ","))
+	}
+	if len(parts) == 0 {
+		return "all"
+	}
+	return strings.Join(parts, " ")
+}
+
+// ruleTrigger summarizes what fires a rule ("die,oom 3x/120s",
+// "level>=ERROR pattern=timeout").
+func ruleTrigger(r alertRule) string {
+	var parts []string
+	if r.Type == "event" {
+		if len(r.Events) > 0 {
+			parts = append(parts, strings.Join(r.Events, ","))
+		}
+	} else {
+		if r.MinLevel != "" {
+			parts = append(parts, "level>="+r.MinLevel)
+		}
+		if r.Pattern != "" {
+			parts = append(parts, "pattern="+r.Pattern)
+		}
+	}
+	if r.Threshold > 0 {
+		parts = append(parts, fmt.Sprintf("%dx/%ds", r.Threshold, r.WindowSeconds))
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, " ")
+}
+
+// parseSecondsFlag converts a duration flag value ("60s", "5m", or bare
+// seconds like "90") to whole seconds. Empty means unset (0).
+func parseSecondsFlag(flag, value string) (int, error) {
+	if value == "" {
+		return 0, nil
+	}
+	if n, err := strconv.Atoi(value); err == nil {
+		if n < 0 {
+			return 0, fmt.Errorf("--%s must be >= 0", flag)
+		}
+		return n, nil
+	}
+	d, err := parseDuration(value)
+	if err != nil || d < 0 {
+		return 0, fmt.Errorf("invalid --%s duration %q (examples: 60s, 5m, 90)", flag, value)
+	}
+	return int(d / time.Second), nil
+}
+
+func newAlertRuleCreateCmd(a *app) *cobra.Command {
+	var (
+		ruleType, name, minLevel, pattern, window, cooldown string
+		hosts, containers, projects, events                 []string
+		threshold                                           int
+		disabled                                            bool
+		req                                                 alertRule
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create --type <log|event> --name <name>",
+		Short: "Create an alert rule",
+		Args:  cobra.NoArgs,
+		// Flag validation runs in PreRunE so bad combinations are usage
+		// errors (exit 2) and never reach the server.
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+			switch ruleType {
+			case "log":
+				if len(events) > 0 {
+					return fmt.Errorf("--events only applies to --type event")
+				}
+			case "event":
+				if len(events) == 0 {
+					return fmt.Errorf("--events is required for --type event (die, oom)")
+				}
+				for _, e := range events {
+					if e != "die" && e != "oom" {
+						return fmt.Errorf("invalid event %q (must be die or oom)", e)
+					}
+				}
+				if minLevel != "" {
+					return fmt.Errorf("--min-level only applies to --type log")
+				}
+				if pattern != "" {
+					return fmt.Errorf("--pattern only applies to --type log")
+				}
+			case "":
+				return fmt.Errorf("--type is required (log or event)")
+			default:
+				return fmt.Errorf("invalid --type %q (must be log or event)", ruleType)
+			}
+
+			req = alertRule{
+				Name:       name,
+				Enabled:    !disabled,
+				Type:       ruleType,
+				Hosts:      hosts,
+				Containers: containers,
+				Projects:   projects,
+				Events:     events,
+				MinLevel:   minLevel,
+				Pattern:    pattern,
+			}
+			if cmd.Flags().Changed("threshold") {
+				if threshold < 1 {
+					return fmt.Errorf("--threshold must be >= 1")
+				}
+				req.Threshold = threshold
+			}
+			var err error
+			if req.WindowSeconds, err = parseSecondsFlag("window", window); err != nil {
+				return err
+			}
+			if req.CooldownSeconds, err = parseSecondsFlag("cooldown", cooldown); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var created map[string]any
+			if err := a.client.post(cmd.Context(), "/alerts/rules", nil, req, &created); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(created)
+			}
+			id, _ := created["id"].(string)
+			fmt.Printf("created rule %q (%s)\n", name, id)
+			return nil
+		}),
+	}
+
+	cmd.Flags().StringVar(&ruleType, "type", "", "rule type: log or event")
+	cmd.Flags().StringVar(&name, "name", "", "rule name")
+	cmd.Flags().StringSliceVar(&hosts, "host", nil, "limit to these hosts (repeatable)")
+	cmd.Flags().StringSliceVar(&containers, "container", nil, "limit to these container names (repeatable)")
+	cmd.Flags().StringSliceVar(&projects, "project", nil, "limit to these compose projects (repeatable)")
+	cmd.Flags().StringSliceVar(&events, "events", nil, "events to match: die, oom (only with --type event)")
+	cmd.Flags().StringVar(&minLevel, "min-level", "", "minimum log level to match, e.g. ERROR (only with --type log)")
+	cmd.Flags().StringVar(&pattern, "pattern", "", "regex the log message must match (only with --type log)")
+	cmd.Flags().IntVar(&threshold, "threshold", 0, "fire only after this many matches within --window")
+	cmd.Flags().StringVar(&window, "window", "", "threshold window (e.g. 60s, 5m, or bare seconds)")
+	cmd.Flags().StringVar(&cooldown, "cooldown", "", "minimum time between deliveries (e.g. 5m)")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "create the rule disabled")
+	return cmd
+}
+
+func newAlertRuleDeleteCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete an alert rule",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			if err := a.client.do(cmd.Context(), http.MethodDelete, "/alerts/rules/"+args[0], nil, nil, nil); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"message": "rule deleted", "id": args[0]})
+			}
+			fmt.Printf("deleted rule %q\n", args[0])
+			return nil
+		}),
+	}
+}
+
+func newAlertRuleToggleCmd(a *app, verb, short string, enabled bool) *cobra.Command {
+	return &cobra.Command{
+		Use:   verb + " <id>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// The API has no single-rule GET: fetch the list, flip the flag,
+			// and PUT the full rule back. Maps keep fields the CLI doesn't
+			// model from being dropped.
+			var resp struct {
+				Rules []map[string]any `json:"rules"`
+			}
+			if err := a.client.get(ctx, "/alerts/rules", nil, &resp); err != nil {
+				return err
+			}
+			for _, rule := range resp.Rules {
+				id, _ := rule["id"].(string)
+				if id != args[0] {
+					continue
+				}
+				rule["enabled"] = enabled
+				if err := a.client.put(ctx, "/alerts/rules/"+id, nil, rule, nil); err != nil {
+					return err
+				}
+
+				if a.jsonOutput() {
+					return a.printJSON(map[string]string{"message": "rule " + verb + "d", "id": id})
+				}
+				fmt.Printf("%sd rule %q\n", verb, id)
+				return nil
+			}
+			return fmt.Errorf("no rule with id %q (see: logdeck alerts rules)", args[0])
+		}),
+	}
+}
+
+func newAlertHistoryCmd(a *app) *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "List recently fired alerts, newest first",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var resp struct {
+				Alerts json.RawMessage `json:"alerts"`
+				Count  int             `json:"count"`
+			}
+			query := url.Values{"limit": {strconv.Itoa(limit)}}
+			if err := a.client.get(cmd.Context(), "/alerts/history", query, &resp); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				var alerts any
+				if len(resp.Alerts) > 0 {
+					if err := json.Unmarshal(resp.Alerts, &alerts); err != nil {
+						return err
+					}
+				}
+				if alerts == nil {
+					alerts = []any{}
+				}
+				return a.printJSON(map[string]any{"alerts": alerts, "count": resp.Count})
+			}
+
+			var alerts []alertInfo
+			if len(resp.Alerts) > 0 {
+				if err := json.Unmarshal(resp.Alerts, &alerts); err != nil {
+					return err
+				}
+			}
+			sort.SliceStable(alerts, func(i, j int) bool { return alerts[i].FiredAt.After(alerts[j].FiredAt) })
+			now := time.Now()
+			rows := make([][]string, 0, len(alerts))
+			for _, al := range alerts {
+				rows = append(rows, []string{
+					humanAge(al.FiredAt, now),
+					al.RuleName,
+					al.ContainerName + "@" + al.Host,
+					al.Reason,
+					strconv.FormatBool(al.Suppressed),
+					deliverySummary(al.Delivery),
+				})
+			}
+			renderTable(os.Stdout, []string{"TIME", "RULE", "CONTAINER@HOST", "REASON", "SUPPRESSED", "DELIVERY"}, rows)
+			return nil
+		}),
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 50, "maximum number of alerts to return")
+	cmd.AddCommand(newAlertHistoryClearCmd(a))
+	return cmd
+}
+
+// deliverySummary renders a delivery result on one line ("ok (HTTP 200)",
+// "failed (HTTP 500): timeout").
+func deliverySummary(d alertDelivery) string {
+	s := d.Status
+	if s == "" {
+		s = "-"
+	}
+	if d.HTTPStatus > 0 {
+		s = fmt.Sprintf("%s (HTTP %d)", s, d.HTTPStatus)
+	}
+	if d.Error != "" {
+		s += ": " + d.Error
+	}
+	return s
+}
+
+func newAlertHistoryClearCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "Delete all fired-alert history",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			if err := a.client.do(cmd.Context(), http.MethodDelete, "/alerts/history", nil, nil, nil); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"message": "alert history cleared"})
+			}
+			fmt.Println("cleared alert history")
+			return nil
+		}),
+	}
+}
+
+func newAlertWebhookCmd(a *app) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "webhook",
+		Short: "Show the alert webhook URL",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var resp struct {
+				URL string `json:"url"`
+			}
+			if err := a.client.get(cmd.Context(), "/alerts/webhook", nil, &resp); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"url": resp.URL})
+			}
+			if resp.URL == "" {
+				fmt.Println("(not set)")
+			} else {
+				fmt.Println(resp.URL)
+			}
+			return nil
+		}),
+	}
+	cmd.AddCommand(newAlertWebhookSetCmd(a), newAlertWebhookClearCmd(a))
+	return cmd
+}
+
+func newAlertWebhookSetCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <url>",
+		Short: "Set the alert webhook URL",
+		Args:  cobra.ExactArgs(1),
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			body := map[string]string{"url": args[0]}
+			if err := a.client.put(cmd.Context(), "/alerts/webhook", nil, body, nil); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"message": "webhook updated", "url": args[0]})
+			}
+			fmt.Printf("webhook set to %s\n", args[0])
+			return nil
+		}),
+	}
+}
+
+func newAlertWebhookClearCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "Clear the alert webhook URL",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			body := map[string]string{"url": ""}
+			if err := a.client.put(cmd.Context(), "/alerts/webhook", nil, body, nil); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				return a.printJSON(map[string]string{"message": "webhook cleared"})
+			}
+			fmt.Println("webhook cleared")
+			return nil
+		}),
+	}
+}
+
+func newAlertTestCmd(a *app) *cobra.Command {
+	return &cobra.Command{
+		Use:   "test",
+		Short: "Send a test alert to the webhook",
+		Args:  cobra.NoArgs,
+		RunE: a.run(func(cmd *cobra.Command, args []string) error {
+			var result alertDelivery
+			if err := a.client.post(cmd.Context(), "/alerts/test", nil, nil, &result); err != nil {
+				return err
+			}
+
+			if a.jsonOutput() {
+				if err := a.printJSON(result); err != nil {
+					return err
+				}
+			} else {
+				fmt.Println("delivery " + deliverySummary(result))
+			}
+			if result.Status != "ok" {
+				msg := "webhook test failed"
+				if result.Error != "" {
+					msg += ": " + result.Error
+				}
+				return fmt.Errorf("%s", msg)
+			}
+			return nil
+		}),
+	}
+}

--- a/server/internal/cli/alerts_test.go
+++ b/server/internal/cli/alerts_test.go
@@ -269,8 +269,8 @@ func TestAlertHistoryTable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotLimit = r.URL.Query().Get("limit")
 		fmt.Fprintf(w, `{"alerts":[
-			{"id":"a1","ruleName":"older-rule","host":"prod","containerName":"web","reason":"exited","suppressed":false,"firedAt":%q,"delivery":{"status":"ok","httpStatus":200,"error":""}},
-			{"id":"a2","ruleName":"newer-rule","host":"prod","containerName":"api","reason":"oom","suppressed":true,"firedAt":%q,"delivery":{"status":"failed","httpStatus":500,"error":"boom"}}
+			{"id":"a1","ruleName":"older-rule","host":"prod","containerName":"web","reason":"exited","suppressed":0,"firedAt":%q,"delivery":{"status":"ok","httpStatus":200,"error":""}},
+			{"id":"a2","ruleName":"newer-rule","host":"prod","containerName":"api","reason":"oom","suppressed":3,"firedAt":%q,"delivery":{"status":"failed","httpStatus":500,"error":"boom"}}
 		],"count":2}`, older, newer)
 	}))
 	defer server.Close()

--- a/server/internal/cli/alerts_test.go
+++ b/server/internal/cli/alerts_test.go
@@ -1,0 +1,400 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureStdout runs fn and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+
+	w.Close()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(data)
+}
+
+func TestAlertRuleCreateLogPayload(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/alerts/rules" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"r1","name":"errors","type":"log"}`)
+	}))
+	defer server.Close()
+
+	code := execute(context.Background(), "test", []string{
+		"alerts", "rules", "create", "--type", "log", "--name", "errors",
+		"--host", "prod", "--container", "web", "--min-level", "ERROR",
+		"--pattern", "timeout", "--threshold", "5", "--window", "60s",
+		"--cooldown", "5m", "--url", server.URL,
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	want := map[string]any{
+		"name":            "errors",
+		"enabled":         true,
+		"type":            "log",
+		"minLevel":        "ERROR",
+		"pattern":         "timeout",
+		"threshold":       float64(5),
+		"windowSeconds":   float64(60),
+		"cooldownSeconds": float64(300),
+	}
+	for key, value := range want {
+		if body[key] != value {
+			t.Errorf("body[%q] = %v, want %v", key, body[key], value)
+		}
+	}
+	if hosts := fmt.Sprintf("%v", body["hosts"]); hosts != "[prod]" {
+		t.Errorf("body[hosts] = %v, want [prod]", body["hosts"])
+	}
+	if containers := fmt.Sprintf("%v", body["containers"]); containers != "[web]" {
+		t.Errorf("body[containers] = %v, want [web]", body["containers"])
+	}
+	for _, absent := range []string{"events", "projects", "id"} {
+		if _, ok := body[absent]; ok {
+			t.Errorf("body should not contain %q, got %v", absent, body[absent])
+		}
+	}
+}
+
+func TestAlertRuleCreateEventPayload(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"r2"}`)
+	}))
+	defer server.Close()
+
+	code := execute(context.Background(), "test", []string{
+		"alerts", "rules", "create", "--type", "event", "--name", "crashes",
+		"--events", "die,oom", "--window", "120", "--disabled",
+		"--url", server.URL,
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	if events := fmt.Sprintf("%v", body["events"]); events != "[die oom]" {
+		t.Errorf("body[events] = %v, want [die oom]", body["events"])
+	}
+	if body["enabled"] != false {
+		t.Errorf("body[enabled] = %v, want false", body["enabled"])
+	}
+	if body["windowSeconds"] != float64(120) {
+		t.Errorf("body[windowSeconds] = %v, want 120", body["windowSeconds"])
+	}
+	for _, absent := range []string{"minLevel", "pattern", "threshold", "cooldownSeconds"} {
+		if _, ok := body[absent]; ok {
+			t.Errorf("body should not contain %q, got %v", absent, body[absent])
+		}
+	}
+}
+
+func TestParseSecondsFlag(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"60s", 60, false},
+		{"5m", 300, false},
+		{"90", 90, false},
+		{"1h", 3600, false},
+		{"-5", 0, true},
+		{"abc", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := parseSecondsFlag("window", tt.value)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseSecondsFlag(%q) expected error, got %d", tt.value, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSecondsFlag(%q) unexpected error: %v", tt.value, err)
+		} else if got != tt.want {
+			t.Errorf("parseSecondsFlag(%q) = %d, want %d", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestAlertRuleCreateUsageErrorsBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"min-level on event", []string{"--type", "event", "--name", "x", "--events", "die", "--min-level", "ERROR"}},
+		{"pattern on event", []string{"--type", "event", "--name", "x", "--events", "die", "--pattern", "re"}},
+		{"events on log", []string{"--type", "log", "--name", "x", "--events", "die"}},
+		{"missing events on event", []string{"--type", "event", "--name", "x"}},
+		{"unknown event", []string{"--type", "event", "--name", "x", "--events", "start"}},
+		{"missing name", []string{"--type", "log"}},
+		{"missing type", []string{"--name", "x"}},
+		{"invalid type", []string{"--type", "bogus", "--name", "x"}},
+		{"invalid window", []string{"--type", "log", "--name", "x", "--window", "abc"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+			requested := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requested = true
+			}))
+			defer server.Close()
+
+			args := append([]string{"alerts", "rules", "create"}, tt.args...)
+			args = append(args, "--url", server.URL)
+			var code int
+			captureStderr(t, func() {
+				code = execute(context.Background(), "test", args)
+			})
+
+			if code != 2 {
+				t.Errorf("exit code = %d, want 2", code)
+			}
+			if requested {
+				t.Error("usage error should not reach the server")
+			}
+		})
+	}
+}
+
+func TestAlertRuleEnableRoundTrip(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var putBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/alerts/rules", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"rules":[{"id":"r1","name":"errors","enabled":false,"type":"log","createdAt":"2026-07-01T00:00:00Z"}]}`)
+	})
+	mux.HandleFunc("/api/v1/alerts/rules/r1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&putBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		fmt.Fprint(w, `{}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	code := execute(context.Background(), "test", []string{
+		"alerts", "rules", "enable", "r1", "--url", server.URL,
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if putBody["enabled"] != true {
+		t.Errorf("putBody[enabled] = %v, want true", putBody["enabled"])
+	}
+	// The full rule round-trips: fields the CLI doesn't model must survive.
+	if putBody["createdAt"] != "2026-07-01T00:00:00Z" {
+		t.Errorf("putBody[createdAt] = %v, want original value preserved", putBody["createdAt"])
+	}
+	if putBody["name"] != "errors" {
+		t.Errorf("putBody[name] = %v, want errors", putBody["name"])
+	}
+}
+
+func TestAlertRuleDisableUnknownID(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"rules":[]}`)
+	}))
+	defer server.Close()
+
+	var code int
+	stderr := captureStderr(t, func() {
+		code = execute(context.Background(), "test", []string{
+			"alerts", "rules", "disable", "nope", "--url", server.URL,
+		})
+	})
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, `no rule with id "nope"`) {
+		t.Errorf("expected unknown-id error, got: %q", stderr)
+	}
+}
+
+func TestAlertHistoryTable(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now().UTC()
+	older := now.Add(-time.Hour).Format(time.RFC3339)
+	newer := now.Add(-3 * time.Minute).Format(time.RFC3339)
+
+	var gotLimit string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("limit")
+		fmt.Fprintf(w, `{"alerts":[
+			{"id":"a1","ruleName":"older-rule","host":"prod","containerName":"web","reason":"exited","suppressed":false,"firedAt":%q,"delivery":{"status":"ok","httpStatus":200,"error":""}},
+			{"id":"a2","ruleName":"newer-rule","host":"prod","containerName":"api","reason":"oom","suppressed":true,"firedAt":%q,"delivery":{"status":"failed","httpStatus":500,"error":"boom"}}
+		],"count":2}`, older, newer)
+	}))
+	defer server.Close()
+
+	var code int
+	stdout := captureStdout(t, func() {
+		code = execute(context.Background(), "test", []string{
+			"alerts", "history", "--limit", "5", "--url", server.URL,
+		})
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if gotLimit != "5" {
+		t.Errorf("limit query = %q, want 5", gotLimit)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected header + 2 rows, got %d lines:\n%s", len(lines), stdout)
+	}
+	for _, column := range []string{"TIME", "RULE", "CONTAINER@HOST", "REASON", "SUPPRESSED", "DELIVERY"} {
+		if !strings.Contains(lines[0], column) {
+			t.Errorf("header missing %q: %q", column, lines[0])
+		}
+	}
+	if !strings.Contains(lines[1], "newer-rule") {
+		t.Errorf("first row should be the newest alert, got: %q", lines[1])
+	}
+	if !strings.Contains(lines[1], "api@prod") || !strings.Contains(lines[1], "failed (HTTP 500): boom") {
+		t.Errorf("newest row missing container@host or delivery summary: %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "older-rule") || !strings.Contains(lines[2], "ok (HTTP 200)") {
+		t.Errorf("second row should be the older alert: %q", lines[2])
+	}
+}
+
+func TestAlertTestExitCodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		wantCode int
+	}{
+		{"ok", `{"status":"ok","httpStatus":200,"error":""}`, 0},
+		{"failed", `{"status":"failed","httpStatus":500,"error":"boom"}`, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/api/v1/alerts/test" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				fmt.Fprint(w, tt.response)
+			}))
+			defer server.Close()
+
+			var code int
+			captureStdout(t, func() {
+				captureStderr(t, func() {
+					code = execute(context.Background(), "test", []string{
+						"alerts", "test", "--url", server.URL,
+					})
+				})
+			})
+			if code != tt.wantCode {
+				t.Errorf("exit code = %d, want %d", code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestAlertRulesJSONPassthrough(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"rules":[{"id":"r1","name":"errors","enabled":true,"type":"log","futureField":42}]}`)
+	}))
+	defer server.Close()
+
+	var code int
+	stdout := captureStdout(t, func() {
+		code = execute(context.Background(), "test", []string{
+			"alerts", "rules", "-o", "json", "--url", server.URL,
+		})
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	var doc struct {
+		Rules []map[string]any `json:"rules"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout: %q", err, stdout)
+	}
+	if len(doc.Rules) != 1 || doc.Rules[0]["id"] != "r1" {
+		t.Fatalf("unexpected rules document: %q", stdout)
+	}
+	// -o json passes the server's list through, keeping unmodeled fields.
+	if doc.Rules[0]["futureField"] != float64(42) {
+		t.Errorf("futureField = %v, want 42 (raw passthrough)", doc.Rules[0]["futureField"])
+	}
+}
+
+func TestAlertWebhookNotSet(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"url":""}`)
+	}))
+	defer server.Close()
+
+	var code int
+	stdout := captureStdout(t, func() {
+		code = execute(context.Background(), "test", []string{
+			"alerts", "webhook", "--url", server.URL,
+		})
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if strings.TrimSpace(stdout) != "(not set)" {
+		t.Errorf("stdout = %q, want (not set)", stdout)
+	}
+}

--- a/server/internal/cli/alerts_test.go
+++ b/server/internal/cli/alerts_test.go
@@ -344,6 +344,41 @@ func TestAlertTestExitCodes(t *testing.T) {
 	}
 }
 
+func TestAlertRulesTableCooldown(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"rules":[
+			{"id":"r1","name":"default-cd","enabled":true,"type":"event","events":["die"]},
+			{"id":"r2","name":"explicit-cd","enabled":true,"type":"log","minLevel":"ERROR","threshold":3,"windowSeconds":60,"cooldownSeconds":120}
+		]}`)
+	}))
+	defer server.Close()
+
+	var code int
+	stdout := captureStdout(t, func() {
+		code = execute(context.Background(), "test", []string{
+			"alerts", "rules", "--url", server.URL,
+		})
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected header + 2 rows, got %d lines:\n%s", len(lines), stdout)
+	}
+	// cooldownSeconds absent/0 means the server default of 300s; the trigger
+	// column must say so instead of hiding the cooldown.
+	if !strings.Contains(lines[1], "cooldown 300s (default)") {
+		t.Errorf("default-cooldown row missing default marker: %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "cooldown 120s") || strings.Contains(lines[2], "default") {
+		t.Errorf("explicit-cooldown row wrong: %q", lines[2])
+	}
+}
+
 func TestAlertRulesJSONPassthrough(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 

--- a/server/internal/cli/root.go
+++ b/server/internal/cli/root.go
@@ -158,6 +158,7 @@ func newRootCmd(a *app) *cobra.Command {
 		newImagesCmd(a),
 		newVolumesCmd(a),
 		newNetworksCmd(a),
+		newAlertsCmd(a),
 	)
 
 	return root

--- a/server/internal/config/alerts.go
+++ b/server/internal/config/alerts.go
@@ -1,0 +1,63 @@
+package config
+
+// AlertsConfig holds the alerting settings persisted in the config file:
+// the webhook destination and the list of alert rules.
+type AlertsConfig struct {
+	WebhookURL string      `json:"webhookUrl,omitempty"`
+	Rules      []AlertRule `json:"rules,omitempty"`
+}
+
+// AlertRule describes one alerting rule.
+type AlertRule struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+	Type    string `json:"type"` // "event" | "log"
+
+	// Targeting: all optional, empty = match-all in that dimension, ANDed.
+	Hosts      []string `json:"hosts,omitempty"`
+	Containers []string `json:"containers,omitempty"` // exact container names
+	Projects   []string `json:"projects,omitempty"`   // compose projects
+
+	// Event rules.
+	Events []string `json:"events,omitempty"` // "die" | "oom"
+
+	// Log rules.
+	MinLevel string `json:"minLevel,omitempty"`
+	Pattern  string `json:"pattern,omitempty"` // RE2
+
+	// Rate + cooldown (both rule types).
+	Threshold       int    `json:"threshold"`
+	WindowSeconds   int    `json:"windowSeconds,omitempty"`
+	CooldownSeconds int    `json:"cooldownSeconds,omitempty"`
+	CreatedAt       string `json:"createdAt"`
+}
+
+// UpdateAlerts applies a mutation function to the stored alerts config
+// atomically. Alerts live only in the file config (never env), so no remerge
+// is needed — readers access them through FileConfigSnapshot.
+func (m *Manager) UpdateAlerts(mutate func(current AlertsConfig) (AlertsConfig, error)) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Clone to prevent mutate from modifying the live config in-place.
+	current := AlertsConfig{}
+	if m.fileConfig.Alerts != nil {
+		current.WebhookURL = m.fileConfig.Alerts.WebhookURL
+		current.Rules = make([]AlertRule, len(m.fileConfig.Alerts.Rules))
+		copy(current.Rules, m.fileConfig.Alerts.Rules)
+	}
+
+	updated, err := mutate(current)
+	if err != nil {
+		return err
+	}
+
+	old := m.fileConfig.Alerts
+	m.fileConfig.Alerts = &updated
+	if err := m.persist(); err != nil {
+		m.fileConfig.Alerts = old
+		return err
+	}
+	return nil
+}

--- a/server/internal/config/alerts_test.go
+++ b/server/internal/config/alerts_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestUpdateAlertsRoundTrip(t *testing.T) {
+	t.Setenv("CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+
+	rules := []AlertRule{
+		{
+			ID:              "rule-1",
+			Name:            "OOM kills",
+			Enabled:         true,
+			Type:            "event",
+			Hosts:           []string{"local"},
+			Events:          []string{"oom", "die"},
+			Threshold:       1,
+			CooldownSeconds: 300,
+			CreatedAt:       "2026-07-11T00:00:00Z",
+		},
+		{
+			ID:            "rule-2",
+			Name:          "API errors",
+			Enabled:       true,
+			Type:          "log",
+			Containers:    []string{"api"},
+			Projects:      []string{"demostack"},
+			MinLevel:      "ERROR",
+			Pattern:       "timeout",
+			Threshold:     5,
+			WindowSeconds: 60,
+			CreatedAt:     "2026-07-11T00:00:00Z",
+		},
+	}
+
+	m := NewManager()
+	err := m.UpdateAlerts(func(current AlertsConfig) (AlertsConfig, error) {
+		current.WebhookURL = "https://example.com/hook"
+		current.Rules = append(current.Rules, rules...)
+		return current, nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateAlerts failed: %v", err)
+	}
+
+	// A fresh manager must read the persisted alerts back from disk.
+	reloaded := NewManager()
+	fc := reloaded.FileConfigSnapshot()
+	if fc.Alerts == nil {
+		t.Fatal("expected alerts config to survive a reload")
+	}
+	if fc.Alerts.WebhookURL != "https://example.com/hook" {
+		t.Fatalf("expected webhook URL to round-trip, got %q", fc.Alerts.WebhookURL)
+	}
+	if !reflect.DeepEqual(fc.Alerts.Rules, rules) {
+		t.Fatalf("expected rules to round-trip, got %+v", fc.Alerts.Rules)
+	}
+}
+
+func TestUpdateAlertsMutateErrorLeavesConfigUntouched(t *testing.T) {
+	t.Setenv("CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+
+	m := NewManager()
+	if err := m.UpdateAlerts(func(current AlertsConfig) (AlertsConfig, error) {
+		current.WebhookURL = "https://example.com/hook"
+		return current, nil
+	}); err != nil {
+		t.Fatalf("UpdateAlerts failed: %v", err)
+	}
+
+	wantErr := errors.New("nope")
+	err := m.UpdateAlerts(func(current AlertsConfig) (AlertsConfig, error) {
+		return AlertsConfig{}, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected mutate error to propagate, got %v", err)
+	}
+
+	fc := m.FileConfigSnapshot()
+	if fc.Alerts == nil || fc.Alerts.WebhookURL != "https://example.com/hook" {
+		t.Fatalf("expected alerts config to be untouched after mutate error, got %+v", fc.Alerts)
+	}
+}

--- a/server/internal/config/manager.go
+++ b/server/internal/config/manager.go
@@ -117,6 +117,12 @@ func (m *Manager) Sources() ConfigSources {
 	return m.sources
 }
 
+// ConfigFilePath returns the path of the JSON config file. The path is fixed
+// at construction and never changes, so no locking is needed.
+func (m *Manager) ConfigFilePath() string {
+	return m.filePath
+}
+
 // FileConfig returns the current file config (for reading stored secrets).
 func (m *Manager) FileConfigSnapshot() FileConfig {
 	m.mu.RLock()

--- a/server/internal/config/manager.go
+++ b/server/internal/config/manager.go
@@ -16,6 +16,7 @@ type FileConfig struct {
 	ReadOnly     *bool               `json:"readOnly,omitempty"`
 	Auth         *FileAuthConfig     `json:"auth,omitempty"`
 	APITokens    []APIToken          `json:"apiTokens,omitempty"`
+	Alerts       *AlertsConfig       `json:"alerts,omitempty"`
 }
 
 // APIToken represents a stored API access token. Only the SHA256 hash of the

--- a/server/internal/docker/events.go
+++ b/server/internal/docker/events.go
@@ -83,7 +83,17 @@ func (c *MultiHostClient) StreamContainerEvents(ctx context.Context) <-chan mode
 		wg.Add(1)
 		go func(name string, cl *client.Client) {
 			defer wg.Done()
-			watchHostEvents(ctx, name, cl, out)
+			options := events.ListOptions{Filters: containerEventFilters()}
+			watchHostEventStream(ctx, name, cl, options, func(msg events.Message) {
+				event, ok := mapContainerEvent(name, msg)
+				if !ok {
+					return
+				}
+				select {
+				case out <- event:
+				case <-ctx.Done():
+				}
+			})
 		}(hostName, apiClient)
 	}
 
@@ -95,9 +105,12 @@ func (c *MultiHostClient) StreamContainerEvents(ctx context.Context) <-chan mode
 	return out
 }
 
-func watchHostEvents(ctx context.Context, hostName string, cl *client.Client, out chan<- models.ContainerEvent) {
+// watchHostEventStream runs the per-host subscribe/receive/backoff loop shared
+// by all event consumers, invoking handle for every raw message received.
+// Stream errors are retried with exponential backoff (reset on each message);
+// the loop returns once ctx is cancelled.
+func watchHostEventStream(ctx context.Context, hostName string, cl *client.Client, options events.ListOptions, handle func(events.Message)) {
 	backoff := eventsInitialBackoff
-	options := events.ListOptions{Filters: containerEventFilters()}
 
 	for {
 		messages, errs := cl.Events(ctx, options)
@@ -109,15 +122,7 @@ func watchHostEvents(ctx context.Context, hostName string, cl *client.Client, ou
 				return
 			case msg := <-messages:
 				backoff = eventsInitialBackoff
-				event, ok := mapContainerEvent(hostName, msg)
-				if !ok {
-					continue
-				}
-				select {
-				case out <- event:
-				case <-ctx.Done():
-					return
-				}
+				handle(msg)
 			case err := <-errs:
 				if ctx.Err() != nil {
 					return

--- a/server/internal/docker/events_engine.go
+++ b/server/internal/docker/events_engine.go
@@ -1,0 +1,117 @@
+package docker
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+)
+
+// engineEventActions are the container actions consumed by the alerting
+// engine. Distinct from watchedContainerActions (the frontend stream): the
+// engine needs "oom" and skips the purely cosmetic lifecycle actions.
+var engineEventActions = []string{
+	"start",
+	"die",
+	"oom",
+	"destroy",
+	"rename",
+	"health_status",
+}
+
+// EngineEvent is the richer event shape consumed by the alerting engine. It
+// keeps the exit code and the full attribute set (compose labels etc.) that
+// the frontend stream deliberately drops.
+type EngineEvent struct {
+	Host          string
+	ContainerID   string
+	ContainerName string
+	Action        string
+	ExitCode      string            // die events, from Actor.Attributes["exitCode"], "" if absent
+	Labels        map[string]string // full Actor.Attributes copy
+	Timestamp     int64
+}
+
+func engineEventFilters() filters.Args {
+	args := filters.NewArgs(filters.Arg("type", string(events.ContainerEventType)))
+	for _, action := range engineEventActions {
+		args.Add("event", action)
+	}
+	return args
+}
+
+// mapEngineEvent converts a Docker SDK event message into an EngineEvent.
+// It returns false for events that should be skipped.
+func mapEngineEvent(hostName string, msg events.Message) (EngineEvent, bool) {
+	if msg.Type != events.ContainerEventType {
+		return EngineEvent{}, false
+	}
+
+	// Some actions arrive suffixed with detail, e.g. "health_status: healthy";
+	// match the watched set against the base action before ": ".
+	action := string(msg.Action)
+	base, _, _ := strings.Cut(action, ": ")
+	if !slices.Contains(engineEventActions, base) {
+		return EngineEvent{}, false
+	}
+
+	timestamp := msg.Time
+	if timestamp == 0 && msg.TimeNano > 0 {
+		timestamp = msg.TimeNano / int64(time.Second)
+	}
+
+	exitCode := ""
+	if base == "die" {
+		exitCode = msg.Actor.Attributes["exitCode"]
+	}
+
+	return EngineEvent{
+		Host:          hostName,
+		ContainerID:   msg.Actor.ID,
+		ContainerName: msg.Actor.Attributes["name"],
+		Action:        action,
+		ExitCode:      exitCode,
+		Labels:        maps.Clone(msg.Actor.Attributes),
+		Timestamp:     timestamp,
+	}, true
+}
+
+// StreamEngineEvents subscribes to the alerting-relevant container events on
+// every configured host and fans them into a single channel. Same lifecycle
+// as StreamContainerEvents: per-host failures are retried with backoff, and
+// the returned channel closes once all host subscriptions have stopped.
+func (c *MultiHostClient) StreamEngineEvents(ctx context.Context) <-chan EngineEvent {
+	out := make(chan EngineEvent)
+	var wg sync.WaitGroup
+
+	for hostName, apiClient := range c.clients {
+		wg.Add(1)
+		go func(name string, cl *client.Client) {
+			defer wg.Done()
+			options := events.ListOptions{Filters: engineEventFilters()}
+			watchHostEventStream(ctx, name, cl, options, func(msg events.Message) {
+				event, ok := mapEngineEvent(name, msg)
+				if !ok {
+					return
+				}
+				select {
+				case out <- event:
+				case <-ctx.Done():
+				}
+			})
+		}(hostName, apiClient)
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}

--- a/server/internal/docker/events_engine.go
+++ b/server/internal/docker/events_engine.go
@@ -14,15 +14,16 @@ import (
 )
 
 // engineEventActions are the container actions consumed by the alerting
-// engine. Distinct from watchedContainerActions (the frontend stream): the
-// engine needs "oom" and skips the purely cosmetic lifecycle actions.
+// engine and the shared log-tail hub. Distinct from watchedContainerActions
+// (the frontend stream, which also handles health separately): the engine
+// needs "oom" to fire rules; start/destroy/rename exist for the hub's tail
+// lifecycle.
 var engineEventActions = []string{
 	"start",
 	"die",
 	"oom",
 	"destroy",
 	"rename",
-	"health_status",
 }
 
 // EngineEvent is the richer event shape consumed by the alerting engine. It

--- a/server/internal/docker/events_engine_test.go
+++ b/server/internal/docker/events_engine_test.go
@@ -1,0 +1,150 @@
+package docker
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/docker/docker/api/types/events"
+)
+
+func TestMapEngineEventDieCarriesExitCodeAndLabels(t *testing.T) {
+	attributes := map[string]string{
+		"name":                       "web",
+		"exitCode":                   "137",
+		"com.docker.compose.project": "demostack",
+	}
+	msg := events.Message{
+		Type:   events.ContainerEventType,
+		Action: "die",
+		Actor: events.Actor{
+			ID:         "abc123",
+			Attributes: attributes,
+		},
+		Time: 1700000000,
+	}
+
+	event, ok := mapEngineEvent("remote", msg)
+	if !ok {
+		t.Fatal("expected die event to be mapped")
+	}
+	if event.Host != "remote" {
+		t.Fatalf("expected host %q, got %q", "remote", event.Host)
+	}
+	if event.ContainerID != "abc123" {
+		t.Fatalf("expected container id %q, got %q", "abc123", event.ContainerID)
+	}
+	if event.ContainerName != "web" {
+		t.Fatalf("expected container name %q, got %q", "web", event.ContainerName)
+	}
+	if event.ExitCode != "137" {
+		t.Fatalf("expected exit code %q, got %q", "137", event.ExitCode)
+	}
+	if event.Timestamp != 1700000000 {
+		t.Fatalf("expected timestamp 1700000000, got %d", event.Timestamp)
+	}
+	if !maps.Equal(event.Labels, attributes) {
+		t.Fatalf("expected full attribute copy, got %v", event.Labels)
+	}
+	// The copy must be independent of the source map.
+	event.Labels["name"] = "mutated"
+	if attributes["name"] != "web" {
+		t.Fatal("expected labels to be a copy, not an alias of Actor.Attributes")
+	}
+}
+
+func TestMapEngineEventDieWithoutExitCode(t *testing.T) {
+	msg := events.Message{
+		Type:   events.ContainerEventType,
+		Action: "die",
+		Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "web"}},
+		Time:   1700000000,
+	}
+
+	event, ok := mapEngineEvent("local", msg)
+	if !ok {
+		t.Fatal("expected die event to be mapped")
+	}
+	if event.ExitCode != "" {
+		t.Fatalf("expected empty exit code, got %q", event.ExitCode)
+	}
+}
+
+func TestMapEngineEventOOMPassesThrough(t *testing.T) {
+	msg := events.Message{
+		Type:   events.ContainerEventType,
+		Action: "oom",
+		Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "web"}},
+		Time:   1700000000,
+	}
+
+	event, ok := mapEngineEvent("local", msg)
+	if !ok {
+		t.Fatal("expected oom event to be mapped")
+	}
+	if event.Action != "oom" {
+		t.Fatalf("expected action %q, got %q", "oom", event.Action)
+	}
+	if event.ExitCode != "" {
+		t.Fatalf("expected empty exit code on oom, got %q", event.ExitCode)
+	}
+}
+
+func TestMapEngineEventHealthStatusPrefixMatch(t *testing.T) {
+	msg := events.Message{
+		Type:   events.ContainerEventType,
+		Action: "health_status: unhealthy",
+		Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "web"}},
+		Time:   1700000000,
+	}
+
+	event, ok := mapEngineEvent("local", msg)
+	if !ok {
+		t.Fatal("expected health_status event to be mapped")
+	}
+	if event.Action != "health_status: unhealthy" {
+		t.Fatalf("expected full action string, got %q", event.Action)
+	}
+}
+
+func TestMapEngineEventSkipsUnwatchedActions(t *testing.T) {
+	for _, action := range []events.Action{"create", "pause", "exec_start: bash"} {
+		msg := events.Message{
+			Type:   events.ContainerEventType,
+			Action: action,
+			Actor:  events.Actor{ID: "abc123"},
+		}
+		if _, ok := mapEngineEvent("local", msg); ok {
+			t.Fatalf("expected action %q to be skipped", action)
+		}
+	}
+}
+
+func TestMapEngineEventSkipsNonContainerTypes(t *testing.T) {
+	msg := events.Message{
+		Type:   events.NetworkEventType,
+		Action: "die",
+		Actor:  events.Actor{ID: "net1"},
+	}
+	if _, ok := mapEngineEvent("local", msg); ok {
+		t.Fatal("expected non-container event to be skipped")
+	}
+}
+
+func TestMapEngineEventPerHostTagging(t *testing.T) {
+	msg := events.Message{
+		Type:   events.ContainerEventType,
+		Action: "start",
+		Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "web"}},
+		Time:   1700000000,
+	}
+
+	for _, host := range []string{"local", "prod-1"} {
+		event, ok := mapEngineEvent(host, msg)
+		if !ok {
+			t.Fatal("expected start event to be mapped")
+		}
+		if event.Host != host {
+			t.Fatalf("expected host %q, got %q", host, event.Host)
+		}
+	}
+}

--- a/server/internal/docker/events_engine_test.go
+++ b/server/internal/docker/events_engine_test.go
@@ -89,25 +89,8 @@ func TestMapEngineEventOOMPassesThrough(t *testing.T) {
 	}
 }
 
-func TestMapEngineEventHealthStatusPrefixMatch(t *testing.T) {
-	msg := events.Message{
-		Type:   events.ContainerEventType,
-		Action: "health_status: unhealthy",
-		Actor:  events.Actor{ID: "abc123", Attributes: map[string]string{"name": "web"}},
-		Time:   1700000000,
-	}
-
-	event, ok := mapEngineEvent("local", msg)
-	if !ok {
-		t.Fatal("expected health_status event to be mapped")
-	}
-	if event.Action != "health_status: unhealthy" {
-		t.Fatalf("expected full action string, got %q", event.Action)
-	}
-}
-
 func TestMapEngineEventSkipsUnwatchedActions(t *testing.T) {
-	for _, action := range []events.Action{"create", "pause", "exec_start: bash"} {
+	for _, action := range []events.Action{"create", "pause", "exec_start: bash", "health_status: unhealthy"} {
 		msg := events.Message{
 			Type:   events.ContainerEventType,
 			Action: action,

--- a/server/internal/docker/logs_tail.go
+++ b/server/internal/docker/logs_tail.go
@@ -1,0 +1,119 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+// callbackLogWriter parses raw log bytes into lines and hands each parsed
+// entry to a callback. Same line handling as logWriter (newline splitting,
+// CR trimming, oversized-line flush), but emits instead of accumulating.
+type callbackLogWriter struct {
+	stream string
+	buffer []byte
+	emit   func(models.LogEntry)
+}
+
+func (w *callbackLogWriter) Write(p []byte) (n int, err error) {
+	w.buffer = append(w.buffer, p...)
+
+	for {
+		idx := bytes.IndexByte(w.buffer, '\n')
+		if idx == -1 {
+			break
+		}
+
+		line := string(w.buffer[:idx])
+		w.buffer = w.buffer[idx+1:]
+
+		if line != "" {
+			line = strings.TrimSuffix(line, "\r")
+			w.emit(models.ParseLogLine(line, w.stream))
+		}
+	}
+
+	if len(w.buffer) > maxLineBufferSize {
+		w.Flush()
+	}
+
+	return len(p), nil
+}
+
+func (w *callbackLogWriter) Flush() {
+	if len(w.buffer) == 0 {
+		return
+	}
+	line := strings.TrimSuffix(string(w.buffer), "\r")
+	if line != "" {
+		w.emit(models.ParseLogLine(line, w.stream))
+	}
+	w.buffer = nil
+}
+
+// TailContainerLogs streams one container's logs and hands each parsed entry
+// to emit. It honors opts (Since, Tail, Follow, ShowStdout/ShowStderr,
+// Timestamps) and returns once ctx is cancelled or the log stream ends. emit
+// is called sequentially from a single goroutine, and no calls happen after
+// TailContainerLogs returns.
+func (c *MultiHostClient) TailContainerLogs(ctx context.Context, host, containerID string, opts models.LogOptions, emit func(models.LogEntry)) error {
+	apiClient, err := c.GetClient(host)
+	if err != nil {
+		return err
+	}
+
+	// stdcopy demux garbles raw TTY streams: a TTY container exposes a single
+	// unframed stream, so detect TTY up front and read it directly.
+	inspect, err := apiClient.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return err
+	}
+	tty := inspect.Config != nil && inspect.Config.Tty
+
+	logs, err := apiClient.ContainerLogs(ctx, containerID, buildLogsOptions(opts, opts.Follow, opts.Timestamps))
+	if err != nil {
+		return err
+	}
+
+	return tailLogStream(ctx, logs, tty, emit)
+}
+
+// tailLogStream parses the raw Docker log stream and emits entries until the
+// stream ends or ctx is cancelled. On cancellation it closes logs to unblock
+// the reader and waits for it to exit, so no goroutine outlives the call.
+func tailLogStream(ctx context.Context, logs io.ReadCloser, tty bool, emit func(models.LogEntry)) error {
+	done := make(chan error, 1)
+	go func() {
+		var err error
+		if tty {
+			// TTY streams carry no stdcopy framing; everything is stdout.
+			w := &callbackLogWriter{stream: "stdout", emit: emit}
+			_, err = io.Copy(w, logs)
+			w.Flush()
+		} else {
+			stdout := &callbackLogWriter{stream: "stdout", emit: emit}
+			stderr := &callbackLogWriter{stream: "stderr", emit: emit}
+			_, err = stdcopy.StdCopy(stdout, stderr, logs)
+			stdout.Flush()
+			stderr.Flush()
+		}
+		done <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		logs.Close() // unblock the reader goroutine
+		<-done
+		return ctx.Err()
+	case err := <-done:
+		logs.Close()
+		if err != nil && err != io.EOF {
+			return err
+		}
+		return nil
+	}
+}

--- a/server/internal/docker/logs_tail_test.go
+++ b/server/internal/docker/logs_tail_test.go
@@ -1,0 +1,229 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+func TestTailLogStreamParsesMultiplexedFrames(t *testing.T) {
+	var stream bytes.Buffer
+	stdout := stdcopy.NewStdWriter(&stream, stdcopy.Stdout)
+	stderr := stdcopy.NewStdWriter(&stream, stdcopy.Stderr)
+	if _, err := stdout.Write([]byte("INFO: request received\n")); err != nil {
+		t.Fatalf("failed to write stdout frame: %v", err)
+	}
+	if _, err := stderr.Write([]byte("ERROR: boom\n")); err != nil {
+		t.Fatalf("failed to write stderr frame: %v", err)
+	}
+
+	var entries []models.LogEntry
+	err := tailLogStream(context.Background(), io.NopCloser(&stream), false, func(e models.LogEntry) {
+		entries = append(entries, e)
+	})
+	if err != nil {
+		t.Fatalf("tailLogStream failed: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Stream != "stdout" || entries[0].Level != models.LogLevelInfo {
+		t.Fatalf("expected stdout INFO entry, got stream=%s level=%s", entries[0].Stream, entries[0].Level)
+	}
+	if entries[1].Stream != "stderr" || entries[1].Level != models.LogLevelError {
+		t.Fatalf("expected stderr ERROR entry, got stream=%s level=%s", entries[1].Stream, entries[1].Level)
+	}
+}
+
+func TestTailLogStreamTTYReadsRawStream(t *testing.T) {
+	// Raw unframed bytes, as a TTY container produces them. Feeding these to
+	// stdcopy would fail on the bogus header; the TTY path must read directly.
+	raw := "INFO: request received\nERROR: boom\n"
+
+	var entries []models.LogEntry
+	err := tailLogStream(context.Background(), io.NopCloser(strings.NewReader(raw)), true, func(e models.LogEntry) {
+		entries = append(entries, e)
+	})
+	if err != nil {
+		t.Fatalf("tailLogStream failed: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	for i, entry := range entries {
+		if entry.Stream != "stdout" {
+			t.Fatalf("expected TTY entry %d on stdout, got %s", i, entry.Stream)
+		}
+	}
+	if entries[0].Level != models.LogLevelInfo || entries[1].Level != models.LogLevelError {
+		t.Fatalf("expected INFO then ERROR, got %s then %s", entries[0].Level, entries[1].Level)
+	}
+}
+
+func TestTailLogStreamStopsOnContextCancel(t *testing.T) {
+	// A stream that never delivers data and never closes on its own.
+	rawReader, _ := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	results := make(chan error, 1)
+	go func() {
+		results <- tailLogStream(ctx, rawReader, false, func(models.LogEntry) {})
+	}()
+
+	cancel()
+
+	select {
+	case err := <-results:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("tailLogStream did not terminate after context cancellation")
+	}
+}
+
+// roundTripFunc fakes the Docker daemon behind the SDK's HTTP client.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func jsonResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func TestTailContainerLogsPassesOptionsToAPI(t *testing.T) {
+	var stream bytes.Buffer
+	stdout := stdcopy.NewStdWriter(&stream, stdcopy.Stdout)
+	if _, err := stdout.Write([]byte("hello world\n")); err != nil {
+		t.Fatalf("failed to write stdout frame: %v", err)
+	}
+
+	var logsQuery url.Values
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/containers/abc/json"):
+			return jsonResponse(req, `{"Id":"abc","Config":{"Tty":false}}`), nil
+		case strings.HasSuffix(req.URL.Path, "/containers/abc/logs"):
+			logsQuery = req.URL.Query()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/octet-stream"}},
+				Body:       io.NopCloser(bytes.NewReader(stream.Bytes())),
+				Request:    req,
+			}, nil
+		default:
+			t.Errorf("unexpected request path %s", req.URL.Path)
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+		}
+	})
+
+	apiClient, err := client.NewClientWithOpts(
+		client.WithHost("tcp://127.0.0.1:2375"),
+		client.WithVersion("1.44"),
+		client.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create fake client: %v", err)
+	}
+	c := &MultiHostClient{clients: map[string]*client.Client{"local": apiClient}}
+
+	opts := models.LogOptions{
+		Since:      "1700000000",
+		Tail:       "50",
+		Timestamps: true,
+		ShowStdout: true,
+		ShowStderr: true,
+	}
+
+	var entries []models.LogEntry
+	if err := c.TailContainerLogs(context.Background(), "local", "abc", opts, func(e models.LogEntry) {
+		entries = append(entries, e)
+	}); err != nil {
+		t.Fatalf("TailContainerLogs failed: %v", err)
+	}
+
+	if logsQuery == nil {
+		t.Fatal("expected a logs API call")
+	}
+	if got := logsQuery.Get("since"); !strings.HasPrefix(got, "1700000000") {
+		t.Fatalf("expected since to be passed through, got %q", got)
+	}
+	if got := logsQuery.Get("tail"); got != "50" {
+		t.Fatalf("expected tail=50, got %q", got)
+	}
+	if got := logsQuery.Get("timestamps"); got != "1" {
+		t.Fatalf("expected timestamps=1, got %q", got)
+	}
+	if got := logsQuery.Get("stdout"); got != "1" {
+		t.Fatalf("expected stdout=1, got %q", got)
+	}
+	if got := logsQuery.Get("stderr"); got != "1" {
+		t.Fatalf("expected stderr=1, got %q", got)
+	}
+	if got := logsQuery.Get("follow"); got != "" && got != "0" {
+		t.Fatalf("expected follow to be unset, got %q", got)
+	}
+
+	if len(entries) != 1 || entries[0].Message != "hello world" {
+		t.Fatalf("expected the parsed entry to be emitted, got %+v", entries)
+	}
+}
+
+func TestTailContainerLogsUsesTTYPathFromInspect(t *testing.T) {
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/containers/abc/json"):
+			return jsonResponse(req, `{"Id":"abc","Config":{"Tty":true}}`), nil
+		case strings.HasSuffix(req.URL.Path, "/containers/abc/logs"):
+			// Raw TTY bytes; stdcopy would choke on this.
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/octet-stream"}},
+				Body:       io.NopCloser(strings.NewReader("WARN: tty line\n")),
+				Request:    req,
+			}, nil
+		default:
+			t.Errorf("unexpected request path %s", req.URL.Path)
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+		}
+	})
+
+	apiClient, err := client.NewClientWithOpts(
+		client.WithHost("tcp://127.0.0.1:2375"),
+		client.WithVersion("1.44"),
+		client.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create fake client: %v", err)
+	}
+	c := &MultiHostClient{clients: map[string]*client.Client{"local": apiClient}}
+
+	var entries []models.LogEntry
+	opts := models.LogOptions{ShowStdout: true, ShowStderr: true}
+	if err := c.TailContainerLogs(context.Background(), "local", "abc", opts, func(e models.LogEntry) {
+		entries = append(entries, e)
+	}); err != nil {
+		t.Fatalf("TailContainerLogs failed on TTY container: %v", err)
+	}
+
+	if len(entries) != 1 || entries[0].Stream != "stdout" || entries[0].Level != models.LogLevelWarn {
+		t.Fatalf("expected one stdout WARN entry from the TTY stream, got %+v", entries)
+	}
+}

--- a/server/internal/logstream/client.go
+++ b/server/internal/logstream/client.go
@@ -1,0 +1,36 @@
+package logstream
+
+import (
+	"context"
+
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// engineClient is the slice of the Docker client the hub needs. Tests inject
+// fakes; production wraps *docker.MultiHostClient. Implementations must be
+// comparable so the hub can detect hot-swapped clients by equality.
+type engineClient interface {
+	listContainers(ctx context.Context) (map[string][]models.ContainerInfo, []docker.HostError, error)
+	streamEvents(ctx context.Context) <-chan docker.EngineEvent
+	openTail(ctx context.Context, host, containerID string, opts models.LogOptions, emit func(models.LogEntry)) error
+}
+
+// dockerAdapter adapts one *docker.MultiHostClient snapshot. It is a
+// comparable single-pointer struct: two adapters are equal exactly when they
+// wrap the same client, which is what the hot-swap check compares.
+type dockerAdapter struct {
+	c *docker.MultiHostClient
+}
+
+func (a dockerAdapter) listContainers(ctx context.Context) (map[string][]models.ContainerInfo, []docker.HostError, error) {
+	return a.c.ListContainersAllHosts(ctx)
+}
+
+func (a dockerAdapter) streamEvents(ctx context.Context) <-chan docker.EngineEvent {
+	return a.c.StreamEngineEvents(ctx)
+}
+
+func (a dockerAdapter) openTail(ctx context.Context, host, containerID string, opts models.LogOptions, emit func(models.LogEntry)) error {
+	return a.c.TailContainerLogs(ctx, host, containerID, opts, emit)
+}

--- a/server/internal/logstream/logstream.go
+++ b/server/internal/logstream/logstream.go
@@ -1,0 +1,72 @@
+// Package logstream provides a shared hub that multiplexes container log
+// tailing: the hub maintains one tail per (host, container) covering the
+// union of live subscriber specs, and fans parsed entries out to every
+// subscriber whose spec matches. Types and method contracts are defined
+// here; the implementation lands in the logstream territory.
+package logstream
+
+import (
+	"context"
+
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// DockerProvider yields the current Docker client set; reading through it on
+// every use keeps the hub correct across hot-swapped config updates.
+type DockerProvider interface {
+	Docker() *docker.MultiHostClient
+}
+
+// Record is one parsed log entry tagged with its origin container.
+type Record struct {
+	Host          string
+	ContainerID   string
+	ContainerName string
+	Labels        map[string]string
+	Entry         models.LogEntry
+}
+
+// ContainerSpec selects containers to tail. All dimensions are optional and
+// ANDed together; an empty slice matches everything in that dimension.
+type ContainerSpec struct {
+	Hosts      []string
+	Containers []string // exact container names
+	Projects   []string // compose projects
+}
+
+// Hub owns the container log tails shared by all subscribers. The desired
+// tail set is the union of live subscriber specs; each subscriber keeps its
+// own LogOptions and delivery policy, applied when records are fanned out.
+type Hub struct {
+	provider DockerProvider
+}
+
+// New creates a hub that tails containers through the provider's current
+// Docker client set.
+func New(provider DockerProvider) *Hub {
+	return &Hub{provider: provider}
+}
+
+// Subscribe registers a sink for records from containers matching spec,
+// tailed with the subscriber's opts. The returned function removes the
+// subscription; after it returns, sink is never called again. Subscribing
+// widens the hub's desired tail set, unsubscribing narrows it.
+func (h *Hub) Subscribe(spec ContainerSpec, opts models.LogOptions, sink func(Record)) (unsubscribe func()) {
+	return func() {}
+}
+
+// Reconcile re-computes the desired tail set (union of live subscriber
+// specs) against the currently running containers and starts/stops tails to
+// match. Called on subscription changes, container lifecycle events, and
+// config reloads.
+func (h *Hub) Reconcile() {}
+
+// Run drives the hub's tail supervision until ctx is cancelled. It is
+// typically invoked in its own goroutine; use Wait to block until every
+// tail has fully stopped.
+func (h *Hub) Run(ctx context.Context) {}
+
+// Wait blocks until the hub has shut down: Run returned and all container
+// tails have stopped.
+func (h *Hub) Wait() {}

--- a/server/internal/logstream/logstream.go
+++ b/server/internal/logstream/logstream.go
@@ -56,19 +56,21 @@ var composeProjectLabels = []string{
 	"io.podman.compose.project",
 }
 
-// specMatches reports whether a container (identified by host, name without
-// the leading "/", and labels) is selected by spec.
-func specMatches(spec ContainerSpec, host, name string, labels map[string]string) bool {
-	if len(spec.Hosts) > 0 && !slices.Contains(spec.Hosts, host) {
+// Matches reports whether a container (identified by host, name without the
+// leading "/", and labels) is selected by the spec. Hosts are ANDed with the
+// container/project dimension, which is an OR between exact names and compose
+// projects.
+func (s ContainerSpec) Matches(host, name string, labels map[string]string) bool {
+	if len(s.Hosts) > 0 && !slices.Contains(s.Hosts, host) {
 		return false
 	}
-	if len(spec.Containers) == 0 && len(spec.Projects) == 0 {
+	if len(s.Containers) == 0 && len(s.Projects) == 0 {
 		return true
 	}
-	if slices.Contains(spec.Containers, name) {
+	if slices.Contains(s.Containers, name) {
 		return true
 	}
-	for _, project := range spec.Projects {
+	for _, project := range s.Projects {
 		for _, label := range composeProjectLabels {
 			if labels[label] == project {
 				return true
@@ -103,8 +105,7 @@ type tailExit struct {
 // subscription gets its own tails (with its own LogOptions); the hub's run
 // loop is the single owner of all subscription and tail state.
 type Hub struct {
-	provider DockerProvider
-	source   func() engineClient
+	source func() engineClient
 
 	reqCh      chan func()
 	pokeCh     chan struct{}
@@ -132,14 +133,13 @@ type Hub struct {
 // New creates a hub that tails containers through the provider's current
 // Docker client set.
 func New(provider DockerProvider) *Hub {
-	return newHub(provider, func() engineClient { return dockerAdapter{c: provider.Docker()} })
+	return newHub(func() engineClient { return dockerAdapter{c: provider.Docker()} })
 }
 
 // newHub builds a hub over an arbitrary client source; tests inject fakes
 // here. source must return comparable values so client swaps are detectable.
-func newHub(provider DockerProvider, source func() engineClient) *Hub {
+func newHub(source func() engineClient) *Hub {
 	return &Hub{
-		provider:       provider,
 		source:         source,
 		reqCh:          make(chan func()),
 		pokeCh:         make(chan struct{}, 1),
@@ -319,7 +319,7 @@ func (h *Hub) handleEvent(ev docker.EngineEvent) {
 			if _, ok := sub.tails[key]; ok {
 				continue
 			}
-			if !specMatches(sub.spec, ev.Host, name, ev.Labels) {
+			if !sub.spec.Matches(ev.Host, name, ev.Labels) {
 				continue
 			}
 			h.spawnTail(sub, key, name, ev.Labels)
@@ -396,7 +396,7 @@ func (h *Hub) handleList(res listResult) {
 			if !listedHosts[key.host] {
 				continue
 			}
-			if meta, ok := running[key]; ok && specMatches(sub.spec, key.host, meta.name, meta.labels) {
+			if meta, ok := running[key]; ok && sub.spec.Matches(key.host, meta.name, meta.labels) {
 				continue
 			}
 			t.cancel()
@@ -407,7 +407,7 @@ func (h *Hub) handleList(res listResult) {
 			if _, ok := sub.tails[key]; ok {
 				continue
 			}
-			if !specMatches(sub.spec, key.host, meta.name, meta.labels) {
+			if !sub.spec.Matches(key.host, meta.name, meta.labels) {
 				continue
 			}
 			h.spawnTail(sub, key, meta.name, meta.labels)

--- a/server/internal/logstream/logstream.go
+++ b/server/internal/logstream/logstream.go
@@ -1,15 +1,28 @@
-// Package logstream provides a shared hub that multiplexes container log
-// tailing: the hub maintains one tail per (host, container) covering the
-// union of live subscriber specs, and fans parsed entries out to every
-// subscriber whose spec matches. Types and method contracts are defined
-// here; the implementation lands in the logstream territory.
+// Package logstream provides a shared hub that supervises container log
+// tailing for background subscribers (alerting, and later persistence). Each
+// subscriber registers a ContainerSpec plus its own LogOptions; the hub keeps
+// one tail per (subscription, host, container) so every subscriber controls
+// its own backfill window, and fans parsed entries into per-subscription
+// bounded buffers so a slow sink can never stall a tail read.
 package logstream
 
 import (
 	"context"
+	"log"
+	"slices"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/docker"
 	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+const (
+	defaultListTimeout    = 15 * time.Second
+	defaultResyncInterval = 60 * time.Second
+	defaultRetryBaseDelay = 2 * time.Second
+	defaultRetryMaxDelay  = 30 * time.Second
 )
 
 // DockerProvider yields the current Docker client set; reading through it on
@@ -35,38 +48,401 @@ type ContainerSpec struct {
 	Projects   []string // compose projects
 }
 
-// Hub owns the container log tails shared by all subscribers. The desired
-// tail set is the union of live subscriber specs; each subscriber keeps its
-// own LogOptions and delivery policy, applied when records are fanned out.
+// Docker Compose and recent podman-compose both set the com.docker label;
+// older podman-compose releases only set the io.podman one. Mirrors the
+// unexported helper in internal/docker/compose.go.
+var composeProjectLabels = []string{
+	"com.docker.compose.project",
+	"io.podman.compose.project",
+}
+
+// specMatches reports whether a container (identified by host, name without
+// the leading "/", and labels) is selected by spec.
+func specMatches(spec ContainerSpec, host, name string, labels map[string]string) bool {
+	if len(spec.Hosts) > 0 && !slices.Contains(spec.Hosts, host) {
+		return false
+	}
+	if len(spec.Containers) == 0 && len(spec.Projects) == 0 {
+		return true
+	}
+	if slices.Contains(spec.Containers, name) {
+		return true
+	}
+	for _, project := range spec.Projects {
+		for _, label := range composeProjectLabels {
+			if labels[label] == project {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// containerKey identifies one container on one host.
+type containerKey struct {
+	host string
+	id   string
+}
+
+// listResult is a container snapshot posted back to the run loop by the
+// single-flight listing goroutine.
+type listResult struct {
+	snapshot map[string][]models.ContainerInfo
+	hostErrs []docker.HostError
+	err      error
+}
+
+// tailExit notifies the run loop that a tail goroutine has stopped.
+type tailExit struct {
+	sub *subscription
+	key containerKey
+	t   *tail
+}
+
+// Hub owns the container log tails shared by all subscribers. Each live
+// subscription gets its own tails (with its own LogOptions); the hub's run
+// loop is the single owner of all subscription and tail state.
 type Hub struct {
 	provider DockerProvider
+	source   func() engineClient
+
+	reqCh      chan func()
+	pokeCh     chan struct{}
+	listCh     chan listResult
+	tailExitCh chan tailExit
+	stopped    chan struct{} // closed when the hub stops accepting requests
+	finished   chan struct{} // closed when Run has fully drained
+
+	listTimeout    time.Duration
+	resyncInterval time.Duration
+	retryBaseDelay time.Duration
+	retryMaxDelay  time.Duration
+
+	// State below is owned exclusively by the run loop goroutine.
+	runCtx       context.Context
+	subs         map[*subscription]struct{}
+	events       <-chan docker.EngineEvent
+	eventsCancel context.CancelFunc
+	eventsClient engineClient
+	listInFlight bool
+	listQueued   bool
+	tailWg       sync.WaitGroup
 }
 
 // New creates a hub that tails containers through the provider's current
 // Docker client set.
 func New(provider DockerProvider) *Hub {
-	return &Hub{provider: provider}
+	return newHub(provider, func() engineClient { return dockerAdapter{c: provider.Docker()} })
+}
+
+// newHub builds a hub over an arbitrary client source; tests inject fakes
+// here. source must return comparable values so client swaps are detectable.
+func newHub(provider DockerProvider, source func() engineClient) *Hub {
+	return &Hub{
+		provider:       provider,
+		source:         source,
+		reqCh:          make(chan func()),
+		pokeCh:         make(chan struct{}, 1),
+		listCh:         make(chan listResult, 1),
+		tailExitCh:     make(chan tailExit),
+		stopped:        make(chan struct{}),
+		finished:       make(chan struct{}),
+		listTimeout:    defaultListTimeout,
+		resyncInterval: defaultResyncInterval,
+		retryBaseDelay: defaultRetryBaseDelay,
+		retryMaxDelay:  defaultRetryMaxDelay,
+		subs:           make(map[*subscription]struct{}),
+	}
+}
+
+// do runs fn on the run loop goroutine. It returns false (without running fn)
+// once the hub has begun shutting down.
+func (h *Hub) do(fn func()) bool {
+	select {
+	case h.reqCh <- fn:
+		return true
+	case <-h.stopped:
+		return false
+	}
 }
 
 // Subscribe registers a sink for records from containers matching spec,
 // tailed with the subscriber's opts. The returned function removes the
-// subscription; after it returns, sink is never called again. Subscribing
-// widens the hub's desired tail set, unsubscribing narrows it.
+// subscription; after it returns, sink is never called again (do not call
+// unsubscribe from inside the sink). Subscribe blocks until the hub's run
+// loop is started; after shutdown it registers nothing and returns a no-op.
+// Follow is forced on: hub tails are continuous by nature, and a non-follow
+// tail would end immediately and be retried as a failure.
 func (h *Hub) Subscribe(spec ContainerSpec, opts models.LogOptions, sink func(Record)) (unsubscribe func()) {
-	return func() {}
+	opts.Follow = true
+	_, unsubscribe = h.subscribe(spec, opts, sink)
+	return unsubscribe
 }
 
-// Reconcile re-computes the desired tail set (union of live subscriber
-// specs) against the currently running containers and starts/stops tails to
-// match. Called on subscription changes, container lifecycle events, and
-// config reloads.
-func (h *Hub) Reconcile() {}
+// subscribe is the internal form of Subscribe that also exposes the
+// subscription handle (used by tests to observe drop counters).
+func (h *Hub) subscribe(spec ContainerSpec, opts models.LogOptions, sink func(Record)) (*subscription, func()) {
+	sub := newSubscription(spec, opts, sink)
+	registered := h.do(func() {
+		h.subs[sub] = struct{}{}
+		go sub.deliverLoop()
+		h.requestList()
+	})
+	if !registered {
+		return sub, func() {}
+	}
 
-// Run drives the hub's tail supervision until ctx is cancelled. It is
-// typically invoked in its own goroutine; use Wait to block until every
-// tail has fully stopped.
-func (h *Hub) Run(ctx context.Context) {}
+	var once sync.Once
+	return sub, func() {
+		once.Do(func() {
+			if !h.do(func() { h.removeSub(sub) }) {
+				// Hub already shut down; its shutdown path closes the
+				// subscription (close is idempotent either way).
+				sub.close(true)
+			}
+			<-sub.delivered
+		})
+	}
+}
+
+// removeSub runs on the loop: it drops the subscription, cancels its tails,
+// and stops its delivery goroutine, discarding buffered records.
+func (h *Hub) removeSub(sub *subscription) {
+	if _, ok := h.subs[sub]; !ok {
+		return
+	}
+	delete(h.subs, sub)
+	for key, t := range sub.tails {
+		t.cancel()
+		delete(sub.tails, key)
+	}
+	sub.close(true)
+}
+
+// Reconcile pokes the run loop to re-list containers and converge tails.
+// Non-blocking; pokes coalesce. Called on container lifecycle events, config
+// reloads, and subscription changes.
+func (h *Hub) Reconcile() {
+	select {
+	case h.pokeCh <- struct{}{}:
+	default:
+	}
+}
+
+// Run drives the hub's supervision until ctx is cancelled. It is typically
+// invoked in its own goroutine; use Wait to block until every tail and
+// delivery goroutine has fully stopped.
+func (h *Hub) Run(ctx context.Context) {
+	defer close(h.finished)
+	h.runCtx = ctx
+
+	h.openEventStream(h.source())
+
+	ticker := time.NewTicker(h.resyncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.shutdown()
+			return
+		case fn := <-h.reqCh:
+			fn()
+		case <-h.pokeCh:
+			h.requestList()
+		case <-ticker.C:
+			h.requestList()
+		case ev, ok := <-h.events:
+			if !ok {
+				// All host watchers stopped (e.g. the client was closed
+				// after a hot swap). Re-list; handleList reopens the stream.
+				h.events = nil
+				h.requestList()
+				continue
+			}
+			h.handleEvent(ev)
+		case res := <-h.listCh:
+			h.handleList(res)
+		case ex := <-h.tailExitCh:
+			h.handleTailExit(ex)
+		}
+	}
+}
 
 // Wait blocks until the hub has shut down: Run returned and all container
-// tails have stopped.
-func (h *Hub) Wait() {}
+// tails and delivery goroutines have stopped.
+func (h *Hub) Wait() {
+	<-h.finished
+}
+
+// openEventStream (re)opens the engine event stream on client under a child
+// context of the run context.
+func (h *Hub) openEventStream(client engineClient) {
+	ctx, cancel := context.WithCancel(h.runCtx)
+	h.eventsCancel = cancel
+	h.events = client.streamEvents(ctx)
+	h.eventsClient = client
+}
+
+// requestList starts a single-flight container listing; pokes arriving while
+// one is in flight coalesce into at most one follow-up listing.
+func (h *Hub) requestList() {
+	if h.listInFlight {
+		h.listQueued = true
+		return
+	}
+	h.listInFlight = true
+
+	client := h.source()
+	runCtx := h.runCtx
+	timeout := h.listTimeout
+	go func() {
+		ctx, cancel := context.WithTimeout(runCtx, timeout)
+		defer cancel()
+		snapshot, hostErrs, err := client.listContainers(ctx)
+		select {
+		case h.listCh <- listResult{snapshot: snapshot, hostErrs: hostErrs, err: err}:
+		case <-runCtx.Done():
+		}
+	}()
+}
+
+// handleEvent is the fast path: start spawns matching tails immediately,
+// die/destroy cancel them, rename is treated as destroy plus a re-list.
+func (h *Hub) handleEvent(ev docker.EngineEvent) {
+	base, _, _ := strings.Cut(ev.Action, ": ")
+	switch base {
+	case "start":
+		name := strings.TrimPrefix(ev.ContainerName, "/")
+		key := containerKey{host: ev.Host, id: ev.ContainerID}
+		for sub := range h.subs {
+			if _, ok := sub.tails[key]; ok {
+				continue
+			}
+			if !specMatches(sub.spec, ev.Host, name, ev.Labels) {
+				continue
+			}
+			h.spawnTail(sub, key, name, ev.Labels)
+		}
+	case "die", "destroy":
+		h.cancelTails(containerKey{host: ev.Host, id: ev.ContainerID})
+	case "rename":
+		h.cancelTails(containerKey{host: ev.Host, id: ev.ContainerID})
+		h.requestList()
+	}
+}
+
+// cancelTails cancels every subscription's tail for key.
+func (h *Hub) cancelTails(key containerKey) {
+	for sub := range h.subs {
+		if t, ok := sub.tails[key]; ok {
+			t.cancel()
+			delete(sub.tails, key)
+		}
+	}
+}
+
+// handleList converges tails against a fresh container snapshot. Hosts that
+// failed to list keep their existing tails untouched: a genuinely dead host's
+// tails exit on their own and are retried by the next resync.
+func (h *Hub) handleList(res listResult) {
+	h.listInFlight = false
+	defer func() {
+		if h.listQueued {
+			h.listQueued = false
+			h.requestList()
+		}
+	}()
+
+	// Hot-swap check: if the provider's client changed since the event stream
+	// was opened (or the stream closed), reopen it on the current client.
+	if current := h.source(); h.events == nil || current != h.eventsClient {
+		h.eventsCancel()
+		h.openEventStream(current)
+	}
+
+	if res.err != nil {
+		log.Printf("logstream: container listing failed: %v", res.err)
+		return
+	}
+	for _, hostErr := range res.hostErrs {
+		log.Printf("logstream: listing containers on host %s failed: %v", hostErr.HostName, hostErr.Err)
+	}
+
+	type containerMeta struct {
+		name   string
+		labels map[string]string
+	}
+	running := make(map[containerKey]containerMeta)
+	listedHosts := make(map[string]bool, len(res.snapshot))
+	for host, containers := range res.snapshot {
+		listedHosts[host] = true
+		for _, ctr := range containers {
+			if ctr.State != "running" {
+				continue
+			}
+			name := ""
+			if len(ctr.Names) > 0 {
+				name = strings.TrimPrefix(ctr.Names[0], "/")
+			}
+			running[containerKey{host: host, id: ctr.ID}] = containerMeta{name: name, labels: ctr.Labels}
+		}
+	}
+
+	for sub := range h.subs {
+		// Cancel tails whose host listed successfully but whose container is
+		// no longer running (or no longer matches, e.g. after a rename).
+		for key, t := range sub.tails {
+			if !listedHosts[key.host] {
+				continue
+			}
+			if meta, ok := running[key]; ok && specMatches(sub.spec, key.host, meta.name, meta.labels) {
+				continue
+			}
+			t.cancel()
+			delete(sub.tails, key)
+		}
+		// Spawn tails for matching running containers we are not tailing yet.
+		for key, meta := range running {
+			if _, ok := sub.tails[key]; ok {
+				continue
+			}
+			if !specMatches(sub.spec, key.host, meta.name, meta.labels) {
+				continue
+			}
+			h.spawnTail(sub, key, meta.name, meta.labels)
+		}
+	}
+}
+
+// handleTailExit removes a self-terminated tail (stream ended and retries
+// exhausted) so the next resync or start event can respawn it.
+func (h *Hub) handleTailExit(ex tailExit) {
+	if _, ok := h.subs[ex.sub]; !ok {
+		return
+	}
+	if current, ok := ex.sub.tails[ex.key]; ok && current == ex.t {
+		delete(ex.sub.tails, ex.key)
+	}
+}
+
+// shutdown drains the hub: reject new requests, cancel the event stream and
+// every tail, wait for tails to stop pushing, then let each delivery
+// goroutine finish its buffered records.
+func (h *Hub) shutdown() {
+	close(h.stopped)
+	h.eventsCancel()
+	for sub := range h.subs {
+		for key, t := range sub.tails {
+			t.cancel()
+			delete(sub.tails, key)
+		}
+	}
+	h.tailWg.Wait()
+	for sub := range h.subs {
+		sub.close(false) // drain buffered records
+	}
+	for sub := range h.subs {
+		<-sub.delivered
+	}
+}

--- a/server/internal/logstream/logstream_test.go
+++ b/server/internal/logstream/logstream_test.go
@@ -1,0 +1,535 @@
+package logstream
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// fakeClient is a scripted engineClient: canned container snapshots (with
+// optional per-host errors), a pushable event channel, and tails that either
+// run a custom tailFn or block until cancelled / the client is "closed".
+type fakeClient struct {
+	events chan docker.EngineEvent
+	closed chan struct{}
+	once   sync.Once
+
+	// tailFn, when set (before the hub runs), replaces the default blocking
+	// tail body. Start/stop tracking applies either way.
+	tailFn func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error
+
+	mu       sync.Mutex
+	snapshot map[string][]models.ContainerInfo
+	hostErrs []docker.HostError
+	active   map[containerKey]int
+	starts   map[containerKey]int
+	streams  int
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		events:   make(chan docker.EngineEvent, 16),
+		closed:   make(chan struct{}),
+		snapshot: map[string][]models.ContainerInfo{},
+		active:   map[containerKey]int{},
+		starts:   map[containerKey]int{},
+	}
+}
+
+func (f *fakeClient) set(snapshot map[string][]models.ContainerInfo, hostErrs []docker.HostError) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.snapshot = snapshot
+	f.hostErrs = hostErrs
+}
+
+func (f *fakeClient) close() { f.once.Do(func() { close(f.closed) }) }
+
+func (f *fakeClient) activeTails(key containerKey) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.active[key]
+}
+
+func (f *fakeClient) totalStarts(key containerKey) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.starts[key]
+}
+
+func (f *fakeClient) streamCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.streams
+}
+
+func (f *fakeClient) listContainers(context.Context) (map[string][]models.ContainerInfo, []docker.HostError, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.snapshot, f.hostErrs, nil
+}
+
+func (f *fakeClient) streamEvents(ctx context.Context) <-chan docker.EngineEvent {
+	f.mu.Lock()
+	f.streams++
+	f.mu.Unlock()
+	out := make(chan docker.EngineEvent)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case ev := <-f.events:
+				select {
+				case out <- ev:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			case <-f.closed:
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func (f *fakeClient) openTail(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+	key := containerKey{host: host, id: id}
+	f.mu.Lock()
+	f.active[key]++
+	f.starts[key]++
+	f.mu.Unlock()
+	defer func() {
+		f.mu.Lock()
+		f.active[key]--
+		f.mu.Unlock()
+	}()
+
+	if f.tailFn != nil {
+		return f.tailFn(ctx, host, id, opts, emit)
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-f.closed:
+		return errors.New("client closed")
+	}
+}
+
+// recorder is a thread-safe sink.
+type recorder struct {
+	mu   sync.Mutex
+	recs []Record
+}
+
+func (r *recorder) sink(rec Record) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recs = append(r.recs, rec)
+}
+
+func (r *recorder) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.recs)
+}
+
+func (r *recorder) all() []Record {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Record(nil), r.recs...)
+}
+
+func ctr(id, name, state string, labels map[string]string) models.ContainerInfo {
+	return models.ContainerInfo{ID: id, Names: []string{"/" + name}, State: state, Labels: labels}
+}
+
+// startHub runs a hub over source with fast retry timings and registers
+// cleanup that cancels it and requires a prompt, leak-free shutdown.
+func startHub(t *testing.T, source func() engineClient) *Hub {
+	t.Helper()
+	h := newHub(nil, source)
+	h.retryBaseDelay = time.Millisecond
+	h.retryMaxDelay = 4 * time.Millisecond
+	h.listTimeout = time.Second
+	h.resyncInterval = time.Hour // tests drive resync via Reconcile pokes
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go h.Run(ctx)
+	t.Cleanup(func() {
+		cancel()
+		waitShutdown(t, h)
+	})
+	return h
+}
+
+func waitShutdown(t *testing.T, h *Hub) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		h.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hub did not shut down within 5s")
+	}
+}
+
+func waitFor(t *testing.T, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", msg)
+}
+
+func TestSpecMatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		spec   ContainerSpec
+		host   string
+		cname  string
+		labels map[string]string
+		want   bool
+	}{
+		{"empty spec matches all", ContainerSpec{}, "h1", "web", nil, true},
+		{"host filter hit", ContainerSpec{Hosts: []string{"h1"}}, "h1", "web", nil, true},
+		{"host filter miss", ContainerSpec{Hosts: []string{"h2"}}, "h1", "web", nil, false},
+		{"name match", ContainerSpec{Containers: []string{"web"}}, "h1", "web", nil, true},
+		{"name miss", ContainerSpec{Containers: []string{"web"}}, "h1", "db", nil, false},
+		{"docker project label", ContainerSpec{Projects: []string{"demo"}}, "h1", "db", map[string]string{"com.docker.compose.project": "demo"}, true},
+		{"podman project label", ContainerSpec{Projects: []string{"demo"}}, "h1", "db", map[string]string{"io.podman.compose.project": "demo"}, true},
+		{"project miss", ContainerSpec{Projects: []string{"demo"}}, "h1", "db", map[string]string{"com.docker.compose.project": "other"}, false},
+		{"name or project", ContainerSpec{Containers: []string{"web"}, Projects: []string{"demo"}}, "h1", "db", map[string]string{"com.docker.compose.project": "demo"}, true},
+		{"host and name both required", ContainerSpec{Hosts: []string{"h2"}, Containers: []string{"web"}}, "h1", "web", nil, false},
+	}
+	for _, tc := range cases {
+		if got := specMatches(tc.spec, tc.host, tc.cname, tc.labels); got != tc.want {
+			t.Errorf("%s: specMatches = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSubscribeTailsOnlyMatchedRunningContainers(t *testing.T) {
+	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		emit(models.LogEntry{Message: "hello-" + id})
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	f.set(map[string][]models.ContainerInfo{
+		"h1": {
+			ctr("c1", "web", "running", map[string]string{"com.docker.compose.project": "demo"}),
+			ctr("c2", "db", "running", nil),
+			ctr("c3", "web", "exited", nil),
+		},
+	}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{Containers: []string{"web"}}, models.LogOptions{Tail: "0", ShowStdout: true, ShowStderr: true}, rec.sink)
+
+	waitFor(t, "matched tail to start", func() bool { return f.activeTails(containerKey{"h1", "c1"}) == 1 })
+	waitFor(t, "record delivery", func() bool { return rec.len() == 1 })
+
+	if n := f.totalStarts(containerKey{"h1", "c2"}); n != 0 {
+		t.Errorf("unmatched container c2 was tailed %d times", n)
+	}
+	if n := f.totalStarts(containerKey{"h1", "c3"}); n != 0 {
+		t.Errorf("exited container c3 was tailed %d times", n)
+	}
+	got := rec.all()[0]
+	if got.Host != "h1" || got.ContainerID != "c1" || got.ContainerName != "web" || got.Entry.Message != "hello-c1" {
+		t.Errorf("unexpected record: %+v", got)
+	}
+	if got.Labels["com.docker.compose.project"] != "demo" {
+		t.Errorf("record labels not propagated: %+v", got.Labels)
+	}
+}
+
+func TestStartEventSpawnsTail(t *testing.T) {
+	f := newFakeClient()
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{Containers: []string{"api"}}, models.LogOptions{}, rec.sink)
+
+	// No running containers yet; then the container starts.
+	f.events <- docker.EngineEvent{Host: "h1", ContainerID: "c9", ContainerName: "api", Action: "start",
+		Labels: map[string]string{"name": "api"}}
+
+	waitFor(t, "start event to spawn tail", func() bool { return f.activeTails(containerKey{"h1", "c9"}) == 1 })
+}
+
+func TestDieEventCancelsTail(t *testing.T) {
+	f := newFakeClient()
+	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{}, models.LogOptions{}, rec.sink)
+	key := containerKey{"h1", "c1"}
+	waitFor(t, "tail to start", func() bool { return f.activeTails(key) == 1 })
+
+	f.set(map[string][]models.ContainerInfo{"h1": {}}, nil)
+	f.events <- docker.EngineEvent{Host: "h1", ContainerID: "c1", ContainerName: "web", Action: "die"}
+
+	waitFor(t, "die event to cancel tail", func() bool { return f.activeTails(key) == 0 })
+	if n := f.totalStarts(key); n != 1 {
+		t.Errorf("tail restarted after die: %d starts", n)
+	}
+}
+
+func TestUnsubscribeCancelsAndIsIdempotent(t *testing.T) {
+	f := newFakeClient()
+	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	unsubscribe := h.Subscribe(ContainerSpec{}, models.LogOptions{}, rec.sink)
+	key := containerKey{"h1", "c1"}
+	waitFor(t, "tail to start", func() bool { return f.activeTails(key) == 1 })
+
+	unsubscribe()
+	waitFor(t, "unsubscribe to cancel tail", func() bool { return f.activeTails(key) == 0 })
+	unsubscribe() // second call must return without blocking or panicking
+
+	before := rec.len()
+	time.Sleep(20 * time.Millisecond)
+	if after := rec.len(); after != before {
+		t.Errorf("sink called after unsubscribe: %d -> %d records", before, after)
+	}
+}
+
+func TestFailedHostListingPreservesTails(t *testing.T) {
+	f := newFakeClient()
+	f.set(map[string][]models.ContainerInfo{
+		"h1": {ctr("c1", "web", "running", nil)},
+		"h2": {ctr("c2", "db", "running", nil)},
+	}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{}, models.LogOptions{}, rec.sink)
+	k1, k2 := containerKey{"h1", "c1"}, containerKey{"h2", "c2"}
+	waitFor(t, "both tails to start", func() bool { return f.activeTails(k1) == 1 && f.activeTails(k2) == 1 })
+
+	// h1 becomes unreachable, h2 lists fine but its container is gone.
+	f.set(map[string][]models.ContainerInfo{"h2": {}},
+		[]docker.HostError{{HostName: "h1", Err: errors.New("connection refused")}})
+	h.Reconcile()
+
+	waitFor(t, "healthy-host disappearance to cancel tail", func() bool { return f.activeTails(k2) == 0 })
+	if f.activeTails(k1) != 1 {
+		t.Error("tail on failed host was cancelled; it must be preserved")
+	}
+}
+
+func TestSlowSinkDropsOldestAndTailKeepsReading(t *testing.T) {
+	total := ringSize + 100
+	emitted := make(chan struct{})
+	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		for i := 0; i < total; i++ {
+			emit(models.LogEntry{Message: strconv.Itoa(i)})
+		}
+		close(emitted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	gate := make(chan struct{})
+	rec := &recorder{}
+	sub, unsubscribe := h.subscribe(ContainerSpec{}, models.LogOptions{}, func(r Record) {
+		<-gate
+		rec.sink(r)
+	})
+	defer unsubscribe()
+
+	// The tail must finish all pushes while the sink is stuck: it never blocks.
+	select {
+	case <-emitted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("tail blocked on slow sink")
+	}
+
+	drops := sub.drops.Load()
+	if drops < uint64(total-ringSize-1) {
+		t.Fatalf("drop counter = %d, want >= %d", drops, total-ringSize-1)
+	}
+
+	close(gate)
+	want := total - int(drops)
+	waitFor(t, "buffered records to drain", func() bool { return rec.len() == want })
+	recs := rec.all()
+	if last := recs[len(recs)-1].Entry.Message; last != strconv.Itoa(total-1) {
+		t.Errorf("newest record lost: last delivered = %q, want %q (oldest must be dropped)", last, strconv.Itoa(total-1))
+	}
+}
+
+func TestTailRetriesThenGivesUpUntilResync(t *testing.T) {
+	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		return errors.New("stream broke")
+	}
+	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{}, models.LogOptions{}, rec.sink)
+	key := containerKey{"h1", "c1"}
+
+	waitFor(t, "retries to reach the attempt cap", func() bool { return f.totalStarts(key) == maxTailAttempts })
+	time.Sleep(30 * time.Millisecond)
+	if n := f.totalStarts(key); n != maxTailAttempts {
+		t.Fatalf("tail kept retrying after giving up: %d starts", n)
+	}
+
+	// The next resync (driven here by a poke) respawns the tail.
+	waitFor(t, "resync to respawn the tail", func() bool {
+		h.Reconcile()
+		return f.totalStarts(key) >= 2*maxTailAttempts
+	})
+}
+
+func TestShutdownDrainsBufferedRecordsAndWaitReturns(t *testing.T) {
+	const total = 50
+	pushed := make(chan struct{})
+	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		for i := 0; i < total; i++ {
+			emit(models.LogEntry{Message: strconv.Itoa(i)})
+		}
+		close(pushed)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
+
+	h := newHub(nil, func() engineClient { return f })
+	h.resyncInterval = time.Hour
+	ctx, cancel := context.WithCancel(context.Background())
+	go h.Run(ctx)
+
+	gate := make(chan struct{})
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{}, models.LogOptions{}, func(r Record) {
+		<-gate
+		rec.sink(r)
+	})
+
+	<-pushed // all records pushed; sink still blocked, so most sit in the buffer
+	cancel()
+	close(gate)
+	waitShutdown(t, h)
+
+	if got := rec.len(); got != total {
+		t.Errorf("shutdown delivered %d buffered records, want %d", got, total)
+	}
+}
+
+func TestTwoSubscribersGetIndependentTailsAndRecords(t *testing.T) {
+	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		emit(models.LogEntry{Message: "from-" + id})
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	f.set(map[string][]models.ContainerInfo{
+		"h1": {ctr("c1", "web", "running", nil), ctr("c2", "db", "running", nil)},
+	}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	recA, recB := &recorder{}, &recorder{}
+	h.Subscribe(ContainerSpec{Containers: []string{"web"}}, models.LogOptions{Tail: "0"}, recA.sink)
+	h.Subscribe(ContainerSpec{}, models.LogOptions{Tail: "100"}, recB.sink)
+
+	k1, k2 := containerKey{"h1", "c1"}, containerKey{"h1", "c2"}
+	// Overlapping specs still get one tail each: c1 is tailed twice.
+	waitFor(t, "per-subscription tails", func() bool {
+		return f.activeTails(k1) == 2 && f.activeTails(k2) == 1
+	})
+	waitFor(t, "records to fan out", func() bool { return recA.len() == 1 && recB.len() == 2 })
+
+	if r := recA.all()[0]; r.ContainerID != "c1" {
+		t.Errorf("subscriber A got record for %s, want c1", r.ContainerID)
+	}
+	seen := map[string]bool{}
+	for _, r := range recB.all() {
+		seen[r.ContainerID] = true
+	}
+	if !seen["c1"] || !seen["c2"] {
+		t.Errorf("subscriber B records incomplete: %v", seen)
+	}
+}
+
+func TestHotSwapReopensStreamAndRespawnsTails(t *testing.T) {
+	snapshot := map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}
+	fakeA, fakeB := newFakeClient(), newFakeClient()
+	fakeA.set(snapshot, nil)
+	fakeB.set(snapshot, nil)
+
+	var mu sync.Mutex
+	current := fakeA
+	h := startHub(t, func() engineClient {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	})
+
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{}, models.LogOptions{}, rec.sink)
+	key := containerKey{"h1", "c1"}
+	waitFor(t, "tail on old client", func() bool { return fakeA.activeTails(key) == 1 })
+	if n := fakeA.streamCount(); n != 1 {
+		t.Fatalf("expected 1 event stream on old client, got %d", n)
+	}
+
+	// Swap the client (config reload) and poke, as main.go does.
+	mu.Lock()
+	current = fakeB
+	mu.Unlock()
+	h.Reconcile()
+	waitFor(t, "event stream reopened on new client", func() bool { return fakeB.streamCount() == 1 })
+
+	// Old client closes; its tail dies, retries fail, and resync respawns on
+	// the new client.
+	fakeA.close()
+	waitFor(t, "tail respawned on new client", func() bool {
+		h.Reconcile()
+		return fakeB.activeTails(key) == 1
+	})
+	if fakeA.activeTails(key) != 0 {
+		t.Error("old client's tail still running after close")
+	}
+}
+
+func TestReconcileBeforeRunDoesNotBlock(t *testing.T) {
+	h := newHub(nil, func() engineClient { return newFakeClient() })
+	done := make(chan struct{})
+	go func() {
+		h.Reconcile()
+		h.Reconcile() // coalesces; must never block
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Reconcile blocked before Run")
+	}
+}

--- a/server/internal/logstream/logstream_test.go
+++ b/server/internal/logstream/logstream_test.go
@@ -155,7 +155,7 @@ func ctr(id, name, state string, labels map[string]string) models.ContainerInfo 
 // cleanup that cancels it and requires a prompt, leak-free shutdown.
 func startHub(t *testing.T, source func() engineClient) *Hub {
 	t.Helper()
-	h := newHub(nil, source)
+	h := newHub(source)
 	h.retryBaseDelay = time.Millisecond
 	h.retryMaxDelay = 4 * time.Millisecond
 	h.listTimeout = time.Second
@@ -217,8 +217,8 @@ func TestSpecMatches(t *testing.T) {
 		{"host and name both required", ContainerSpec{Hosts: []string{"h2"}, Containers: []string{"web"}}, "h1", "web", nil, false},
 	}
 	for _, tc := range cases {
-		if got := specMatches(tc.spec, tc.host, tc.cname, tc.labels); got != tc.want {
-			t.Errorf("%s: specMatches = %v, want %v", tc.name, got, tc.want)
+		if got := tc.spec.Matches(tc.host, tc.cname, tc.labels); got != tc.want {
+			t.Errorf("%s: Matches = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }
@@ -421,7 +421,7 @@ func TestShutdownDrainsBufferedRecordsAndWaitReturns(t *testing.T) {
 	}
 	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
 
-	h := newHub(nil, func() engineClient { return f })
+	h := newHub(func() engineClient { return f })
 	h.resyncInterval = time.Hour
 	ctx, cancel := context.WithCancel(context.Background())
 	go h.Run(ctx)
@@ -520,7 +520,7 @@ func TestHotSwapReopensStreamAndRespawnsTails(t *testing.T) {
 }
 
 func TestReconcileBeforeRunDoesNotBlock(t *testing.T) {
-	h := newHub(nil, func() engineClient { return newFakeClient() })
+	h := newHub(func() engineClient { return newFakeClient() })
 	done := make(chan struct{})
 	go func() {
 		h.Reconcile()

--- a/server/internal/logstream/subscription.go
+++ b/server/internal/logstream/subscription.go
@@ -1,0 +1,115 @@
+package logstream
+
+import (
+	"log"
+	"sync"
+	"sync/atomic"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+const (
+	// ringSize bounds each subscription's record buffer; on overflow the
+	// oldest record is dropped so tails never block on a slow sink.
+	ringSize = 1024
+	// dropLogEvery throttles overflow logging to one line per N drops.
+	dropLogEvery = 1000
+)
+
+// subscription pairs one subscriber's spec, options, and sink with its tails
+// and its bounded delivery buffer. Records are pushed by tail goroutines and
+// consumed by a single delivery goroutine that invokes sink sequentially.
+type subscription struct {
+	spec ContainerSpec
+	opts models.LogOptions
+	sink func(Record)
+
+	// tails is owned exclusively by the hub's run loop goroutine.
+	tails map[containerKey]*tail
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	buf     []Record // fixed-size ring
+	head    int
+	count   int
+	closed  bool
+	discard bool // when closed: drop buffered records instead of draining
+
+	drops     atomic.Uint64
+	delivered chan struct{} // closed when the delivery goroutine exits
+}
+
+func newSubscription(spec ContainerSpec, opts models.LogOptions, sink func(Record)) *subscription {
+	s := &subscription{
+		spec:      spec,
+		opts:      opts,
+		sink:      sink,
+		tails:     make(map[containerKey]*tail),
+		buf:       make([]Record, ringSize),
+		delivered: make(chan struct{}),
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// push enqueues a record, dropping the oldest buffered record on overflow.
+// It never blocks on the sink. Records pushed after close are discarded.
+func (s *subscription) push(r Record) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	dropped := false
+	if s.count == len(s.buf) {
+		s.buf[s.head] = Record{}
+		s.head = (s.head + 1) % len(s.buf)
+		s.count--
+		dropped = true
+	}
+	s.buf[(s.head+s.count)%len(s.buf)] = r
+	s.count++
+	s.cond.Signal()
+	s.mu.Unlock()
+
+	if dropped {
+		if n := s.drops.Add(1); n%dropLogEvery == 0 {
+			log.Printf("logstream: subscription %+v dropped %d records (slow sink)", s.spec, n)
+		}
+	}
+}
+
+// deliverLoop invokes the sink sequentially until the subscription is closed.
+// A drain close finishes buffered records first; a discard close returns
+// immediately without further sink calls.
+func (s *subscription) deliverLoop() {
+	defer close(s.delivered)
+	for {
+		s.mu.Lock()
+		for s.count == 0 && !s.closed {
+			s.cond.Wait()
+		}
+		if s.closed && (s.discard || s.count == 0) {
+			s.mu.Unlock()
+			return
+		}
+		r := s.buf[s.head]
+		s.buf[s.head] = Record{}
+		s.head = (s.head + 1) % len(s.buf)
+		s.count--
+		s.mu.Unlock()
+		s.sink(r)
+	}
+}
+
+// close stops the subscription; the first call wins (a later close cannot
+// change drain/discard semantics). Idempotent.
+func (s *subscription) close(discard bool) {
+	s.mu.Lock()
+	if !s.closed {
+		s.closed = true
+		s.discard = discard
+		s.cond.Broadcast()
+	}
+	s.mu.Unlock()
+}

--- a/server/internal/logstream/tail.go
+++ b/server/internal/logstream/tail.go
@@ -1,0 +1,75 @@
+package logstream
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// maxTailAttempts bounds how many times a tail is opened before giving up
+// until the next resync or start event respawns it.
+const maxTailAttempts = 5
+
+// tail is the run loop's handle to one tail goroutine.
+type tail struct {
+	cancel context.CancelFunc
+}
+
+// spawnTail starts a tail goroutine for one (subscription, container) pair.
+// Runs on the loop. The Docker client is captured at spawn time: after a hot
+// swap the old client's close ends the tail and resync respawns it on the
+// new client.
+func (h *Hub) spawnTail(sub *subscription, key containerKey, name string, labels map[string]string) {
+	client := h.source()
+	ctx, cancel := context.WithCancel(h.runCtx)
+	t := &tail{cancel: cancel}
+	sub.tails[key] = t
+
+	h.tailWg.Add(1)
+	go func() {
+		defer h.tailWg.Done()
+		defer cancel()
+		h.runTail(ctx, client, sub, key, name, labels)
+		// Tell the loop this tail is gone so resync can respawn it. Skipped
+		// on shutdown, when the loop is no longer receiving.
+		select {
+		case h.tailExitCh <- tailExit{sub: sub, key: key, t: t}:
+		case <-h.runCtx.Done():
+		}
+	}()
+}
+
+// runTail opens the log tail and keeps it open while desired, retrying with
+// exponential backoff when the stream ends prematurely. Returns when ctx is
+// cancelled (tail no longer desired) or after maxTailAttempts.
+func (h *Hub) runTail(ctx context.Context, client engineClient, sub *subscription, key containerKey, name string, labels map[string]string) {
+	emit := func(entry models.LogEntry) {
+		sub.push(Record{
+			Host:          key.host,
+			ContainerID:   key.id,
+			ContainerName: name,
+			Labels:        labels,
+			Entry:         entry,
+		})
+	}
+
+	delay := h.retryBaseDelay
+	for attempt := 1; ; attempt++ {
+		err := client.openTail(ctx, key.host, key.id, sub.opts, emit)
+		if ctx.Err() != nil {
+			return
+		}
+		if attempt >= maxTailAttempts {
+			log.Printf("logstream: tail %s/%s gave up after %d attempts (last error: %v)", key.host, name, attempt, err)
+			return
+		}
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return
+		}
+		delay = min(delay*2, h.retryMaxDelay)
+	}
+}

--- a/server/internal/models/alerts.go
+++ b/server/internal/models/alerts.go
@@ -1,0 +1,50 @@
+package models
+
+// LevelSeverity returns the canonical numeric severity for a log level, used
+// by alert min-level matching and the persistence store. UNKNOWN is lowest so
+// unclassified lines never satisfy a min-level threshold; the named levels
+// ascend from TRACE to PANIC. Unrecognized values map to 0 like UNKNOWN.
+func LevelSeverity(level LogLevel) int {
+	switch level {
+	case LogLevelTrace:
+		return 1
+	case LogLevelDebug:
+		return 2
+	case LogLevelInfo:
+		return 3
+	case LogLevelWarn:
+		return 4
+	case LogLevelError:
+		return 5
+	case LogLevelFatal:
+		return 6
+	case LogLevelPanic:
+		return 7
+	default: // LogLevelUnknown and anything unrecognized
+		return 0
+	}
+}
+
+// Alert is one fired-alert history entry.
+type Alert struct {
+	ID            string          `json:"id"`
+	RuleID        string          `json:"ruleId"`
+	RuleName      string          `json:"ruleName"`
+	Type          string          `json:"type"`
+	Host          string          `json:"host"`
+	ContainerID   string          `json:"containerId"`
+	ContainerName string          `json:"containerName"`
+	Reason        string          `json:"reason"`
+	Sample        string          `json:"sample,omitempty"`
+	Count         int             `json:"count"`
+	Suppressed    int             `json:"suppressed"`
+	FiredAt       string          `json:"firedAt"`
+	Delivery      *DeliveryResult `json:"delivery,omitempty"`
+}
+
+// DeliveryResult records the outcome of one webhook delivery attempt.
+type DeliveryResult struct {
+	Status     string `json:"status"`
+	HTTPStatus int    `json:"httpStatus,omitempty"`
+	Error      string `json:"error,omitempty"`
+}

--- a/server/internal/models/alerts_test.go
+++ b/server/internal/models/alerts_test.go
@@ -1,0 +1,39 @@
+package models
+
+import "testing"
+
+func TestLevelSeverityOrdering(t *testing.T) {
+	// The full canonical ordering: UNKNOWN lowest, then TRACE ascending to PANIC.
+	ordered := []struct {
+		level LogLevel
+		want  int
+	}{
+		{LogLevelUnknown, 0},
+		{LogLevelTrace, 1},
+		{LogLevelDebug, 2},
+		{LogLevelInfo, 3},
+		{LogLevelWarn, 4},
+		{LogLevelError, 5},
+		{LogLevelFatal, 6},
+		{LogLevelPanic, 7},
+	}
+
+	for _, tt := range ordered {
+		if got := LevelSeverity(tt.level); got != tt.want {
+			t.Fatalf("LevelSeverity(%s) = %d, want %d", tt.level, got, tt.want)
+		}
+	}
+
+	for i := 1; i < len(ordered); i++ {
+		prev, cur := ordered[i-1], ordered[i]
+		if LevelSeverity(prev.level) >= LevelSeverity(cur.level) {
+			t.Fatalf("expected LevelSeverity(%s) < LevelSeverity(%s)", prev.level, cur.level)
+		}
+	}
+}
+
+func TestLevelSeverityUnrecognizedIsLowest(t *testing.T) {
+	if got := LevelSeverity(LogLevel("BOGUS")); got != 0 {
+		t.Fatalf("LevelSeverity(BOGUS) = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

LogDeck's first standing background responsibility: an alerting engine that watches containers and notifies you, instead of waiting for you to look.

Stacked on `feat/container-health` (#87) because it builds on that branch's events changes. GitHub retargets this to main once #87 merges.

## What you get

**Rules** — two kinds, both with the same rate and cooldown machinery:
- **Event rules**: a container died (nonzero exit) or was OOM-killed.
- **Log rules**: log lines at or above a level (server-side classifier), with an optional regex.
- **Targeting**: container names, compose projects, hosts. Empty means all.
- **Rate**: "N occurrences within W seconds" — a sliding window. A crash-loop rule is just `die, 3 in 120s`.
- **Cooldown** (default 300s, per rule x container x host): after firing, the rule goes quiet. Repeat occurrences are **counted, not dropped**, and reported on the next alert as a suppressed count. A container crash-looping for hours produces one alert, not hundreds.

**Delivery** — one global JSON webhook. The payload carries top-level `text` and `content` so Slack and Discord webhooks both accept it unmodified; the structured `alert` object serves relays and ntfy. 10s timeout, one retry on 5xx/network error, none on 4xx. A test-fire endpoint verifies the wiring.

**History** — every fired alert is recorded server-side (bounded ring, 500 entries, persisted next to the config file) and survives restarts, whether or not a webhook is configured. Alerts are written to history *before* delivery, so a hung webhook can never lose them.

**Surfaces** — REST API (`/api/v1/alerts/*`), `logdeck alerts` CLI (rules, history, webhook, test), and an Alerts card in Settings with a preset-driven rule dialog (Container crashed / Crash looping / Out of memory / Error spike / Log pattern / Custom), combobox targeting fed by the live container list, and a scrolling history table.

## Architecture

- `internal/logstream` — a shared tail hub: subscribers declare a container spec plus log options, and the hub owns one tail per (subscription, host, container). Single-owner control loop, off-loop container listing, per-subscription ring buffers so a slow consumer can never stall a tail, self-healing across host disconnects and config hot-swaps. **Log persistence will subscribe to this same hub**, which is why alerting tails only rule-matched containers rather than everything.
- `docker.StreamEngineEvents` — an engine-grade event stream carrying exit codes, OOM, and labels (the existing frontend event stream is unchanged, byte for byte).
- `docker.TailContainerLogs` — a TTY-aware callback tail primitive.
- `internal/alerts` — rule compilation, sliding windows, cooldown/dedup, webhook dispatch, history.

## Testing

- Go: unit tests for windows/cooldowns/targeting, engine integration tests with fake event and log sources, webhook delivery tests (retry semantics, payload shape), history tests (cap eviction, corrupt-file tolerance, atomic writes). `-race` clean on the concurrent packages.
- Frontend: tsc, biome, 77 tests, build.
- **Live-verified end to end** against Podman + Docker: webhook test-fire delivered; a 5-ERROR-in-60s rule fired and delivered; the cooldown surfaced a suppressed count on the follow-up alert; `kill` produced an exit-137 alert; a container crash-looping for three minutes produced exactly one alert; alerts flowed from both hosts.
- Adversarially reviewed by a multi-agent workflow; all confirmed findings fixed in this branch (OOM double-counting, a history flush race, unbounded shutdown drain, container-name normalization, and more).

https://claude.ai/code/session_01BNuavDshHAEjeUcqMrSjE5