### PR TITLE
chore: bump to Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           touch internal/static/dist/index.html
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
           working-directory: server

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  exclusions:
+    presets:
+      - std-error-handling

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ COPY frontend/ ./
 RUN bun run build
 
 # Stage 2: Build the backend with embedded frontend
-FROM --platform=$BUILDPLATFORM golang:1.23 AS backend-builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS backend-builder
 
 WORKDIR /app
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/AmoabaKelvin/logdeck
 
-go 1.24.3
+go 1.25.0
 
 require (
 	github.com/docker/cli v29.0.2+incompatible


### PR DESCRIPTION
Bumps the go directive and Docker builder image to 1.25.

golangci-lint v1 refuses to lint a 1.25 target, so this also moves the lint step to golangci-lint v2 (action v7). v2 dropped the default error-handling exclusions, so a small `.golangci.yml` restores them — the codebase stays lint-clean without touching unrelated `Close()`/`Setenv()` call sites.

https://claude.ai/code/session_01BWmTRvLf5Q5Cu8m8LMPAjk