### PR TITLE
fix: DOCKER_HOST overriding configured hosts, and settings toggle layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to LogDeck are documented here.
+
+## [0.2.0] - 2026-07-14
+
+### Added
+
+**Log persistence and history.** Container logs are stored on disk, so they stay readable after a container is restarted, rebuilt, or removed. A rebuilt container keeps one continuous timeline under its name, even though the engine gives it a new ID. A `Live | History` toggle in the log viewer pages back through stored logs with server-side level, regex, and time-range filtering. Containers that no longer exist appear on the dashboard under a "Removed" filter, and their logs remain readable until you delete them. Retention defaults to 50 MB per container and 1 GB total, editable in Settings.
+
+**Alerting.** Rules fire on container events (died, OOM-killed) or on log output (level threshold plus an optional regex). A rate condition ("5 in 60 seconds") ignores noise, and a per-rule cooldown means a crash-looping container sends one alert instead of hundreds — repeat occurrences are counted and reported on the next alert. Alerts go to a JSON webhook that Slack, Discord, and ntfy accept as-is, and every alert is recorded in a history you can browse. Manage rules from Settings or the `logdeck alerts` CLI.
+
+**Scoped API tokens.** Tokens are now `admin` or `read`. A read token can fetch logs, stats, events, and container details, but cannot mutate anything, use the web terminal, or read container environment variables, settings, or alert configuration — safe to hand to a CI job or an AI agent.
+
+**Container health.** Healthy, unhealthy, and starting badges from Docker healthchecks, in the containers table and on the container page. (Podman's Docker-compatible list API does not report health, so badges there are Docker-only.)
+
+### Changed
+
+- Settings is organized into tabs: Connections, Access, Alerts, and Log storage. Each tab is linkable (`/settings?tab=alerts`).
+- The `logdeck` CLI gains `alerts` (rules, history, webhook, test).
+
+### Fixed
+
+- `DOCKER_HOST` silently overrode every configured non-SSH host, collapsing a multi-host setup onto a single socket. An explicitly configured host now always wins.
+- Read-scoped tokens could read the alert webhook URL, which is a secret.
+- `env.example` advertised `BACKEND_PORT` and `FRONTEND_PORT`, which the server never reads, and omitted `CONFIG_PATH`, `READONLY_MODE`, and the retention caps.
+- Documentation examples omitted the `/data` volume, so following them cost you your configuration on every upgrade.
+
+### Upgrading
+
+**Mount a volume at `/data`.** It holds the config file (Docker hosts, API tokens, alert rules), the stored logs, and the alert history. Without it, all of that is lost every time the container is recreated. LogDeck now warns at startup if the directory is not a mounted volume.
+
+```
+-v logdeck-data:/data
+```
+
+Log persistence is enabled by default. To turn it off, set `LOG_STORE_ENABLED=false`.
+
+If you script the CLI with a read-scoped token, note that `logdeck alerts` now requires an admin token.
+
+## [0.1.0] - 2026-07-10
+
+First release. Multi-host Docker and Podman support, live and historical log viewing with level classification and search, compose stack grouping and actions, container lifecycle actions, environment and resource editing, a web terminal, image/volume/network views, host and container stats, read-only mode, authentication, API tokens, and the `logdeck` CLI.
+
+[0.2.0]: https://github.com/AmoabaKelvin/logdeck/releases/tag/v0.2.0
+[0.1.0]: https://github.com/AmoabaKelvin/logdeck/releases/tag/v0.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,20 +3,30 @@ services:
     build:
       context: .
       dockerfile: ./server/Dockerfile
+    restart: unless-stopped
     ports:
       - "8123:8080"
     environment:
       - JWT_SECRET=${JWT_SECRET}
       - ADMIN_USERNAME=${ADMIN_USERNAME}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - ADMIN_PASSWORD_SALT=${ADMIN_PASSWORD_SALT}
-      - DOCKER_HOST=${DOCKER_HOST:-unix:///var/run/docker.sock}
+      # Legacy SHA256 auth; leave unset to use the bcrypt ADMIN_PASSWORD.
+      - ADMIN_PASSWORD_SALT=${ADMIN_PASSWORD_SALT:-}
+      # Hosts to connect to (name=address, comma-separated). Leave unset to use
+      # the mounted socket below. Do NOT set DOCKER_HOST: it is a Docker SDK
+      # variable, not a LogDeck one.
       - DOCKER_HOSTS=${DOCKER_HOSTS:-}
       - COOLIFY_CONFIGS=${COOLIFY_CONFIGS:-}
+      # Log persistence (on by default). Uncomment to change the retention caps;
+      # they are also editable in Settings.
+      # - LOG_STORE_PER_CONTAINER_MB=50
+      # - LOG_STORE_TOTAL_MB=1024
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.ssh:/root/.ssh:ro
       - /proc:/host/proc:ro
+      # Holds config.json, the stored logs (logs.db), and the alert history.
+      # Without this volume all of it is lost when the container is recreated.
       - logdeck-data:/data
 
 volumes:

--- a/env.example
+++ b/env.example
@@ -1,7 +1,12 @@
 # LogDeck Environment Configuration
+#
+# Everything here can also be set in the Settings UI, which persists to
+# /data/config.json. An environment variable always wins: a value set here
+# shows up in the UI as "Set via environment variable" and cannot be edited
+# there.
 
 # =============================================================================
-# Authentication Settings (Required)
+# Authentication (set all three to require a login; omit them to run open)
 # =============================================================================
 
 # JWT Secret Key - Use a strong, random string (minimum 32 characters)
@@ -18,15 +23,48 @@ ADMIN_USERNAME=admin
 # Example output: $2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
 ADMIN_PASSWORD=$2a$10$YourBcryptHashHere
 
+# Legacy alternative to bcrypt: SHA256(password + salt). Only set this if you
+# are already using it; new installs should use the bcrypt hash above.
+# ADMIN_PASSWORD_SALT=
+
 # =============================================================================
-# Server Configuration (Optional)
+# Docker / Podman hosts (optional)
 # =============================================================================
 
-# Backend port (default 8080)
-BACKEND_PORT=8080
+# Hosts to connect to, comma-separated as name=address. When unset, LogDeck
+# auto-detects the local Docker or Podman socket.
+#
+# Podman works through its Docker-compatible API socket (see podman.md):
+#   Rootless: unix:///run/user/1000/podman/podman.sock
+#   Rootful:  unix:///run/podman/podman.sock
+# Remote hosts over SSH are supported: prod=ssh://user@example.com
+#
+# DOCKER_HOSTS=local=unix:///var/run/docker.sock,prod=ssh://user@example.com
+#
+# Note: DOCKER_HOST (singular) is not a LogDeck setting. Use DOCKER_HOSTS.
 
-# Frontend port (default: 5173)
-FRONTEND_PORT=5173
+# =============================================================================
+# Storage (optional)
+# =============================================================================
+
+# Path to the config file. Its directory also holds the log database (logs.db)
+# and the alert history, so it must live on a persistent volume.
+# Default: /data/config.json
+# CONFIG_PATH=/data/config.json
+
+# Log persistence keeps container logs readable after a container is removed or
+# rebuilt. Enabled by default; the caps are also editable in Settings.
+# LOG_STORE_ENABLED=true
+# LOG_STORE_PER_CONTAINER_MB=50
+# LOG_STORE_TOTAL_MB=1024
+
+# =============================================================================
+# Server (optional)
+# =============================================================================
+
+# Block every mutating action: start, stop, restart, remove, env and resource
+# edits, compose actions, the web terminal, and deleting stored logs.
+# READONLY_MODE=true
 
 # Allowed CORS origins (comma-separated). Only needed when the frontend is
 # served from a different origin than the backend (e.g. a dev server).
@@ -40,18 +78,6 @@ FRONTEND_PORT=5173
 # TRUST_PROXY_HEADERS=true
 
 # =============================================================================
-# Docker Configuration (Optional)
-# =============================================================================
-
-# Docker host (uncomment to override default)
-# DOCKER_HOST=unix:///var/run/docker.sock
-
-# Podman works too, via its Docker-compatible API socket (see podman.md).
-# Rootless: unix:///run/user/1000/podman/podman.sock
-# Rootful:  unix:///run/podman/podman.sock
-# DOCKER_HOSTS=local=unix:///run/podman/podman.sock
-
-# =============================================================================
 # Coolify Integration (Optional)
 # =============================================================================
 # Enable this to persist env var changes across Coolify redeployments.
@@ -59,4 +85,3 @@ FRONTEND_PORT=5173
 # Host names must match names defined in DOCKER_HOSTS.
 
 # COOLIFY_CONFIGS=local|https://your-coolify-instance.com|your-api-token
-

--- a/frontend/src/features/settings/components/auth-section.tsx
+++ b/frontend/src/features/settings/components/auth-section.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 
 import {
 	Card,
+	CardAction,
 	CardContent,
 	CardDescription,
 	CardHeader,
@@ -70,61 +71,61 @@ export function AuthSection({ config }: AuthSectionProps) {
 				<CardDescription>
 					Protect the dashboard with username and password authentication.
 				</CardDescription>
-			</CardHeader>
-			<CardContent className="space-y-4">
-				<div className="flex items-center gap-3">
+				<CardAction>
 					<Switch
 						id="auth-enabled"
+						aria-label="Enable authentication"
 						checked={enabled}
 						onCheckedChange={(checked) => {
 							setEnabled(checked);
 							if (!checked) setPassword("");
 						}}
 						disabled={isEnv}
+						className="relative after:absolute after:-inset-x-1 after:-inset-y-3"
 					/>
-					<Label htmlFor="auth-enabled" className="cursor-pointer">
-						{enabled ? "Enabled" : "Disabled"}
-					</Label>
-				</div>
-
-				{enabled && (
-					<div className="space-y-3 max-w-sm">
-						<div className="space-y-1.5">
-							<Label htmlFor="admin-username">Admin username</Label>
-							<Input
-								id="admin-username"
-								value={username}
-								onChange={(e) => setUsername(e.target.value)}
-								disabled={isEnv}
-								placeholder="admin"
-							/>
+				</CardAction>
+			</CardHeader>
+			{(enabled || hasChanges) && (
+				<CardContent className="space-y-4">
+					{enabled && (
+						<div className="space-y-3 max-w-sm">
+							<div className="space-y-1.5">
+								<Label htmlFor="admin-username">Admin username</Label>
+								<Input
+									id="admin-username"
+									value={username}
+									onChange={(e) => setUsername(e.target.value)}
+									disabled={isEnv}
+									placeholder="admin"
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="admin-password">
+									{config.enabled
+										? "New password (leave blank to keep current)"
+										: "Password"}
+								</Label>
+								<Input
+									id="admin-password"
+									type="password"
+									value={password}
+									onChange={(e) => setPassword(e.target.value)}
+									disabled={isEnv}
+									placeholder={
+										config.enabled
+											? "Leave blank to keep current"
+											: "Enter password"
+									}
+								/>
+							</div>
 						</div>
-						<div className="space-y-1.5">
-							<Label htmlFor="admin-password">
-								{config.enabled
-									? "New password (leave blank to keep current)"
-									: "Password"}
-							</Label>
-							<Input
-								id="admin-password"
-								type="password"
-								value={password}
-								onChange={(e) => setPassword(e.target.value)}
-								disabled={isEnv}
-								placeholder={
-									config.enabled
-										? "Leave blank to keep current"
-										: "Enter password"
-								}
-							/>
-						</div>
-					</div>
-				)}
+					)}
 
-				{hasChanges && !isEnv && (
-					<SaveButton isPending={mutation.isPending} onClick={handleSave} />
-				)}
-			</CardContent>
+					{hasChanges && !isEnv && (
+						<SaveButton isPending={mutation.isPending} onClick={handleSave} />
+					)}
+				</CardContent>
+			)}
 		</Card>
 	);
 }

--- a/frontend/src/features/settings/components/read-only-section.tsx
+++ b/frontend/src/features/settings/components/read-only-section.tsx
@@ -1,11 +1,10 @@
 import {
 	Card,
-	CardContent,
+	CardAction,
 	CardDescription,
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 
 import { useUpdateReadOnly } from "../hooks/use-settings";
@@ -36,20 +35,17 @@ export function ReadOnlySection({ config }: ReadOnlySectionProps) {
 					When enabled, container actions (start, stop, restart, remove) are
 					disabled. Log viewing is unaffected.
 				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				<div className="flex items-center gap-3">
+				<CardAction>
 					<Switch
 						id="read-only"
+						aria-label="Enable read-only mode"
 						checked={config.value}
 						onCheckedChange={handleToggle}
 						disabled={isEnv || mutation.isPending}
+						className="relative after:absolute after:-inset-x-1 after:-inset-y-3"
 					/>
-					<Label htmlFor="read-only" className="cursor-pointer">
-						{config.value ? "Enabled" : "Disabled"}
-					</Label>
-				</div>
-			</CardContent>
+				</CardAction>
+			</CardHeader>
 		</Card>
 	);
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -53,6 +53,12 @@ func main() {
 		log.Println("Authentication is ENABLED")
 	}
 
+	// Losing the data directory loses the config, the stored logs, and the alert
+	// history — silently, on the next container recreate. Say so at startup.
+	if warning := config.WarnIfDataIsEphemeral(manager.ConfigFilePath()); warning != "" {
+		log.Println(warning)
+	}
+
 	if cfg.ReadOnly {
 		log.Println("READ-ONLY MODE is ENABLED")
 	}

--- a/server/internal/config/persistence.go
+++ b/server/internal/config/persistence.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WarnIfDataIsEphemeral reports a warning when the directory holding the config
+// file (and with it the log database and the alert history) lives inside the
+// container's own writable layer rather than on a mounted volume. Everything in
+// it — Docker hosts, API tokens, alert rules, stored logs — is then discarded
+// the moment the container is recreated, which is exactly what an upgrade does.
+//
+// It returns an empty string when the data is safe, when the check cannot be
+// made, or when LogDeck is not running in a container at all: a false alarm on
+// a bare-metal install would be worse than no warning.
+func WarnIfDataIsEphemeral(configFilePath string) string {
+	if !inContainer() {
+		return ""
+	}
+
+	dir := filepath.Dir(configFilePath)
+	mounted, err := isMountPoint(dir)
+	if err != nil || mounted {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"WARNING: %s is not a mounted volume. Your configuration (Docker hosts, "+
+			"API tokens, alert rules), stored logs, and alert history are written "+
+			"there and will be LOST when this container is recreated, including on "+
+			"every upgrade. Mount a volume, e.g. -v logdeck-data:%s",
+		dir, dir,
+	)
+}
+
+// inContainer reports whether the process looks containerized. /.dockerenv is
+// written by Docker; Podman writes /run/.containerenv.
+func inContainer() bool {
+	for _, marker := range []string{"/.dockerenv", "/run/.containerenv"} {
+		if _, err := os.Stat(marker); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// isMountPoint reports whether dir is a mount point, read from the kernel's
+// mount table. A bind mount and a named volume both appear there; a plain
+// directory in the image's writable layer does not.
+func isMountPoint(dir string) (bool, error) {
+	clean := filepath.Clean(dir)
+
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// mountinfo: id parent major:minor root mount-point ...
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 5 {
+			continue
+		}
+		if filepath.Clean(fields[4]) == clean {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
+}

--- a/server/internal/config/persistence_test.go
+++ b/server/internal/config/persistence_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A bare-metal install must never be warned: a false alarm about data loss on a
+// machine that has no such problem is worse than staying quiet.
+func TestWarnIfDataIsEphemeralStaysQuietOutsideAContainer(t *testing.T) {
+	if inContainer() {
+		t.Skip("this test asserts the non-container path; running inside a container")
+	}
+
+	dir := t.TempDir()
+	if warning := WarnIfDataIsEphemeral(filepath.Join(dir, "config.json")); warning != "" {
+		t.Fatalf("warned on a host install: %s", warning)
+	}
+}
+
+// The mount table is the source of truth: a mounted volume appears in it, a
+// directory in the image's writable layer does not.
+func TestIsMountPoint(t *testing.T) {
+	if _, err := os.Stat("/proc/self/mountinfo"); err != nil {
+		t.Skip("no /proc/self/mountinfo on this platform")
+	}
+
+	mounted, err := isMountPoint("/proc")
+	if err != nil {
+		t.Fatalf("isMountPoint(/proc): %v", err)
+	}
+	if !mounted {
+		t.Error("expected /proc to be reported as a mount point")
+	}
+
+	mounted, err = isMountPoint(t.TempDir())
+	if err != nil {
+		t.Fatalf("isMountPoint(tempdir): %v", err)
+	}
+	if mounted {
+		t.Error("expected a plain directory not to be reported as a mount point")
+	}
+}

--- a/server/internal/docker/client.go
+++ b/server/internal/docker/client.go
@@ -49,10 +49,15 @@ func NewMultiHostClient(hosts []config.DockerHost) (*MultiHostClient, error) {
 				client.WithAPIVersionNegotiation(),
 			)
 		} else {
+			// FromEnv comes first so DOCKER_HOST cannot override a configured
+			// host: it applies WithHostFromEnv, and the last option wins. With
+			// the order reversed, a single DOCKER_HOST would silently collapse
+			// every configured host onto one socket. The TLS and API-version
+			// parts of FromEnv still apply.
 			apiClient, err = client.NewClientWithOpts(
+				client.FromEnv,
 				client.WithHost(host.Host),
 				client.WithAPIVersionNegotiation(),
-				client.FromEnv,
 			)
 		}
 

--- a/server/internal/docker/client_test.go
+++ b/server/internal/docker/client_test.go
@@ -1,6 +1,10 @@
 package docker
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+)
 
 func TestHealthFromStatus(t *testing.T) {
 	tests := []struct {
@@ -22,5 +26,35 @@ func TestHealthFromStatus(t *testing.T) {
 				t.Errorf("healthFromStatus(%q) = %q, want %q", tt.status, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestConfiguredHostWinsOverDockerHostEnv guards a footgun: the Docker SDK's
+// FromEnv option applies DOCKER_HOST, and the last option wins. Applied after
+// the configured host it would silently point every non-SSH host at the same
+// socket, collapsing a multi-host setup — and the shipped compose file sets
+// DOCKER_HOST.
+func TestConfiguredHostWinsOverDockerHostEnv(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+
+	hosts := []config.DockerHost{
+		{Name: "a", Host: "tcp://10.0.0.1:2375"},
+		{Name: "b", Host: "tcp://10.0.0.2:2375"},
+	}
+	multi, err := NewMultiHostClient(hosts)
+	if err != nil {
+		t.Fatalf("NewMultiHostClient: %v", err)
+	}
+	defer multi.Close()
+
+	for _, host := range hosts {
+		cl, err := multi.GetClient(host.Name)
+		if err != nil {
+			t.Fatalf("GetClient(%s): %v", host.Name, err)
+		}
+		if got := cl.DaemonHost(); got != host.Host {
+			t.Errorf("host %s: DOCKER_HOST overrode the configured host: got %s, want %s",
+				host.Name, got, host.Host)
+		}
 	}
 }


### PR DESCRIPTION
Two follow-ups to #89, found while reconciling the sample configuration with the code.

## DOCKER_HOST silently collapsed multi-host setups

The Docker client was built with `WithHost(configuredHost)` followed by `client.FromEnv`. The last option wins, and `FromEnv` applies `DOCKER_HOST` — so a single `DOCKER_HOST` value silently overrode **every** configured non-SSH host. The shipped `docker-compose.yml` set `DOCKER_HOST` unconditionally, so anyone running multiple hosts through the official compose file had all of them pointing at the same socket.

`FromEnv` now runs first, so an explicitly configured host always wins; the TLS and API-version parts of `FromEnv` still apply. `TestConfiguredHostWinsOverDockerHostEnv` covers it and fails against the previous ordering (two distinct hosts both resolved to `unix:///var/run/docker.sock`).

## env.example and docker-compose.yml did not match the code

- `BACKEND_PORT` and `FRONTEND_PORT` were advertised but are never read by the server (the listen port is fixed; the compose port mapping is what matters).
- `CONFIG_PATH`, `READONLY_MODE`, and the `LOG_STORE_*` retention caps were missing entirely.
- `DOCKER_HOST` is removed from both files, with a note that it is a Docker SDK variable rather than a LogDeck one.
- The compose file now states what the `/data` volume holds: the config file, the stored logs (`logs.db`), and the alert history — losing it loses all three.

Every variable in `env.example` is now one the server actually reads, and every variable the server reads is documented.

## Settings toggle layout

The Authentication and Read-Only Mode switches sat on their own line below the card description, labelled with a redundant "Enabled"/"Disabled" word. Both now use the Card primitive's existing `CardAction` header slot, so the switch is right-aligned opposite the section title — the shadcn pattern already used elsewhere in the codebase. The state word is gone (the switch conveys it; an `aria-label` replaces it for screen readers), the env-pinned badge and the disabled switch now read as one statement instead of a broken control, and the switch hit area is extended to meet the 40px minimum (it was 18x32px). A switched-off Authentication card collapses to a header-only card instead of leaving dead space.

No behavior change: same mutations, same toasts, same env-pinned disabling.

## Testing
Go build, vet, and full suite pass; frontend tsc, biome, 106 tests, and build pass.

https://claude.ai/code/session_01BNuavDshHAEjeUcqMrSjE5