### PR TITLE
chore: remove slop from recent work

### DIFF
--- a/frontend/src/features/settings/components/channel-utils.ts
+++ b/frontend/src/features/settings/components/channel-utils.ts
@@ -16,7 +16,7 @@ const TYPE_LABELS: Record<AlertChannelType, string> = {
 };
 
 export function channelTypeLabel(type: AlertChannelType): string {
-	return TYPE_LABELS[type] ?? type;
+	return TYPE_LABELS[type];
 }
 
 export function channelDestination(channel: AlertChannel): string {

--- a/server/cmd/logstore-stress/main.go
+++ b/server/cmd/logstore-stress/main.go
@@ -75,11 +75,11 @@ var presets = map[string]scenarioPreset{
 func main() {
 	cfg, err := parseFlags()
 	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "logstore-stress:", err)
+		fmt.Fprintln(os.Stderr, "logstore-stress:", err)
 		os.Exit(2)
 	}
 	if err := run(cfg); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "logstore-stress:", err)
+		fmt.Fprintln(os.Stderr, "logstore-stress:", err)
 		os.Exit(1)
 	}
 }
@@ -211,27 +211,27 @@ type queryStats struct {
 
 // report is the full machine-readable result.
 type report struct {
-	Config           runConfig   `json:"config"`
-	OfferedLines     uint64      `json:"offeredLines"`
-	CommittedLines   int64       `json:"committedLines"`
-	RetainedLines    int64       `json:"retainedLines"`
-	SampleErrors     int         `json:"sampleErrors"`
-	DroppedLines     uint64      `json:"droppedLines"`
-	OfferedRate      float64     `json:"offeredRateLinesPerSec"`
-	CommitRate       float64     `json:"committedRateLinesPerSec"`
-	DropFraction     float64     `json:"dropFraction"`
-	DBBytesFinal     int64       `json:"dbBytesFinal"`
-	DBBytesPeak      int64       `json:"dbBytesPeak"`
-	TotalCapBytes    int64       `json:"totalCapBytes"`
-	HeapAllocPeak    uint64      `json:"heapAllocPeakBytes"`
-	HeapInusePeak    uint64      `json:"heapInusePeakBytes"`
-	HeapAllocFirst   uint64      `json:"heapAllocFirstBytes"`
-	HeapAllocLast    uint64      `json:"heapAllocLastBytes"`
-	GoroutinesPeak   int         `json:"goroutinesPeak"`
-	GoroutinesFirst  int         `json:"goroutinesFirst"`
-	GoroutinesLast   int         `json:"goroutinesLast"`
-	Query            *queryStats `json:"query"`
-	Samples          []sample    `json:"samples"`
+	Config          runConfig   `json:"config"`
+	OfferedLines    uint64      `json:"offeredLines"`
+	CommittedLines  int64       `json:"committedLines"`
+	RetainedLines   int64       `json:"retainedLines"`
+	SampleErrors    int         `json:"sampleErrors"`
+	DroppedLines    uint64      `json:"droppedLines"`
+	OfferedRate     float64     `json:"offeredRateLinesPerSec"`
+	CommitRate      float64     `json:"committedRateLinesPerSec"`
+	DropFraction    float64     `json:"dropFraction"`
+	DBBytesFinal    int64       `json:"dbBytesFinal"`
+	DBBytesPeak     int64       `json:"dbBytesPeak"`
+	TotalCapBytes   int64       `json:"totalCapBytes"`
+	HeapAllocPeak   uint64      `json:"heapAllocPeakBytes"`
+	HeapInusePeak   uint64      `json:"heapInusePeakBytes"`
+	HeapAllocFirst  uint64      `json:"heapAllocFirstBytes"`
+	HeapAllocLast   uint64      `json:"heapAllocLastBytes"`
+	GoroutinesPeak  int         `json:"goroutinesPeak"`
+	GoroutinesFirst int         `json:"goroutinesFirst"`
+	GoroutinesLast  int         `json:"goroutinesLast"`
+	Query           *queryStats `json:"query"`
+	Samples         []sample    `json:"samples"`
 }
 
 // --- run --------------------------------------------------------------------
@@ -668,7 +668,7 @@ func emitJSON(rep report) error {
 
 func writeHumanSummary(rep report) {
 	w := os.Stderr
-	p := func(format string, args ...any) { _, _ = fmt.Fprintf(w, format, args...) }
+	p := func(format string, args ...any) { fmt.Fprintf(w, format, args...) }
 
 	p("\n=== logstore-stress: %s ===\n", rep.Config.Scenario)
 	p("containers=%d rate=%s duration=%.0fs line-bytes=%d caps=%d/%dMB queryWorkers=%d\n",

--- a/server/internal/alerts/engine.go
+++ b/server/internal/alerts/engine.go
@@ -8,8 +8,7 @@
 // non-blocking match messages onto firedCh. A single dispatcher goroutine
 // consumes fired alerts, appends them to history, delivers them to the
 // configured channels, and records each delivery outcome on the history entry.
-// Helper
-// goroutines exist only for single container-inspect exit-code lookups.
+// Helper goroutines exist only for single container-inspect lookups.
 package alerts
 
 import (

--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -158,17 +158,10 @@ func (ar *APIRouter) RemoveContainer(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// execRunTimeout bounds a single RunCommand invocation.
-const execRunTimeout = 60 * time.Second
-
 type runCommandRequest struct {
 	Command string `json:"command"`
 }
 
-// RunCommand runs one non-interactive command in a container through the shell
-// and returns its separated stdout, stderr, and exit code. This is the
-// programmatic counterpart to the interactive terminal (HandleTerminal): no
-// TTY, so streams stay distinct and the exit code is authoritative.
 func (ar *APIRouter) RunCommand(w http.ResponseWriter, r *http.Request) {
 	host, id, ok := containerParams(w, r)
 	if !ok {
@@ -185,7 +178,7 @@ func (ar *APIRouter) RunCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), execRunTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
 
 	stdout, stderr, exitCode, err := ar.registry.Docker().RunExec(ctx, host, id, []string{"/bin/sh", "-c", req.Command})

--- a/server/internal/cli/alerts.go
+++ b/server/internal/cli/alerts.go
@@ -533,8 +533,8 @@ func newAlertChannelsListCmd(a *app) *cobra.Command {
 func newAlertChannelAddCmd(a *app) *cobra.Command {
 	var (
 		channelType, name, channelURL, token, target string
-		disabled                                      bool
-		req                                           alertChannel
+		disabled                                     bool
+		req                                          alertChannel
 	)
 
 	cmd := &cobra.Command{

--- a/server/internal/config/alerts.go
+++ b/server/internal/config/alerts.go
@@ -59,7 +59,7 @@ type AlertRule struct {
 // (enabled) at the front of the channel list and clears WebhookURL. It reports
 // whether it changed the config so the caller can persist the result once.
 func migrateAlertChannels(a *AlertsConfig) bool {
-	if a == nil || a.WebhookURL == "" {
+	if a.WebhookURL == "" {
 		return false
 	}
 	a.Channels = append([]AlertChannel{{

--- a/server/internal/models/logs.go
+++ b/server/internal/models/logs.go
@@ -428,11 +428,8 @@ func tryParseTimestampCandidate(candidate string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 
-	// Every supported layout renders between these lengths (the shortest is a
-	// bare "2006/01/02 15:04:05" at 19; the longest is RFC3339Nano with nine
-	// fractional digits and a numeric offset at 35). A candidate outside that
-	// band cannot match any layout, so skip the time.Parse attempts entirely —
-	// this is what keeps the prefix scan cheap without dropping any real match.
+	// A candidate outside the layout length bounds cannot match any format, so
+	// skip the time.Parse attempts entirely and keep the prefix scan cheap.
 	if n := len(sanitized); n < minTimestampLen || n > maxTimestampLen {
 		return time.Time{}, false
 	}


### PR DESCRIPTION
Small consistency pass over the code added this session (alerting channels, health alerts, MCP + exec endpoint, logstore perf, stress harness). Five focused reviews found little — the earlier comment cleanup and reviews had already covered most of it.

Removed: a dead `a == nil` guard whose caller already guards, a dead `?? type` label fallback on an exhaustive map, a one-off timeout constant (inlined to match sibling handlers), `_, _ =` error-capture on a few `fmt.Fprint` calls (bare matches the repo), and two redundant comments; plus gofmt on a couple of tag/var blocks. No behavior change; build, tests, lint, tsc all green.

https://claude.ai/code/session_01BWmTRvLf5Q5Cu8m8LMPAjk