### PR TITLE
perf: hold the retention cap under load and speed up history queries

### DIFF
--- a/server/cmd/logstore-stress/main.go
+++ b/server/cmd/logstore-stress/main.go
@@ -1,0 +1,675 @@
+// Command logstore-stress exercises the real internal/logstore.Store through
+// its actual live ingestion path at high, sustained write rates and reports
+// where it slows or drops. It drives the store's unexported sink directly (via
+// a capturing fake hub) while the real writeLoop, batching, dedup, watermarks,
+// and janitor run, and while representative queries run concurrently.
+//
+// It changes no store behavior. It measures. Output is machine-readable JSON on
+// stdout plus a human summary on stderr.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+	"github.com/AmoabaKelvin/logdeck/internal/logstore"
+	"github.com/AmoabaKelvin/logdeck/internal/logstream"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+const stressHost = "stress"
+
+// runConfig is the fully-resolved harness configuration (scenario preset with
+// any explicit flag overrides applied).
+type runConfig struct {
+	Scenario       string        `json:"scenario"`
+	Containers     int           `json:"containers"`
+	RateLinesPerS  int           `json:"rateLinesPerSec"` // 0 == flood
+	Flood          bool          `json:"flood"`
+	Duration       time.Duration `json:"-"`
+	DurationSec    float64       `json:"durationSec"`
+	PerContainerMB int           `json:"perContainerMB"`
+	TotalMB        int           `json:"totalMB"`
+	LineBytes      int           `json:"lineBytes"`
+	QueryWorkers   int           `json:"queryWorkers"`
+}
+
+// scenarioPreset is the default parameter set for a named scenario.
+type scenarioPreset struct {
+	containers   int
+	rate         int
+	flood        bool
+	duration     time.Duration
+	perMB        int
+	totalMB      int
+	lineBytes    int
+	queryWorkers int
+}
+
+var presets = map[string]scenarioPreset{
+	// The "chatty stack" baseline: expect zero drops, db plateaus at cap, flat memory.
+	"steady": {containers: 12, rate: 1000, duration: 3 * time.Minute, perMB: 50, totalMB: 1024, lineBytes: 150},
+	// One container, unbounded: find the max sustained commit rate and drop behavior.
+	"flood": {containers: 1, rate: 0, flood: true, duration: 30 * time.Second, perMB: 50, totalMB: 1024, lineBytes: 150},
+	// Tiny caps + high rate: the janitor evicts continuously; watch for throughput dips / contention.
+	"retention-churn": {containers: 8, rate: 20000, duration: 2 * time.Minute, perMB: 1, totalMB: 5, lineBytes: 150},
+	// Steady ingest with a concurrent query workload: report query p50/p95/p99.
+	"query-under-load": {containers: 12, rate: 1000, duration: 2 * time.Minute, perMB: 50, totalMB: 1024, lineBytes: 150, queryWorkers: 4},
+	// Breadth: many containers at a moderate aggregate rate.
+	"many-containers": {containers: 100, rate: 5000, duration: 2 * time.Minute, perMB: 20, totalMB: 1024, lineBytes: 150},
+}
+
+func main() {
+	cfg, err := parseFlags()
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "logstore-stress:", err)
+		os.Exit(2)
+	}
+	if err := run(cfg); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "logstore-stress:", err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags() (runConfig, error) {
+	var (
+		scenario     = flag.String("scenario", "steady", "preset: steady|flood|retention-churn|query-under-load|many-containers")
+		containers   = flag.Int("containers", -1, "number of synthetic containers (overrides scenario)")
+		rate         = flag.Int("rate", -1, "aggregate lines/sec; 0 = flood (overrides scenario)")
+		duration     = flag.Duration("duration", 0, "run duration (overrides scenario)")
+		perMB        = flag.Int("per-container-mb", -1, "per-container retention cap in MB (overrides scenario)")
+		totalMB      = flag.Int("total-mb", -1, "total retention cap in MB (overrides scenario)")
+		lineBytes    = flag.Int("line-bytes", -1, "approximate stored bytes per line (overrides scenario)")
+		queryWorkers = flag.Int("query-workers", -1, "concurrent query goroutines (overrides scenario)")
+	)
+	flag.Parse()
+
+	preset, ok := presets[*scenario]
+	if !ok {
+		return runConfig{}, fmt.Errorf("unknown scenario %q", *scenario)
+	}
+
+	cfg := runConfig{
+		Scenario:       *scenario,
+		Containers:     preset.containers,
+		RateLinesPerS:  preset.rate,
+		Duration:       preset.duration,
+		PerContainerMB: preset.perMB,
+		TotalMB:        preset.totalMB,
+		LineBytes:      preset.lineBytes,
+		QueryWorkers:   preset.queryWorkers,
+	}
+	if *containers >= 0 {
+		cfg.Containers = *containers
+	}
+	if *rate >= 0 {
+		cfg.RateLinesPerS = *rate
+	}
+	if *duration > 0 {
+		cfg.Duration = *duration
+	}
+	if *perMB >= 0 {
+		cfg.PerContainerMB = *perMB
+	}
+	if *totalMB >= 0 {
+		cfg.TotalMB = *totalMB
+	}
+	if *lineBytes >= 0 {
+		cfg.LineBytes = *lineBytes
+	}
+	if *queryWorkers >= 0 {
+		cfg.QueryWorkers = *queryWorkers
+	}
+
+	cfg.Flood = cfg.RateLinesPerS == 0
+	cfg.DurationSec = cfg.Duration.Seconds()
+
+	if cfg.Containers < 1 {
+		return runConfig{}, fmt.Errorf("containers must be >= 1, got %d", cfg.Containers)
+	}
+	if cfg.LineBytes < 40 {
+		return runConfig{}, fmt.Errorf("line-bytes must be >= 40, got %d", cfg.LineBytes)
+	}
+	return cfg, nil
+}
+
+// --- pipeline fakes ---------------------------------------------------------
+
+// captureHub satisfies logstore.Hub: it records the sink the store hands it so
+// the harness can drive live ingestion directly.
+type captureHub struct {
+	mu   sync.Mutex
+	sink func(logstream.Record)
+}
+
+func (h *captureHub) Subscribe(_ logstream.ContainerSpec, _ models.LogOptions, sink func(logstream.Record)) func() {
+	h.mu.Lock()
+	h.sink = sink
+	h.mu.Unlock()
+	return func() {
+		h.mu.Lock()
+		h.sink = nil
+		h.mu.Unlock()
+	}
+}
+
+func (h *captureHub) get() func(logstream.Record) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.sink
+}
+
+// emptyProvider satisfies logstore.DockerProvider with a real MultiHostClient
+// that has no hosts, so the store's lifecycle poll lists nothing and never
+// tails — the harness feeds the sink directly.
+type emptyProvider struct{ client *docker.MultiHostClient }
+
+func (p emptyProvider) Docker() *docker.MultiHostClient { return p.client }
+
+// --- metrics ----------------------------------------------------------------
+
+// sample is one point-in-time reading of the store under load.
+type sample struct {
+	TSec              float64 `json:"tSec"`
+	OfferedLines      uint64  `json:"offeredLines"`
+	CommittedLines    int64   `json:"committedLines"`
+	DroppedLines      uint64  `json:"droppedLines"`
+	OfferedRatePerSec float64 `json:"offeredRatePerSec"`
+	CommitRatePerSec  float64 `json:"commitRatePerSec"`
+	DBBytes           int64   `json:"dbBytes"`
+	HeapAllocBytes    uint64  `json:"heapAllocBytes"`
+	HeapInuseBytes    uint64  `json:"heapInuseBytes"`
+	Goroutines        int     `json:"goroutines"`
+}
+
+// queryStats summarizes the concurrent query workload.
+type queryStats struct {
+	Count  int     `json:"count"`
+	Errors int     `json:"errors"`
+	P50Ms  float64 `json:"p50Ms"`
+	P95Ms  float64 `json:"p95Ms"`
+	P99Ms  float64 `json:"p99Ms"`
+	MaxMs  float64 `json:"maxMs"`
+}
+
+// report is the full machine-readable result.
+type report struct {
+	Config           runConfig   `json:"config"`
+	OfferedLines     uint64      `json:"offeredLines"`
+	CommittedLines   int64       `json:"committedLines"`
+	DroppedLines     uint64      `json:"droppedLines"`
+	OfferedRate      float64     `json:"offeredRateLinesPerSec"`
+	CommitRate       float64     `json:"committedRateLinesPerSec"`
+	DropFraction     float64     `json:"dropFraction"`
+	DBBytesFinal     int64       `json:"dbBytesFinal"`
+	DBBytesPeak      int64       `json:"dbBytesPeak"`
+	TotalCapBytes    int64       `json:"totalCapBytes"`
+	HeapAllocPeak    uint64      `json:"heapAllocPeakBytes"`
+	HeapInusePeak    uint64      `json:"heapInusePeakBytes"`
+	HeapAllocFirst   uint64      `json:"heapAllocFirstBytes"`
+	HeapAllocLast    uint64      `json:"heapAllocLastBytes"`
+	GoroutinesPeak   int         `json:"goroutinesPeak"`
+	GoroutinesFirst  int         `json:"goroutinesFirst"`
+	GoroutinesLast   int         `json:"goroutinesLast"`
+	Query            *queryStats `json:"query"`
+	Samples          []sample    `json:"samples"`
+}
+
+// --- run --------------------------------------------------------------------
+
+func run(cfg runConfig) error {
+	tmpDir, err := os.MkdirTemp("", "logstore-stress")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	dbPath := filepath.Join(tmpDir, "logs.db")
+
+	limits := func() config.ResolvedLogStoreConfig {
+		return config.ResolvedLogStoreConfig{
+			Enabled:        true,
+			PerContainerMB: cfg.PerContainerMB,
+			TotalMB:        cfg.TotalMB,
+		}
+	}
+	store, err := logstore.Open(dbPath, limits)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	client, err := docker.NewMultiHostClient(nil)
+	if err != nil {
+		return fmt.Errorf("empty docker client: %w", err)
+	}
+	hub := &captureHub{}
+
+	// storeCtx keeps the store's loops (writeLoop, syncLoop, janitorLoop) alive
+	// for the whole run; cancelling it triggers the final flush.
+	storeCtx, storeCancel := context.WithCancel(context.Background())
+	store.Start(storeCtx, hub, emptyProvider{client: client})
+
+	sink := hub.get()
+	if sink == nil {
+		storeCancel()
+		return fmt.Errorf("store did not subscribe a sink")
+	}
+
+	var offered atomic.Uint64
+	emit := func(rec logstream.Record) {
+		sink(rec)
+		offered.Add(1)
+	}
+
+	// genCtx bounds the ingest + query window.
+	genCtx, genCancel := context.WithTimeout(context.Background(), cfg.Duration)
+	defer genCancel()
+
+	start := time.Now()
+	var (
+		samples   []sample
+		qLatMu    sync.Mutex
+		qLatency  []int64
+		qErrors   atomic.Int64
+		workersWG sync.WaitGroup
+	)
+
+	// Metrics sampler: one reading per second plus a final reading.
+	samplerDone := make(chan struct{})
+	go func() {
+		defer close(samplerDone)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		var last sample
+		haveLast := false
+		record := func() {
+			s := readSample(store, dbPath, start, &offered)
+			if haveLast {
+				dt := s.TSec - last.TSec
+				if dt > 0 {
+					s.OfferedRatePerSec = float64(s.OfferedLines-last.OfferedLines) / dt
+					s.CommitRatePerSec = float64(s.CommittedLines-last.CommittedLines) / dt
+				}
+			}
+			samples = append(samples, s)
+			last, haveLast = s, true
+		}
+		for {
+			select {
+			case <-genCtx.Done():
+				record() // final in-window reading
+				return
+			case <-ticker.C:
+				record()
+			}
+		}
+	}()
+
+	// Query workers: representative reads concurrent with heavy ingestion.
+	for i := 0; i < cfg.QueryWorkers; i++ {
+		workersWG.Add(1)
+		go func(seed int64) {
+			defer workersWG.Done()
+			rng := rand.New(rand.NewSource(seed))
+			for genCtx.Err() == nil {
+				q := pickQuery(rng, cfg.Containers)
+				t0 := time.Now()
+				_, err := store.Query(genCtx, q)
+				d := time.Since(t0)
+				if err != nil {
+					if genCtx.Err() == nil {
+						qErrors.Add(1)
+					}
+					continue
+				}
+				qLatMu.Lock()
+				qLatency = append(qLatency, int64(d))
+				qLatMu.Unlock()
+				// A real history viewer is not a tight loop; this also bounds the
+				// sample count on long runs.
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(int64(i) + 1)
+	}
+
+	// Generators drive the sink until genCtx expires.
+	runGenerators(genCtx, cfg, emit)
+
+	// Ingest window closed: stop query workers and the sampler.
+	genCancel()
+	workersWG.Wait()
+	<-samplerDone
+	ingestElapsed := time.Since(start).Seconds()
+
+	// Drain: cancel the store so writeLoop flushes the last batch, then wait.
+	storeCancel()
+	store.Wait()
+
+	committed, err := store.CountLines(context.Background())
+	if err != nil {
+		return fmt.Errorf("final count: %w", err)
+	}
+
+	rep := buildReport(cfg, samples, offered.Load(), committed, store.Drops(),
+		dbSize(dbPath), ingestElapsed, qLatency, int(qErrors.Load()))
+
+	if err := emitJSON(rep); err != nil {
+		return err
+	}
+	writeHumanSummary(rep)
+	return nil
+}
+
+// readSample takes one instantaneous reading of the store and process.
+func readSample(store *logstore.Store, dbPath string, start time.Time, offered *atomic.Uint64) sample {
+	committed, _ := store.CountLines(context.Background())
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	return sample{
+		TSec:           time.Since(start).Seconds(),
+		OfferedLines:   offered.Load(),
+		CommittedLines: committed,
+		DroppedLines:   store.Drops(),
+		DBBytes:        dbSize(dbPath),
+		HeapAllocBytes: mem.HeapAlloc,
+		HeapInuseBytes: mem.HeapInuse,
+		Goroutines:     runtime.NumGoroutine(),
+	}
+}
+
+// runGenerators drives synthetic records into the sink at the configured rate,
+// or as fast as possible in flood mode, until ctx expires.
+func runGenerators(ctx context.Context, cfg runConfig, emit func(logstream.Record)) {
+	var seq atomic.Uint64
+	next := func() logstream.Record {
+		n := seq.Add(1) - 1
+		return makeRecord(n%uint64(cfg.Containers), n, cfg.LineBytes)
+	}
+
+	if cfg.Flood {
+		// One busy producer per container; the sink drops when the writer falls
+		// behind, so producers never block and we find the commit ceiling.
+		var wg sync.WaitGroup
+		for c := 0; c < cfg.Containers; c++ {
+			wg.Add(1)
+			go func(container int) {
+				defer wg.Done()
+				for ctx.Err() == nil {
+					// seq.Add is globally unique, keeping (ts, stream, raw) unique
+					// across all producers so the store's dedup never fires.
+					emit(makeRecord(uint64(container), seq.Add(1), cfg.LineBytes))
+				}
+			}(c)
+		}
+		wg.Wait()
+		return
+	}
+
+	// Paced mode: emit rate/200 lines every 5ms so the aggregate rate is held
+	// without a per-line sleep.
+	const tickHz = 200
+	interval := time.Second / tickHz
+	perTick := cfg.RateLinesPerS / tickHz
+	if perTick < 1 {
+		perTick = 1
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for i := 0; i < perTick; i++ {
+				emit(next())
+			}
+		}
+	}
+}
+
+// levelBodies are pre-rendered log bodies carrying a level keyword the store's
+// classifier and the query filters both recognize.
+type levelBody struct {
+	level  models.LogLevel
+	stream string
+	body   string
+}
+
+// makeRecord builds one synthetic live record for a container. The timestamp is
+// wall-clock (so bounded-window queries are meaningful) and the sequence number
+// keeps (ts, stream, raw) unique, so the store's insert dedup never
+// under-counts a genuinely new line.
+func makeRecord(container, seq uint64, lineBytes int) logstream.Record {
+	lb := pickLevelBody(seq)
+	ts := time.Now()
+	prefix := ts.UTC().Format(time.RFC3339Nano)
+	// prefix + space + "level=xxxx seq=<n> " + body, padded to lineBytes.
+	head := prefix + " " + string(lb.level) + " seq=" + itoa(seq) + " " + lb.body
+	raw := padTo(head, lineBytes)
+
+	return logstream.Record{
+		Host:          stressHost,
+		ContainerID:   containerID(container),
+		ContainerName: containerName(container),
+		Labels:        map[string]string{"com.docker.compose.project": "stressstack"},
+		Entry: models.LogEntry{
+			Timestamp: ts,
+			Level:     lb.level,
+			Stream:    lb.stream,
+			Raw:       raw,
+		},
+	}
+}
+
+// pickLevelBody returns a level/stream/body for a sequence number with a
+// realistic mix: ~70% info, ~15% warn, ~10% error, ~5% debug. Errors and
+// warnings go to stderr.
+func pickLevelBody(seq uint64) levelBody {
+	switch seq % 20 {
+	case 0, 1:
+		return levelBody{models.LogLevelError, "stderr", "error request failed handler=api status=500"}
+	case 2:
+		return levelBody{models.LogLevelDebug, "stdout", "debug cache lookup key=session hit=false"}
+	case 3, 4, 5:
+		return levelBody{models.LogLevelWarn, "stderr", "warn slow request handled latency=812ms"}
+	default:
+		return levelBody{models.LogLevelInfo, "stdout", "info request handled method=GET path=/api/v1/things"}
+	}
+}
+
+// padTo pads s with a filler suffix so its byte length is at least n.
+func padTo(s string, n int) string {
+	if len(s) >= n {
+		return s
+	}
+	pad := make([]byte, n-len(s))
+	for i := range pad {
+		pad[i] = 'x'
+	}
+	return s + " " + string(pad[1:])
+}
+
+func itoa(n uint64) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func containerID(c uint64) string   { return "gen-" + itoa(c) }
+func containerName(c uint64) string { return "svc-" + itoa(c) }
+
+// pickQuery rotates through representative reads: a recent page, a level
+// filter, a bounded-window substring search, and a bounded-window regex search.
+func pickQuery(rng *rand.Rand, containers int) logstore.LogQuery {
+	name := containerName(uint64(rng.Intn(containers)))
+	base := logstore.LogQuery{Host: stressHost, Container: name}
+	switch rng.Intn(4) {
+	case 0:
+		base.Limit = 500 // recent window
+	case 1:
+		base.Levels = []string{"ERROR"}
+		base.Limit = 200
+	case 2:
+		base.Since = time.Now().Add(-30 * time.Second)
+		base.Search = "request"
+		base.Limit = 200
+	default:
+		base.Since = time.Now().Add(-30 * time.Second)
+		base.Search = "req.*handled"
+		base.Regex = true
+		base.Limit = 200
+	}
+	return base
+}
+
+// --- reporting --------------------------------------------------------------
+
+func buildReport(cfg runConfig, samples []sample, offered uint64, committed int64,
+	drops uint64, dbFinal int64, elapsed float64, qLatency []int64, qErrors int) report {
+
+	rep := report{
+		Config:         cfg,
+		OfferedLines:   offered,
+		CommittedLines: committed,
+		DroppedLines:   drops,
+		DBBytesFinal:   dbFinal,
+		TotalCapBytes:  int64(cfg.TotalMB) * 1024 * 1024,
+		Samples:        samples,
+	}
+	if elapsed > 0 {
+		rep.OfferedRate = float64(offered) / elapsed
+		rep.CommitRate = float64(committed) / elapsed
+	}
+	if offered > 0 {
+		rep.DropFraction = float64(drops) / float64(offered)
+	}
+
+	for i, s := range samples {
+		if s.DBBytes > rep.DBBytesPeak {
+			rep.DBBytesPeak = s.DBBytes
+		}
+		if s.HeapAllocBytes > rep.HeapAllocPeak {
+			rep.HeapAllocPeak = s.HeapAllocBytes
+		}
+		if s.HeapInuseBytes > rep.HeapInusePeak {
+			rep.HeapInusePeak = s.HeapInuseBytes
+		}
+		if s.Goroutines > rep.GoroutinesPeak {
+			rep.GoroutinesPeak = s.Goroutines
+		}
+		if i == 0 {
+			rep.HeapAllocFirst = s.HeapAllocBytes
+			rep.GoroutinesFirst = s.Goroutines
+		}
+		rep.HeapAllocLast = s.HeapAllocBytes
+		rep.GoroutinesLast = s.Goroutines
+	}
+	if dbFinal > rep.DBBytesPeak {
+		rep.DBBytesPeak = dbFinal
+	}
+	if cfg.QueryWorkers > 0 {
+		rep.Query = summarizeQueries(qLatency, qErrors)
+	}
+	return rep
+}
+
+func summarizeQueries(latency []int64, errors int) *queryStats {
+	qs := &queryStats{Count: len(latency), Errors: errors}
+	if len(latency) == 0 {
+		return qs
+	}
+	sort.Slice(latency, func(i, j int) bool { return latency[i] < latency[j] })
+	qs.P50Ms = ms(percentile(latency, 0.50))
+	qs.P95Ms = ms(percentile(latency, 0.95))
+	qs.P99Ms = ms(percentile(latency, 0.99))
+	qs.MaxMs = ms(latency[len(latency)-1])
+	return qs
+}
+
+// percentile returns the p-quantile of a sorted slice (nearest-rank).
+func percentile(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(p * float64(len(sorted)))
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func ms(ns int64) float64 { return float64(ns) / 1e6 }
+
+// dbSize sums the SQLite main file and its WAL/SHM sidecars.
+func dbSize(dbPath string) int64 {
+	var total int64
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if info, err := os.Stat(dbPath + suffix); err == nil {
+			total += info.Size()
+		}
+	}
+	return total
+}
+
+func emitJSON(rep report) error {
+	data, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	if _, err := os.Stdout.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+func writeHumanSummary(rep report) {
+	w := os.Stderr
+	p := func(format string, args ...any) { _, _ = fmt.Fprintf(w, format, args...) }
+
+	p("\n=== logstore-stress: %s ===\n", rep.Config.Scenario)
+	p("containers=%d rate=%s duration=%.0fs line-bytes=%d caps=%d/%dMB queryWorkers=%d\n",
+		rep.Config.Containers, rateLabel(rep.Config), rep.Config.DurationSec,
+		rep.Config.LineBytes, rep.Config.PerContainerMB, rep.Config.TotalMB, rep.Config.QueryWorkers)
+	p("offered=%d committed=%d dropped=%d (%.2f%% dropped)\n",
+		rep.OfferedLines, rep.CommittedLines, rep.DroppedLines, rep.DropFraction*100)
+	p("offered rate=%.0f lines/s   committed rate=%.0f lines/s\n", rep.OfferedRate, rep.CommitRate)
+	p("db size: final=%.1fMB peak=%.1fMB   total cap=%.1fMB\n",
+		mb(rep.DBBytesFinal), mb(rep.DBBytesPeak), mb(rep.TotalCapBytes))
+	p("heap alloc: first=%.1fMB last=%.1fMB peak=%.1fMB\n",
+		mb(int64(rep.HeapAllocFirst)), mb(int64(rep.HeapAllocLast)), mb(int64(rep.HeapAllocPeak)))
+	p("goroutines: first=%d last=%d peak=%d\n", rep.GoroutinesFirst, rep.GoroutinesLast, rep.GoroutinesPeak)
+	if rep.Query != nil {
+		p("query latency: n=%d errors=%d  p50=%.2fms p95=%.2fms p99=%.2fms max=%.2fms\n",
+			rep.Query.Count, rep.Query.Errors, rep.Query.P50Ms, rep.Query.P95Ms, rep.Query.P99Ms, rep.Query.MaxMs)
+	}
+	p("samples=%d (1/s)\n", len(rep.Samples))
+}
+
+func rateLabel(cfg runConfig) string {
+	if cfg.Flood {
+		return "flood"
+	}
+	return itoa(uint64(cfg.RateLinesPerS)) + "/s"
+}
+
+func mb(bytes int64) float64 { return float64(bytes) / (1024 * 1024) }

--- a/server/cmd/logstore-stress/main.go
+++ b/server/cmd/logstore-stress/main.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -180,11 +181,15 @@ func (p emptyProvider) Docker() *docker.MultiHostClient { return p.client }
 
 // --- metrics ----------------------------------------------------------------
 
-// sample is one point-in-time reading of the store under load.
+// sample is one point-in-time reading of the store under load. CommittedLines
+// is cumulative (monotonic) so the derived commit rate is true ingestion, never
+// negative when retention evicts; RetainedLines is the live row count, which
+// falls as the janitor sweeps. RetainedLines is -1 when its query failed.
 type sample struct {
 	TSec              float64 `json:"tSec"`
 	OfferedLines      uint64  `json:"offeredLines"`
 	CommittedLines    int64   `json:"committedLines"`
+	RetainedLines     int64   `json:"retainedLines"`
 	DroppedLines      uint64  `json:"droppedLines"`
 	OfferedRatePerSec float64 `json:"offeredRatePerSec"`
 	CommitRatePerSec  float64 `json:"commitRatePerSec"`
@@ -209,6 +214,8 @@ type report struct {
 	Config           runConfig   `json:"config"`
 	OfferedLines     uint64      `json:"offeredLines"`
 	CommittedLines   int64       `json:"committedLines"`
+	RetainedLines    int64       `json:"retainedLines"`
+	SampleErrors     int         `json:"sampleErrors"`
 	DroppedLines     uint64      `json:"droppedLines"`
 	OfferedRate      float64     `json:"offeredRateLinesPerSec"`
 	CommitRate       float64     `json:"committedRateLinesPerSec"`
@@ -279,11 +286,12 @@ func run(cfg runConfig) error {
 
 	start := time.Now()
 	var (
-		samples   []sample
-		qLatMu    sync.Mutex
-		qLatency  []int64
-		qErrors   atomic.Int64
-		workersWG sync.WaitGroup
+		samples      []sample
+		sampleErrors int
+		qLatMu       sync.Mutex
+		qLatency     []int64
+		qErrors      atomic.Int64
+		workersWG    sync.WaitGroup
 	)
 
 	// Metrics sampler: one reading per second plus a final reading.
@@ -295,7 +303,10 @@ func run(cfg runConfig) error {
 		var last sample
 		haveLast := false
 		record := func() {
-			s := readSample(store, dbPath, start, &offered)
+			s, err := readSample(store, dbPath, start, &offered)
+			if err != nil {
+				sampleErrors++
+			}
 			if haveLast {
 				dt := s.TSec - last.TSec
 				if dt > 0 {
@@ -357,13 +368,14 @@ func run(cfg runConfig) error {
 	storeCancel()
 	store.Wait()
 
-	committed, err := store.CountLines(context.Background())
+	committed := store.Committed()
+	retained, err := store.CountLines(context.Background())
 	if err != nil {
-		return fmt.Errorf("final count: %w", err)
+		return fmt.Errorf("final retained count: %w", err)
 	}
 
-	rep := buildReport(cfg, samples, offered.Load(), committed, store.Drops(),
-		dbSize(dbPath), ingestElapsed, qLatency, int(qErrors.Load()))
+	rep := buildReport(cfg, samples, offered.Load(), committed, retained, sampleErrors,
+		store.Drops(), dbSize(dbPath), ingestElapsed, qLatency, int(qErrors.Load()))
 
 	if err := emitJSON(rep); err != nil {
 		return err
@@ -372,21 +384,27 @@ func run(cfg runConfig) error {
 	return nil
 }
 
-// readSample takes one instantaneous reading of the store and process.
-func readSample(store *logstore.Store, dbPath string, start time.Time, offered *atomic.Uint64) sample {
-	committed, _ := store.CountLines(context.Background())
+// readSample takes one instantaneous reading of the store and process. The
+// error is non-nil when the retained-row query failed, in which case
+// RetainedLines is -1 so a transient failure reads as invalid, not as zero.
+func readSample(store *logstore.Store, dbPath string, start time.Time, offered *atomic.Uint64) (sample, error) {
+	retained, err := store.CountLines(context.Background())
+	if err != nil {
+		retained = -1
+	}
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	return sample{
 		TSec:           time.Since(start).Seconds(),
 		OfferedLines:   offered.Load(),
-		CommittedLines: committed,
+		CommittedLines: store.Committed(),
+		RetainedLines:  retained,
 		DroppedLines:   store.Drops(),
 		DBBytes:        dbSize(dbPath),
 		HeapAllocBytes: mem.HeapAlloc,
 		HeapInuseBytes: mem.HeapInuse,
 		Goroutines:     runtime.NumGoroutine(),
-	}
+	}, err
 }
 
 // runGenerators drives synthetic records into the sink at the configured rate,
@@ -417,22 +435,22 @@ func runGenerators(ctx context.Context, cfg runConfig, emit func(logstream.Recor
 		return
 	}
 
-	// Paced mode: emit rate/200 lines every 5ms so the aggregate rate is held
-	// without a per-line sleep.
+	// Paced mode: hold the configured aggregate rate on a 200Hz tick. The count
+	// per tick comes from a cumulative target (rate*tick/tickHz), not rate/tickHz,
+	// so the integer remainder carries across ticks instead of being truncated —
+	// 1001/s stays 1001, and rates below tickHz stay exact rather than snapping up.
 	const tickHz = 200
-	interval := time.Second / tickHz
-	perTick := cfg.RateLinesPerS / tickHz
-	if perTick < 1 {
-		perTick = 1
-	}
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(time.Second / tickHz)
 	defer ticker.Stop()
+	var tick, emitted int64
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			for i := 0; i < perTick; i++ {
+			tick++
+			target := int64(cfg.RateLinesPerS) * tick / tickHz
+			for ; emitted < target; emitted++ {
 				emit(next())
 			}
 		}
@@ -544,13 +562,15 @@ func pickQuery(rng *rand.Rand, containers int) logstore.LogQuery {
 
 // --- reporting --------------------------------------------------------------
 
-func buildReport(cfg runConfig, samples []sample, offered uint64, committed int64,
-	drops uint64, dbFinal int64, elapsed float64, qLatency []int64, qErrors int) report {
+func buildReport(cfg runConfig, samples []sample, offered uint64, committed, retained int64,
+	sampleErrors int, drops uint64, dbFinal int64, elapsed float64, qLatency []int64, qErrors int) report {
 
 	rep := report{
 		Config:         cfg,
 		OfferedLines:   offered,
 		CommittedLines: committed,
+		RetainedLines:  retained,
+		SampleErrors:   sampleErrors,
 		DroppedLines:   drops,
 		DBBytesFinal:   dbFinal,
 		TotalCapBytes:  int64(cfg.TotalMB) * 1024 * 1024,
@@ -606,12 +626,16 @@ func summarizeQueries(latency []int64, errors int) *queryStats {
 	return qs
 }
 
-// percentile returns the p-quantile of a sorted slice (nearest-rank).
+// percentile returns the p-quantile of a sorted slice by the nearest-rank
+// method: rank ceil(p*N) taken 1-based, so the slice index is ceil(p*N)-1.
 func percentile(sorted []int64, p float64) int64 {
 	if len(sorted) == 0 {
 		return 0
 	}
-	idx := int(p * float64(len(sorted)))
+	idx := int(math.Ceil(p*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
 	if idx >= len(sorted) {
 		idx = len(sorted) - 1
 	}
@@ -650,8 +674,11 @@ func writeHumanSummary(rep report) {
 	p("containers=%d rate=%s duration=%.0fs line-bytes=%d caps=%d/%dMB queryWorkers=%d\n",
 		rep.Config.Containers, rateLabel(rep.Config), rep.Config.DurationSec,
 		rep.Config.LineBytes, rep.Config.PerContainerMB, rep.Config.TotalMB, rep.Config.QueryWorkers)
-	p("offered=%d committed=%d dropped=%d (%.2f%% dropped)\n",
-		rep.OfferedLines, rep.CommittedLines, rep.DroppedLines, rep.DropFraction*100)
+	p("offered=%d committed=%d retained=%d dropped=%d (%.2f%% dropped)\n",
+		rep.OfferedLines, rep.CommittedLines, rep.RetainedLines, rep.DroppedLines, rep.DropFraction*100)
+	if rep.SampleErrors > 0 {
+		p("WARNING: %d retained-count sample(s) failed\n", rep.SampleErrors)
+	}
 	p("offered rate=%.0f lines/s   committed rate=%.0f lines/s\n", rep.OfferedRate, rep.CommitRate)
 	p("db size: final=%.1fMB peak=%.1fMB   total cap=%.1fMB\n",
 		mb(rep.DBBytesFinal), mb(rep.DBBytesPeak), mb(rep.TotalCapBytes))

--- a/server/internal/logstore/ingest.go
+++ b/server/internal/logstore/ingest.go
@@ -85,6 +85,11 @@ func (s *Store) writeLoop() {
 	ticker := time.NewTicker(batchInterval)
 	defer ticker.Stop()
 
+	// batchesSinceRetain counts committed batches since the last retention sweep.
+	// Retention runs on this goroutine so it never competes with ingestion for
+	// SQLite's single write lock; see janitorLoop.
+	batchesSinceRetain := 0
+
 	flush := func() {
 		if len(batch) == 0 {
 			return
@@ -98,6 +103,23 @@ func (s *Store) writeLoop() {
 			s.markBatchGaps(batch)
 		}
 		batch = batch[:0]
+		batchesSinceRetain++
+	}
+
+	retain := func() {
+		batchesSinceRetain = 0
+		before := s.evictions.Load()
+		if err := s.retain(context.Background()); err != nil {
+			log.Printf("logstore: retention sweep failed: %v", err)
+		}
+		// Fold the WAL only when the sweep actually evicted: retention's deletes
+		// are the bulk of the WAL churn, so truncating right after them keeps the
+		// file near its cap. A store under its cap evicts nothing and must not pay
+		// for a checkpoint here — that is what preserves the flood throughput
+		// ceiling. SQLite's automatic checkpoint keeps the WAL bounded otherwise.
+		if s.evictions.Load() != before {
+			s.checkpoint()
+		}
 	}
 
 	for {
@@ -113,8 +135,30 @@ func (s *Store) writeLoop() {
 			}
 		case <-ticker.C:
 			flush()
+		case <-s.retainCh:
+			flush()
+			retain()
+		}
+		// Cap the file's high-water mark under sustained load: the janitorInterval
+		// signal alone is far too coarse when batches flush many times a second.
+		if batchesSinceRetain >= retainEveryBatches {
+			retain()
 		}
 	}
+}
+
+// checkpoint folds the write-ahead log back into the main database and truncates
+// the WAL file. It runs on the writer goroutine right after an eviction, so it
+// never races the store's own writes. TRUNCATE (rather than PASSIVE) is what
+// actually shrinks the file on disk; it briefly blocks new readers while it
+// truncates, but queries are short enough that the pause is not observable, and
+// bounding the file is worth it. A checkpoint that cannot complete because a
+// reader is mid-query simply truncates less this pass and catches up on the
+// next, so its error is not worth logging.
+func (s *Store) checkpoint() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _ = s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
 }
 
 // markBatchGaps records a dropped-line gap for every generation in a batch the

--- a/server/internal/logstore/ingest.go
+++ b/server/internal/logstore/ingest.go
@@ -207,6 +207,7 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 	aggs := make(map[int64]*agg)
 	fresh := make(map[genKey]int64) // ids this transaction discovered
 	nowMS := time.Now().UnixMilli()
+	insertedCount := int64(0)
 
 	for _, msg := range batch {
 		ref, ok := refs[msg.key]
@@ -238,6 +239,7 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 		if !inserted {
 			continue
 		}
+		insertedCount++
 
 		a := aggs[ref]
 		if a == nil {
@@ -269,6 +271,7 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 	if err := tx.Commit(); err != nil {
 		return err
 	}
+	s.committed.Add(insertedCount)
 
 	// The ids are real only now.
 	for key, ref := range fresh {

--- a/server/internal/logstore/janitor.go
+++ b/server/internal/logstore/janitor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"log"
 	"strings"
 	"time"
 )
@@ -29,9 +28,14 @@ type logicalGroup struct {
 	bytes int64
 }
 
-// janitorLoop enforces the retention caps periodically. The database file is
-// never VACUUMed: SQLite reuses freed pages, so the file plateaus at its
-// high-water mark instead of shrinking, which avoids a long exclusive lock.
+// janitorLoop schedules retention periodically. It performs no database writes
+// itself: SQLite is single-writer, and a separate eviction transaction competes
+// with the writeLoop for the one write lock and dies with SQLITE_BUSY under a
+// firehose. So the janitor only signals the writer, which runs retention inline
+// between its batches (see writeLoop). The signal is coalescing: a sweep already
+// pending is enough. The database file is never VACUUMed: SQLite reuses freed
+// pages, so the file plateaus at its high-water mark instead of shrinking, which
+// avoids a long exclusive lock.
 func (s *Store) janitorLoop(ctx context.Context) {
 	ticker := time.NewTicker(janitorInterval)
 	defer ticker.Stop()
@@ -41,8 +45,9 @@ func (s *Store) janitorLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := s.retain(ctx); err != nil && ctx.Err() == nil {
-				log.Printf("logstore: retention sweep failed: %v", err)
+			select {
+			case s.retainCh <- struct{}{}:
+			default: // a sweep is already pending
 			}
 		}
 	}
@@ -233,6 +238,12 @@ func (s *Store) evictOldest(ctx context.Context, refs []int64, excess int64) (in
 
 	if err := tx.Commit(); err != nil {
 		return 0, err
+	}
+	if freed > 0 {
+		// Signals the writer to fold the WAL: these deletes are the store's
+		// heaviest WAL churn, so the file only stays near its cap if it is
+		// truncated after them.
+		s.evictions.Add(1)
 	}
 	return freed, nil
 }

--- a/server/internal/logstore/retention_concurrent_test.go
+++ b/server/internal/logstore/retention_concurrent_test.go
@@ -48,14 +48,15 @@ func TestRetentionHoldsCapUnderConcurrentIngestion(t *testing.T) {
 	hub := &fakeHub{}
 	store.start(ctx, hub, func() Engine { return newFakeEngine() })
 
-	// Flood eight containers with unique lines for a couple of seconds — long
-	// enough that the pre-fix store commits tens of megabytes with nothing
-	// evicted, while the fixed store sweeps continuously and plateaus near the
-	// 1 MB cap.
+	// Flood eight containers with unique lines until the writer has committed far
+	// more than the ~1 MB cap can hold (~4.5k lines at this size), so retention is
+	// forced to evict no matter how fast this worker is. Driving to a commit
+	// target rather than a fixed wall-clock duration is what keeps the eviction
+	// assertion below meaningful on a slow CI machine.
 	const (
-		containers = 8
-		lineBytes  = 200
-		floodFor   = 2 * time.Second
+		containers      = 8
+		lineBytes       = 200
+		targetCommitted = 12_000
 	)
 	var (
 		seq  atomic.Uint64
@@ -77,7 +78,10 @@ func TestRetentionHoldsCapUnderConcurrentIngestion(t *testing.T) {
 			}
 		}()
 	}
-	time.Sleep(floodFor)
+	deadline := time.Now().Add(90 * time.Second)
+	for store.Committed() < targetCommitted && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
 	close(stop)
 	wg.Wait()
 
@@ -98,11 +102,19 @@ func TestRetentionHoldsCapUnderConcurrentIngestion(t *testing.T) {
 			size, maxSize)
 	}
 
-	// The store must actually have persisted and evicted, not simply stalled.
-	if lines, err := store.CountLines(context.Background()); err != nil {
+	// Retention must actually have evicted: committing well past the cap is only
+	// possible if the janitor swept. This is the real regression guard — on the
+	// pre-fix code the sweep loses the write lock (SQLITE_BUSY) and evicts
+	// nothing, rather than the test passing because a slow worker never filled up.
+	if store.evictions.Load() == 0 {
+		t.Fatal("retention never evicted; the cap-holding path was not exercised")
+	}
+	retained, err := store.CountLines(context.Background())
+	if err != nil {
 		t.Fatalf("CountLines: %v", err)
-	} else if lines == 0 {
-		t.Fatal("no lines were stored; the flood never reached the writer")
+	}
+	if committed := store.Committed(); committed <= retained {
+		t.Fatalf("committed=%d retained=%d: retention did not evict any lines", committed, retained)
 	}
 
 	if out := logBuf.String(); strings.Contains(out, "retention sweep failed") ||

--- a/server/internal/logstore/retention_concurrent_test.go
+++ b/server/internal/logstore/retention_concurrent_test.go
@@ -1,0 +1,146 @@
+package logstore
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/logstream"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// TestRetentionHoldsCapUnderConcurrentIngestion is the BUG 1 guard: with
+// retention on and a firehose of live lines, the database file must stay bounded
+// near its cap.
+//
+// It reproduces the original defect, in which the janitor ran retention in its
+// own write transaction that competed with the writeLoop for SQLite's single
+// write lock. Under sustained ingestion the writer held the lock nearly
+// continuously, the eviction transaction lost it (SQLITE_BUSY), no lines were
+// ever evicted, and the file grew without bound. The fix routes every write —
+// ingestion and eviction — through the one writer goroutine, so they can never
+// contend. Against the pre-fix code this test fails: nothing is evicted and the
+// file blows far past the assertion.
+func TestRetentionHoldsCapUnderConcurrentIngestion(t *testing.T) {
+	limits := func() config.ResolvedLogStoreConfig {
+		return config.ResolvedLogStoreConfig{Enabled: true, PerContainerMB: 1, TotalMB: 1}
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "logs.db"), limits)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	// Capture the store's own log so the test can assert retention never failed.
+	var logBuf bytes.Buffer
+	prevOut := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(prevOut) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	hub := &fakeHub{}
+	store.start(ctx, hub, func() Engine { return newFakeEngine() })
+
+	// Flood eight containers with unique lines for a couple of seconds — long
+	// enough that the pre-fix store commits tens of megabytes with nothing
+	// evicted, while the fixed store sweeps continuously and plateaus near the
+	// 1 MB cap.
+	const (
+		containers = 8
+		lineBytes  = 200
+		floodFor   = 2 * time.Second
+	)
+	var (
+		seq  atomic.Uint64
+		wg   sync.WaitGroup
+		stop = make(chan struct{})
+	)
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					n := seq.Add(1)
+					hub.emit(floodRecord(n%containers, n, lineBytes))
+				}
+			}
+		}()
+	}
+	time.Sleep(floodFor)
+	close(stop)
+	wg.Wait()
+
+	// Let the writer drain the queue and run a final sweep.
+	cancel()
+	store.Wait()
+
+	size, err := store.DBSize()
+	if err != nil {
+		t.Fatalf("DBSize: %v", err)
+	}
+	// The store held ~1 MB of live data; the file (plus a small ramp overshoot
+	// and its WAL) must stay well under this. Without the fix it reaches tens of
+	// megabytes.
+	const maxSize = 8 * bytesPerMB
+	if size > maxSize {
+		t.Fatalf("database grew to %d bytes under sustained ingestion; retention did not hold the cap (want <= %d)",
+			size, maxSize)
+	}
+
+	// The store must actually have persisted and evicted, not simply stalled.
+	if lines, err := store.CountLines(context.Background()); err != nil {
+		t.Fatalf("CountLines: %v", err)
+	} else if lines == 0 {
+		t.Fatal("no lines were stored; the flood never reached the writer")
+	}
+
+	if out := logBuf.String(); strings.Contains(out, "retention sweep failed") ||
+		strings.Contains(out, "database is locked") {
+		t.Fatalf("retention logged a failure under load:\n%s", out)
+	}
+}
+
+// floodRecord builds one synthetic live record with a unique (ts, stream, raw)
+// so the writer's dedup never collapses distinct lines.
+func floodRecord(container, seq uint64, lineBytes int) logstream.Record {
+	name := "svc-" + itoa(container)
+	ts := time.Now().Add(time.Duration(seq)) // strictly increasing, unique
+	raw := ts.UTC().Format(time.RFC3339Nano) + " INFO seq=" + itoa(seq) + " request handled " +
+		strings.Repeat("x", lineBytes)
+	return logstream.Record{
+		Host:          "stress",
+		ContainerID:   "gen-" + itoa(container),
+		ContainerName: name,
+		Labels:        map[string]string{"com.docker.compose.project": "stressstack"},
+		Entry: models.LogEntry{
+			Timestamp: ts,
+			Stream:    "stdout",
+			Raw:       raw,
+		},
+	}
+}
+
+func itoa(n uint64) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -93,6 +93,10 @@ type Store struct {
 	// checkpoints the WAL only when this advances, so a store that is under its
 	// cap (nothing to evict) never pays for a checkpoint on its hot path.
 	evictions atomic.Uint64
+	// committed counts log lines successfully inserted, cumulatively. Unlike the
+	// live row count it never decreases when retention evicts, so measurement can
+	// report true ingestion throughput. Maintained only for the stress harness.
+	committed atomic.Int64
 
 	// mu guards resume, gaps, and invalidated, all read by goroutines other
 	// than the one that writes them.

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -38,8 +38,18 @@ const (
 	// listTimeout bounds one container listing; an unreachable host must not
 	// stall the lifecycle loop.
 	listTimeout = 15 * time.Second
-	// janitorInterval is the retention sweep cadence.
+	// janitorInterval is the retention sweep cadence: the scheduler signals the
+	// writer this often so retention still runs when ingestion is idle.
 	janitorInterval = time.Minute
+	// retainEveryBatches bounds how many committed batches accumulate between
+	// writer-driven retention sweeps. Under a firehose the janitorInterval tick
+	// is far too coarse to keep the file near its cap, so the writer also sweeps
+	// every this many batches; this is what caps the file's high-water mark.
+	retainEveryBatches = 5
+	// maxDBConns bounds the connection pool. WAL mode serves concurrent readers,
+	// so a small warm pool lets queries run in parallel with the writer without
+	// churning connections; the exact ceiling is not load-bearing.
+	maxDBConns = 8
 	// dropLogEvery throttles the "sink fell behind" warning.
 	dropLogEvery = 1000
 )
@@ -73,7 +83,16 @@ type Store struct {
 	limits Limits
 
 	ingestCh chan ingestMsg
+	// retainCh signals the writer to run a retention sweep between batches. It is
+	// coalescing (buffered one, non-blocking send): all writes go through the
+	// single writer goroutine, so eviction and ingestion never hold two competing
+	// write transactions.
+	retainCh chan struct{}
 	drops    atomic.Uint64
+	// evictions counts retention sweeps that actually freed bytes. The writer
+	// checkpoints the WAL only when this advances, so a store that is under its
+	// cap (nothing to evict) never pays for a checkpoint on its hot path.
+	evictions atomic.Uint64
 
 	// mu guards resume, gaps, and invalidated, all read by goroutines other
 	// than the one that writes them.
@@ -150,6 +169,14 @@ func Open(path string, limits Limits) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open log store: %w", err)
 	}
+	// The default pool keeps only two idle connections, so a burst of concurrent
+	// queries alongside the writer forces connections to be closed and reopened
+	// constantly, and every reopen re-runs the DSN pragmas — pure overhead that
+	// shows up as query-latency tails. WAL mode allows many concurrent readers,
+	// so hold a small warm pool open instead of churning it.
+	db.SetMaxOpenConns(maxDBConns)
+	db.SetMaxIdleConns(maxDBConns)
+	db.SetConnMaxIdleTime(0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -167,6 +194,7 @@ func Open(path string, limits Limits) (*Store, error) {
 		path:        path,
 		limits:      limits,
 		ingestCh:    make(chan ingestMsg, ingestBuffer),
+		retainCh:    make(chan struct{}, 1),
 		resume:      make(map[genKey]resumePoint),
 		gaps:        make(map[genKey]int64),
 		invalidated: make(map[genKey]struct{}),

--- a/server/internal/logstore/stress.go
+++ b/server/internal/logstore/stress.go
@@ -16,8 +16,15 @@ func (s *Store) Drops() uint64 {
 	return s.drops.Load()
 }
 
-// CountLines reports how many log lines are currently committed to the
-// database. Stress/measurement use only.
+// Committed reports the cumulative number of log lines the writer has inserted.
+// It never decreases when retention evicts, so it measures true ingestion,
+// whereas CountLines reports only what currently survives. Stress use only.
+func (s *Store) Committed() int64 {
+	return s.committed.Load()
+}
+
+// CountLines reports how many log lines are currently retained in the database
+// (i.e. after retention eviction). Stress/measurement use only.
 func (s *Store) CountLines(ctx context.Context) (int64, error) {
 	var n int64
 	err := s.db.QueryRowContext(ctx, "SELECT count(*) FROM log_lines").Scan(&n)

--- a/server/internal/logstore/stress.go
+++ b/server/internal/logstore/stress.go
@@ -1,0 +1,25 @@
+package logstore
+
+import "context"
+
+// This file exposes a tiny, read-only measurement surface consumed ONLY by the
+// out-of-tree stress harness (server/cmd/logstore-stress). It adds no behavior
+// to the store and changes no write path: it just reads counters the pipeline
+// already maintains. It exists because those counters (s.drops) and the row
+// table (s.db) are unexported, and the harness must observe the REAL store, not
+// a copy. Do not use these methods in production code.
+
+// Drops reports how many live records the ingest buffer has discarded because
+// the writer fell behind — the store's backpressure signal. Stress/measurement
+// use only.
+func (s *Store) Drops() uint64 {
+	return s.drops.Load()
+}
+
+// CountLines reports how many log lines are currently committed to the
+// database. Stress/measurement use only.
+func (s *Store) CountLines(ctx context.Context) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx, "SELECT count(*) FROM log_lines").Scan(&n)
+	return n, err
+}

--- a/server/internal/models/logs.go
+++ b/server/internal/models/logs.go
@@ -64,6 +64,16 @@ var timestampFormats = []string{
 	time.RubyDate,
 }
 
+// minTimestampLen and maxTimestampLen bound the rendered length of every layout
+// in timestampFormats (the shortest is "2006/01/02 15:04:05" at 19, the longest
+// is RFC3339Nano with nine fractional digits and a numeric offset at 35). The
+// bounds carry a small margin and are used only to skip time.Parse for
+// candidates that provably cannot match any layout; they never widen what parses.
+const (
+	minTimestampLen = 17
+	maxTimestampLen = 40
+)
+
 var tzOffsetNoColon = regexp.MustCompile(`([+-]\d{2})(\d{2})$`)
 var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 var structuredFieldRegex = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_.-]*)\s*[:=]\s*(.+)$`)
@@ -271,25 +281,17 @@ func ParseTimestamp(logLine string) (time.Time, string) {
 	const maxPrefix = 96
 	searchLimit := min(len(line), maxPrefix)
 
-	var (
-		foundTimestamp time.Time
-		foundMessage   string
-		found          bool
-	)
-
-	for i := 1; i <= searchLimit; i++ {
-		prefix := line[:i]
-		if ts, ok := tryParseTimestampCandidate(prefix); ok {
+	// The timestamp is the longest leading prefix that parses, so scan from the
+	// longest candidate down and stop at the first hit: the result is identical
+	// to keeping the last hit of an ascending scan, but a line whose prefix is a
+	// timestamp (the common case) settles in a handful of iterations instead of
+	// paying a time.Parse attempt at every offset up to the limit.
+	for i := searchLimit; i >= 1; i-- {
+		if ts, ok := tryParseTimestampCandidate(line[:i]); ok {
 			remaining := strings.TrimSpace(line[i:])
 			remaining = strings.TrimLeft(remaining, ")]}> \t")
-			foundTimestamp = ts
-			foundMessage = remaining
-			found = true
+			return ts, remaining
 		}
-	}
-
-	if found {
-		return foundTimestamp, foundMessage
 	}
 
 	return time.Time{}, line
@@ -423,6 +425,15 @@ func tryParseTimestampCandidate(candidate string) (time.Time, bool) {
 
 	sanitized = strings.Trim(sanitized, "[](){}<>")
 	if sanitized == "" {
+		return time.Time{}, false
+	}
+
+	// Every supported layout renders between these lengths (the shortest is a
+	// bare "2006/01/02 15:04:05" at 19; the longest is RFC3339Nano with nine
+	// fractional digits and a numeric offset at 35). A candidate outside that
+	// band cannot match any layout, so skip the time.Parse attempts entirely —
+	// this is what keeps the prefix scan cheap without dropping any real match.
+	if n := len(sanitized); n < minTimestampLen || n > maxTimestampLen {
 		return time.Time{}, false
 	}
 


### PR DESCRIPTION
A stress harness driving the real store surfaced two problems under sustained write load.

**Retention broke under load (disk safety).** SQLite is single-writer; the janitor's separate write transaction lost the lock race against ingestion and died with SQLITE_BUSY, so nothing was evicted and the file grew unbounded — 365MB against a 5MB cap in the stress run. Retention is on by default, so a chatty host could fill its disk. Fixed by routing eviction through the single writer goroutine (it sweeps every few batches, then truncates the WAL only when it actually evicted). retention-churn: **365MB → 13MB peak, zero SQLITE_BUSY**. Regression test included; it fails on the old code.

**Slow history queries under writes.** At 1000 lines/s, query p99 was 1.1s. Root cause wasn't WAL or the pool — it was `ParseTimestamp` re-parsing every stored line with ~1000 `time.Parse` attempts each. Made it scan longest-prefix-first and skip impossible lengths, output-identical. p95 739ms → 111ms, p99 1331ms → 233ms. The live log path benefits too, since it shares that code.

Steady (1000/s) stays drop-free and flat; the ~33k lines/s single-writer ceiling is unchanged. Includes a `logstore-stress` dev harness (separate `cmd`, plus two read-only test-only accessors on Store) — happy to drop it from the PR if you'd rather keep it out of the tree.

https://claude.ai/code/session_01BNuavDshHAEjeUcqMrSjE5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log retention during heavy ingestion to keep database size within configured limits.
  - Reduced the risk of database locking and retention failures under concurrent activity.
  - Improved database cleanup behavior after log eviction.

- **Performance**
  - Faster timestamp recognition reduces unnecessary parsing work when processing log entries.
  - Improved ingestion stability and resource usage during sustained high-volume logging.

- **Tests**
  - Added concurrency coverage validating retention limits while logs are ingested continuously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->