### PR TITLE
chore: remove comments that restate the code

### DIFF
--- a/frontend/src/features/containers/components/containers-logs-sheet.tsx
+++ b/frontend/src/features/containers/components/containers-logs-sheet.tsx
@@ -166,7 +166,6 @@ export function ContainersLogsSheet({
 												{container.command}
 											</span>
 										</div>
-										{/* Labels Section */}
 										{container.labels &&
 											Object.keys(container.labels).length > 0 && (
 												<div className="space-y-2 border-t pt-2">
@@ -206,7 +205,6 @@ export function ContainersLogsSheet({
 												</div>
 											)}
 
-										{/* Environment Variables Section */}
 										<div className="space-y-2 border-t pt-2">
 											<Button
 												variant="ghost"

--- a/frontend/src/features/containers/components/environment-variables.tsx
+++ b/frontend/src/features/containers/components/environment-variables.tsx
@@ -202,7 +202,6 @@ export function EnvironmentVariables({
 		if (rawTail.length > 0) {
 			setNewValue(value);
 		}
-		// Move focus to the value field so the user can keep editing if needed.
 		requestAnimationFrame(() => {
 			const input = newValueInputRef.current;
 			if (!input) return;
@@ -405,7 +404,6 @@ export function EnvironmentVariables({
 				)}
 			</div>
 
-			{/* Variables list: one header row, then dense key/value rows */}
 			{(envEntries.length > 0 || showAddNew) && (
 				<div>
 					<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_2rem] items-center gap-2 border-b pb-1.5 text-xs font-medium text-muted-foreground">

--- a/frontend/src/features/containers/components/log-viewer/log-export.ts
+++ b/frontend/src/features/containers/components/log-viewer/log-export.ts
@@ -9,8 +9,6 @@ export function formatLogEntryLine(entry: LogEntry): string {
 	return `[${timestamp}] [${level}] ${message}`;
 }
 
-// Serializes the entries and triggers a browser download named after the
-// container and current time.
 export function downloadLogs(
 	entries: LogEntry[],
 	containerName: string | undefined,

--- a/frontend/src/features/containers/components/log-viewer/log-list.tsx
+++ b/frontend/src/features/containers/components/log-viewer/log-list.tsx
@@ -150,7 +150,6 @@ export function LogList({
 
 	return (
 		<CardContent className="p-0 relative">
-			{/* Selection Action Bar - sticky at top of logs */}
 			<SelectionActionBar
 				selectedCount={selectedIndices.size}
 				onCopy={onCopySelected}

--- a/frontend/src/features/containers/components/log-viewer/log-viewer.test.tsx
+++ b/frontend/src/features/containers/components/log-viewer/log-viewer.test.tsx
@@ -256,7 +256,6 @@ describe("LogViewer shortcut help overlay", () => {
 		});
 		expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
 
-		// Pressing ? again closes it.
 		await act(async () => {
 			fireEvent.keyDown(window, { key: "?", shiftKey: true });
 		});

--- a/frontend/src/features/containers/components/log-viewer/page-toolbar.tsx
+++ b/frontend/src/features/containers/components/log-viewer/page-toolbar.tsx
@@ -105,7 +105,6 @@ export function PageToolbar({
 
 	return (
 		<div className="space-y-3">
-			{/* Row 1: Search + Lines + Stream/Refresh */}
 			<div className="flex items-center gap-2">
 				<CardTitle className="text-base shrink-0">
 					Logs
@@ -317,7 +316,6 @@ export function PageToolbar({
 					<kbd className="font-mono">?</kbd> help
 				</button>
 			</p>
-			{/* Row 2: Options bar */}
 			<div className="flex flex-wrap items-center gap-2">
 				{!isHistory && searchText && (
 					<Select

--- a/frontend/src/features/containers/components/log-viewer/sheet-toolbar.tsx
+++ b/frontend/src/features/containers/components/log-viewer/sheet-toolbar.tsx
@@ -85,9 +85,7 @@ export function SheetToolbar({
 
 	return (
 		<div className="space-y-2">
-			{/* Row 1: Search + Stream controls */}
 			<div className="flex items-center gap-1.5">
-				{/* Search input with inset regex toggle */}
 				<div className="relative flex-1 min-w-[120px]">
 					<SearchIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
 					<Input
@@ -117,7 +115,6 @@ export function SheetToolbar({
 					</button>
 				</div>
 
-				{/* Controls: log level, time range, stream, auto-scroll, overflow */}
 				<div className="flex items-center gap-1 shrink-0">
 					{isReconnecting && (
 						<span className="shrink-0 text-xs text-muted-foreground animate-pulse">
@@ -225,7 +222,6 @@ export function SheetToolbar({
 						</TooltipContent>
 					</Tooltip>
 
-					{/* Overflow menu: view options + download */}
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
 							<Button
@@ -294,7 +290,6 @@ export function SheetToolbar({
 				</div>
 			</div>
 
-			{/* Conditional row: search match navigation + pinned navigation */}
 			{((showMatchNav && searchMatches.length > 0) || showPinNav) && (
 				<div className="flex items-center gap-3">
 					{showMatchNav && (

--- a/frontend/src/features/containers/components/log-viewer/time-range-control.tsx
+++ b/frontend/src/features/containers/components/log-viewer/time-range-control.tsx
@@ -34,7 +34,6 @@ interface TimeRangeControlProps {
 	disabled?: boolean;
 }
 
-// Combine a calendar day with an "HH:mm" time-of-day into an ISO timestamp.
 function combineDateAndTime(day: Date, time: string): string {
 	const [hours = 0, minutes = 0] = time.split(":").map(Number);
 	const date = new Date(day);

--- a/frontend/src/features/containers/components/log-viewer/use-log-search.tsx
+++ b/frontend/src/features/containers/components/log-viewer/use-log-search.tsx
@@ -22,7 +22,6 @@ export function parseSearch(
 	}
 }
 
-// Find all matching log indices for search navigation
 export function computeSearchMatches(
 	entries: LogEntry[],
 	searchText: string,

--- a/frontend/src/features/containers/components/terminal.tsx
+++ b/frontend/src/features/containers/components/terminal.tsx
@@ -192,7 +192,6 @@ export function Terminal({ containerId, host }: TerminalProps) {
 			xtermRef.current = term;
 			fitAddonRef.current = fitAddon;
 		} else {
-			// Clear existing content for reconnection
 			term.clear();
 		}
 

--- a/frontend/src/features/containers/hooks/use-container-stats.ts
+++ b/frontend/src/features/containers/hooks/use-container-stats.ts
@@ -16,7 +16,6 @@ export function useContainerStats() {
 		staleTime: 4000,
 	});
 
-	// Convert array to map for O(1) lookup by container ID
 	const statsMap = useMemo<ContainerStatsMap>(() => {
 		if (!query.data?.stats) return {};
 

--- a/frontend/src/features/containers/hooks/use-document-visible.ts
+++ b/frontend/src/features/containers/hooks/use-document-visible.ts
@@ -5,9 +5,6 @@ function subscribe(onStoreChange: () => void) {
 	return () => document.removeEventListener("visibilitychange", onStoreChange);
 }
 
-/**
- * Tracks whether the document is currently visible (tab in the foreground).
- */
 export function useDocumentVisible(): boolean {
 	return useSyncExternalStore(
 		subscribe,

--- a/frontend/src/features/containers/hooks/use-stats-history.ts
+++ b/frontend/src/features/containers/hooks/use-stats-history.ts
@@ -36,10 +36,6 @@ export function appendSamples(
 let containerHistory: StatsHistoryMap = {};
 let lastContainerStats: ContainerStats[] | undefined;
 
-/**
- * In-memory ring buffer of recent stats per container, fed from the stats
- * query data.
- */
 export function useContainerStatsHistory(
 	stats: ContainerStats[] | undefined,
 ): StatsHistoryMap {

--- a/frontend/src/lib/json-format.ts
+++ b/frontend/src/lib/json-format.ts
@@ -46,9 +46,7 @@ export function formatJson(text: string): {
 			setCachedValue(text, result);
 			return result;
 		}
-	} catch {
-		// fall through to non-JSON result
-	}
+	} catch {}
 
 	const result = { formatted: text, isJson: false };
 	setCachedValue(text, result);

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,9 +5,6 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
-/**
- * Escapes special regex metacharacters in a string for safe use in RegExp
- */
 export function escapeRegExp(string: string): string {
 	return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/frontend/src/routes/containers/$containerId/logs.tsx
+++ b/frontend/src/routes/containers/$containerId/logs.tsx
@@ -73,7 +73,6 @@ function ContainerLogsPage() {
 				return true;
 			}
 		}
-		// Fallback: check if it matches the ID (full or short)
 		return c.id === containerIdentifier || c.id.startsWith(containerIdentifier);
 	});
 
@@ -102,7 +101,6 @@ function ContainerLogsPage() {
 		<div className="min-h-screen bg-background">
 			<div className="container mx-auto px-4 py-6">
 				<div className="space-y-6">
-					{/* Header */}
 					<div className="flex items-center gap-4">
 						<Tooltip>
 							<TooltipTrigger asChild>
@@ -137,7 +135,6 @@ function ContainerLogsPage() {
 						<ThemeToggle />
 					</div>
 
-					{/* Container Info Card */}
 					{container && (
 						<Card>
 							<CardHeader>
@@ -329,7 +326,6 @@ function ContainerLogsPage() {
 						</Card>
 					)}
 
-					{/* Logs Card */}
 					<LogViewer
 						ref={logViewerRef}
 						variant="page"

--- a/frontend/src/routes/stacks/$project/logs.tsx
+++ b/frontend/src/routes/stacks/$project/logs.tsx
@@ -76,7 +76,6 @@ function StackLogsPage() {
 		<div className="min-h-screen bg-background">
 			<div className="container mx-auto px-4 py-6">
 				<div className="space-y-6">
-					{/* Header */}
 					<div className="flex items-center gap-4">
 						<Tooltip>
 							<TooltipTrigger asChild>
@@ -104,13 +103,11 @@ function StackLogsPage() {
 						<ThemeToggle />
 					</div>
 
-					{/* Stack Members */}
 					<StackMembersCard
 						members={members}
 						isReadOnly={containersData?.readOnly ?? false}
 					/>
 
-					{/* Aggregated Logs Card */}
 					<LogViewer
 						variant="page"
 						containerName={project}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -78,11 +78,9 @@ func main() {
 	// unusable; every consumer must treat that as "no stored logs".
 	logStore := logstore.OpenFromConfig(manager)
 
-	// Register hot-reload callback.
 	manager.OnChange(func(newCfg *config.Config) {
 		registry.UpdateConfig(newCfg)
 
-		// Recreate Docker clients.
 		newDocker, err := docker.NewMultiHostClient(newCfg.DockerHosts)
 		if err != nil {
 			log.Printf("Warning: failed to recreate Docker clients after config change: %v", err)
@@ -100,7 +98,6 @@ func main() {
 			logHub.Reconcile()
 		}
 
-		// Recreate Coolify clients.
 		registry.SwapCoolify(coolify.NewMultiClient(newCfg.CoolifyHosts))
 
 		// Recreate auth service from file config (env-based auth is immutable).

--- a/server/internal/api/alerts_handlers_test.go
+++ b/server/internal/api/alerts_handlers_test.go
@@ -364,7 +364,6 @@ func TestAlertChannelsCRUD(t *testing.T) {
 		t.Errorf("expected update to keep id and disable, got %+v", updated)
 	}
 
-	// Delete.
 	w = doAlertsRequest(t, router, "DELETE", "/api/v1/alerts/channels/"+hook.ID, "")
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 deleting channel, got %d: %s", w.Code, w.Body.String())

--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -63,7 +63,6 @@ func (ar *APIRouter) GetContainers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Flatten the map for easier frontend consumption
 	allContainers := []models.ContainerInfo{}
 	for _, containers := range containersMap {
 		allContainers = append(allContainers, containers...)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -102,7 +102,6 @@ func (ar *APIRouter) Routes() *chi.Mux {
 		})
 	})
 
-	// Serve embedded frontend static files
 	staticFS, err := static.GetFileSystem()
 	if err != nil {
 		log.Printf("Warning: Could not load embedded frontend files: %v", err)

--- a/server/internal/api/settings_handlers.go
+++ b/server/internal/api/settings_handlers.go
@@ -27,7 +27,6 @@ func (ar *APIRouter) GetSettings(w http.ResponseWriter, r *http.Request) {
 	cfg := ar.registry.Config()
 	fc := ar.manager.FileConfigSnapshot()
 
-	// Docker hosts with per-entry source
 	envDockerNames := ar.manager.EnvDockerHostNames()
 	dockerHosts := make([]map[string]any, 0, len(cfg.DockerHosts))
 	for _, h := range cfg.DockerHosts {
@@ -42,7 +41,6 @@ func (ar *APIRouter) GetSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Coolify hosts with per-entry source (mask tokens)
 	envCoolifyNames := ar.manager.EnvCoolifyHostNames()
 	coolifyHosts := make([]map[string]any, 0, len(cfg.CoolifyHosts))
 	for _, ch := range cfg.CoolifyHosts {
@@ -58,7 +56,6 @@ func (ar *APIRouter) GetSettings(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Auth
 	authResp := map[string]any{
 		"source":  sources.Auth,
 		"enabled": false,

--- a/server/internal/config/alerts_test.go
+++ b/server/internal/config/alerts_test.go
@@ -16,7 +16,6 @@ func TestMigrateLegacyWebhookURL(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	t.Setenv("CONFIG_PATH", path)
 
-	// Write a legacy config file directly.
 	legacy := FileConfig{Alerts: &AlertsConfig{
 		WebhookURL: "https://example.com/hook",
 		Rules:      []AlertRule{{ID: "r1", Name: "boom", Enabled: true, Type: "log", MinLevel: "ERROR", Threshold: 1, CreatedAt: "2026-07-11T00:00:00Z"}},

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -35,7 +35,6 @@ func NewConfig() *Config {
 
 	coolifyHosts := parseCoolifyHostConfigs()
 
-	// Warn if COOLIFY_CONFIGS references host names not in DOCKER_HOSTS
 	if len(coolifyHosts) > 0 {
 		hostSet := make(map[string]bool, len(dockerHosts))
 		for _, dh := range dockerHosts {

--- a/server/internal/config/manager.go
+++ b/server/internal/config/manager.go
@@ -64,12 +64,12 @@ type Manager struct {
 	mu          sync.RWMutex
 	filePath    string
 	envSnapshot EnvSnapshot
-	envConfig   *Config         // config derived purely from env vars
-	fileConfig  FileConfig      // config from file
-	merged      *Config         // final merged config
-	sources     ConfigSources   // per-category source tracking
-	onChange    []func(*Config) // callbacks when config changes
-	generation  uint64          // incremented on each merge to detect stale callbacks
+	envConfig   *Config // config derived purely from env vars
+	fileConfig  FileConfig
+	merged      *Config
+	sources     ConfigSources
+	onChange    []func(*Config)
+	generation  uint64 // incremented on each merge to detect stale callbacks
 }
 
 // ConfigSources tracks the source of each config category.
@@ -363,7 +363,6 @@ func (m *Manager) merge() (*Config, ConfigSources) {
 		sources.CoolifyHosts = SourceFile
 	}
 
-	// Read-only
 	if m.envSnapshot.ReadOnlySet {
 		cfg.ReadOnly = m.envConfig.ReadOnly
 		sources.ReadOnly = SourceEnv
@@ -401,7 +400,6 @@ func (m *Manager) remerge() {
 	copy(cbs, m.onChange)
 	m.mu.Unlock()
 	for _, fn := range cbs {
-		// Check if a newer update has superseded this one.
 		m.mu.RLock()
 		stale := m.generation != gen
 		m.mu.RUnlock()

--- a/server/internal/docker/client.go
+++ b/server/internal/docker/client.go
@@ -176,7 +176,6 @@ func (c *MultiHostClient) EngineInfo(ctx context.Context, hostName string) (engi
 	return engine, v.Version, nil
 }
 
-// Close closes all underlying Docker API clients.
 func (c *MultiHostClient) Close() {
 	for _, cl := range c.clients {
 		cl.Close()

--- a/server/internal/docker/compose.go
+++ b/server/internal/docker/compose.go
@@ -17,7 +17,6 @@ var composeProjectLabels = []string{
 	"io.podman.compose.project",
 }
 
-// inComposeProject reports whether a container's labels place it in project.
 func inComposeProject(labels map[string]string, project string) bool {
 	for _, label := range composeProjectLabels {
 		if labels[label] == project {

--- a/server/internal/docker/exec.go
+++ b/server/internal/docker/exec.go
@@ -34,7 +34,6 @@ func (c *MultiHostClient) CreateExec(ctx context.Context, host, containerID stri
 	return response.ID, nil
 }
 
-// AttachExec attaches to an existing exec instance and returns the hijacked response
 func (c *MultiHostClient) AttachExec(ctx context.Context, host, execID string) (*types.HijackedResponse, error) {
 	cli, err := c.GetClient(host)
 	if err != nil {
@@ -51,7 +50,6 @@ func (c *MultiHostClient) AttachExec(ctx context.Context, host, execID string) (
 	return &resp, nil
 }
 
-// ResizeExec resizes the tty for an exec instance
 func (c *MultiHostClient) ResizeExec(ctx context.Context, host, execID string, height, width uint) error {
 	cli, err := c.GetClient(host)
 	if err != nil {

--- a/server/internal/docker/host_info.go
+++ b/server/internal/docker/host_info.go
@@ -40,7 +40,6 @@ func (c *MultiHostClient) GetHostsInfo(ctx context.Context) []models.HostInfo {
 	return result
 }
 
-// hostInfoFromEngine maps the engine's Info response to the API model.
 func hostInfoFromEngine(hostName string, info system.Info) models.HostInfo {
 	return models.HostInfo{
 		Host:              hostName,

--- a/server/internal/docker/stats.go
+++ b/server/internal/docker/stats.go
@@ -123,7 +123,6 @@ func currentCPUPercent(key string, stats *container.StatsResponse) float64 {
 	return calculateCPUPercent(stats)
 }
 
-// ContainerIdentifier represents a container on a specific host
 type ContainerIdentifier struct {
 	ID   string
 	Host string
@@ -196,7 +195,6 @@ func (c *MultiHostClient) GetBulkContainerStats(ctx context.Context, containers 
 	return results
 }
 
-// GetAllRunningContainerStats fetches stats for all running containers across all hosts.
 func (c *MultiHostClient) GetAllRunningContainerStats(ctx context.Context) ([]models.ContainerStats, error) {
 	var runningContainers []ContainerIdentifier
 

--- a/server/internal/logstore/ingest.go
+++ b/server/internal/logstore/ingest.go
@@ -28,7 +28,6 @@ const (
 	streamStderr = 1
 )
 
-// line is one stored log line.
 type line struct {
 	tsNS   int64
 	stream int

--- a/server/internal/logstore/logstore_test.go
+++ b/server/internal/logstore/logstore_test.go
@@ -329,7 +329,6 @@ func TestQueryLevelAndSearchFilters(t *testing.T) {
 		t.Fatal("an invalid regex must be rejected")
 	}
 
-	// Time bounds.
 	page, err = store.Query(ctx, LogQuery{
 		Container: "web",
 		Since:     baseTime.Add(time.Second),

--- a/server/internal/logstream/logstream.go
+++ b/server/internal/logstream/logstream.go
@@ -80,7 +80,6 @@ func (s ContainerSpec) Matches(host, name string, labels map[string]string) bool
 	return false
 }
 
-// containerKey identifies one container on one host.
 type containerKey struct {
 	host string
 	id   string

--- a/server/internal/logstream/logstream_test.go
+++ b/server/internal/logstream/logstream_test.go
@@ -267,7 +267,6 @@ func TestStartEventSpawnsTail(t *testing.T) {
 	rec := &recorder{}
 	h.Subscribe(ContainerSpec{Containers: []string{"api"}}, models.LogOptions{}, rec.sink)
 
-	// No running containers yet; then the container starts.
 	f.events <- docker.EngineEvent{Host: "h1", ContainerID: "c9", ContainerName: "api", Action: "start",
 		Labels: map[string]string{"name": "api"}}
 

--- a/server/internal/models/alerts.go
+++ b/server/internal/models/alerts.go
@@ -20,7 +20,7 @@ func LevelSeverity(level LogLevel) int {
 		return 6
 	case LogLevelPanic:
 		return 7
-	default: // LogLevelUnknown and anything unrecognized
+	default:
 		return 0
 	}
 }

--- a/server/internal/models/container.go
+++ b/server/internal/models/container.go
@@ -24,7 +24,6 @@ type ContainerEvent struct {
 	Timestamp     int64  `json:"timestamp"`
 }
 
-// LogOptions represents options for fetching container logs
 type LogOptions struct {
 	Follow     bool   `json:"follow"`
 	Timestamps bool   `json:"timestamps"`
@@ -38,7 +37,6 @@ type LogOptions struct {
 	Search     string `json:"search,omitempty"`
 }
 
-// DefaultLogOptions returns sensible defaults for log fetching
 func DefaultLogOptions() LogOptions {
 	return LogOptions{
 		Timestamps: true,
@@ -48,12 +46,10 @@ func DefaultLogOptions() LogOptions {
 	}
 }
 
-// EnvVariables represents the environment variables for a container
 type EnvVariables struct {
 	Env map[string]string `json:"env"`
 }
 
-// ContainerStats represents CPU and memory usage for a container
 type ContainerStats struct {
 	ID            string  `json:"id"`
 	Host          string  `json:"host"`

--- a/server/internal/services/registry.go
+++ b/server/internal/services/registry.go
@@ -18,7 +18,6 @@ type Registry struct {
 	config  *config.Config
 }
 
-// NewRegistry creates a registry with the initial set of services.
 func NewRegistry(
 	dockerClient *docker.MultiHostClient,
 	coolifyClient *coolify.MultiClient,


### PR DESCRIPTION
Swept the backend and frontend for chatty comments — narration of what the next line does, or doc comments that just rephrase a name. Kept everything that explains a constraint, engine/browser quirk, security reason, or invariant the code can't show.

Comments only, no behavior change. 37 files, ~58 comments removed. Skipped the vendored `components/ui` shadcn primitives, generated files, and left all `//go:*`, `// @ts-expect-error`, `// biome-ignore`, and `TODO`/`FIXME` directives intact.

https://claude.ai/code/session_01BWmTRvLf5Q5Cu8m8LMPAjk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings responses now show whether Docker hosts, Coolify hosts, and authentication values come from environment or file configuration.
  * Container lifecycle events now include timestamps.
* **Bug Fixes**
  * Pasting environment variables with an empty value no longer overwrites an existing value or unexpectedly moves focus.
* **Improvements**
  * Configuration now warns when a configured Coolify host does not match a known Docker host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->