### PR TITLE
test: raise coverage + fix cgroup v2 memory reporting

### DIFF
--- a/frontend/src/features/containers/components/log-viewer/log-export.test.ts
+++ b/frontend/src/features/containers/components/log-viewer/log-export.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LogEntry } from "@/features/containers/api/get-container-logs-parsed";
+
+import { downloadLogs, formatLogEntryLine } from "./log-export";
+
+describe("formatLogEntryLine", () => {
+	it("formats timestamp, level, and message", () => {
+		const entry: LogEntry = {
+			timestamp: "2026-07-15T12:34:56.000Z",
+			level: "INFO",
+			message: "hello world",
+		};
+		expect(formatLogEntryLine(entry)).toBe(
+			"[2026-07-15T12:34:56.000Z] [INFO] hello world",
+		);
+	});
+
+	it("normalizes the timestamp to ISO 8601", () => {
+		const entry: LogEntry = {
+			timestamp: "2026-07-15T12:34:56+02:00",
+			level: "ERROR",
+			message: "boom",
+		};
+		expect(formatLogEntryLine(entry)).toBe(
+			"[2026-07-15T10:34:56.000Z] [ERROR] boom",
+		);
+	});
+
+	it("uses an empty timestamp field when none is present", () => {
+		const entry: LogEntry = { level: "DEBUG", message: "no ts" };
+		expect(formatLogEntryLine(entry)).toBe("[] [DEBUG] no ts");
+	});
+
+	it("falls back to UNKNOWN when the level is empty", () => {
+		const entry = { level: "", message: "x" } as unknown as LogEntry;
+		expect(formatLogEntryLine(entry)).toBe("[] [UNKNOWN] x");
+	});
+
+	it("falls back to raw, then empty, when message is missing", () => {
+		expect(formatLogEntryLine({ level: "INFO", raw: "raw text" })).toBe(
+			"[] [INFO] raw text",
+		);
+		expect(formatLogEntryLine({ level: "INFO" })).toBe("[] [INFO] ");
+	});
+});
+
+// jsdom's Blob does not implement text(), so capture the constructor parts.
+class FakeBlob {
+	parts: BlobPart[];
+	type: string;
+	constructor(parts: BlobPart[], options?: BlobPropertyBag) {
+		this.parts = parts;
+		this.type = options?.type ?? "";
+	}
+	get content(): string {
+		return this.parts.join("");
+	}
+}
+
+describe("downloadLogs", () => {
+	let capturedBlob: FakeBlob | null;
+	let anchor: HTMLAnchorElement;
+	let clickSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-15T12:34:56.789Z"));
+
+		capturedBlob = null;
+		clickSpy = vi.fn();
+
+		vi.stubGlobal("Blob", FakeBlob);
+		vi.stubGlobal("URL", {
+			createObjectURL: vi.fn((blob: FakeBlob) => {
+				capturedBlob = blob;
+				return "blob:mock";
+			}),
+			revokeObjectURL: vi.fn(),
+		});
+
+		anchor = document.createElement("a");
+		anchor.click = clickSpy;
+		vi.spyOn(document, "createElement").mockReturnValue(anchor);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	const entries: LogEntry[] = [
+		{ timestamp: "2026-07-15T00:00:00.000Z", level: "INFO", message: "a" },
+		{ level: "ERROR", message: "b" },
+	];
+
+	it("builds a timestamped filename with the requested extension", () => {
+		downloadLogs(entries, "web", "txt");
+		expect(anchor.download).toBe("web-logs-2026-07-15T12-34-56.txt");
+		expect(clickSpy).toHaveBeenCalledOnce();
+	});
+
+	it("strips a leading slash and sanitizes unsafe filename characters", () => {
+		downloadLogs(entries, "/my/app:v1", "json");
+		expect(anchor.download).toBe("my-app-v1-logs-2026-07-15T12-34-56.json");
+	});
+
+	it("defaults the container name to 'container' when undefined", () => {
+		downloadLogs(entries, undefined, "txt");
+		expect(anchor.download).toBe("container-logs-2026-07-15T12-34-56.txt");
+	});
+
+	it("serializes JSON exports as a pretty-printed array", () => {
+		downloadLogs(entries, "web", "json");
+		expect(capturedBlob?.type).toBe("application/json");
+		expect(capturedBlob?.content).toBe(JSON.stringify(entries, null, 2));
+	});
+
+	it("serializes text exports as newline-joined formatted lines", () => {
+		downloadLogs(entries, "web", "txt");
+		expect(capturedBlob?.type).toBe("text/plain");
+		expect(capturedBlob?.content).toBe(
+			"[2026-07-15T00:00:00.000Z] [INFO] a\n[] [ERROR] b",
+		);
+	});
+});

--- a/frontend/src/lib/json-format.test.ts
+++ b/frontend/src/lib/json-format.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { formatJson, isJsonString } from "./json-format";
+
+describe("formatJson", () => {
+	it("pretty-prints a JSON object with two-space indentation", () => {
+		const result = formatJson('{"a":1,"b":2}');
+		expect(result.isJson).toBe(true);
+		expect(result.formatted).toBe('{\n  "a": 1,\n  "b": 2\n}');
+	});
+
+	it("pretty-prints a JSON array", () => {
+		const result = formatJson("[1,2,3]");
+		expect(result.isJson).toBe(true);
+		expect(result.formatted).toBe("[\n  1,\n  2,\n  3\n]");
+	});
+
+	it("treats an empty object and empty array as JSON", () => {
+		expect(formatJson("{}")).toEqual({ formatted: "{}", isJson: true });
+		expect(formatJson("[]")).toEqual({ formatted: "[]", isJson: true });
+	});
+
+	it("ignores leading and trailing whitespace around JSON", () => {
+		const result = formatJson('  {"a":1}  ');
+		expect(result.isJson).toBe(true);
+		expect(result.formatted).toBe('{\n  "a": 1\n}');
+	});
+
+	it("excludes bare primitives even though they are valid JSON", () => {
+		for (const primitive of ["42", "true", "false", "null", '"hi"']) {
+			const result = formatJson(primitive);
+			expect(result.isJson).toBe(false);
+			expect(result.formatted).toBe(primitive);
+		}
+	});
+
+	it("returns the original text for a brace-prefixed but invalid string", () => {
+		const result = formatJson("{not valid json}");
+		expect(result).toEqual({
+			formatted: "{not valid json}",
+			isJson: false,
+		});
+	});
+
+	it("does not treat trailing garbage after valid JSON as JSON", () => {
+		const result = formatJson('{"a":1} trailing');
+		expect(result.isJson).toBe(false);
+	});
+
+	it("returns the original text for plain (non-JSON) log lines", () => {
+		const line = "2026-07-15 INFO server started";
+		expect(formatJson(line)).toEqual({ formatted: line, isJson: false });
+	});
+
+	it("handles an empty string", () => {
+		expect(formatJson("")).toEqual({ formatted: "", isJson: false });
+	});
+
+	it("caches results and returns the identical reference for repeated input", () => {
+		const first = formatJson('{"cached":true}');
+		const second = formatJson('{"cached":true}');
+		expect(second).toBe(first);
+	});
+});
+
+describe("isJsonString", () => {
+	it("is true for objects and arrays, false for primitives and plain text", () => {
+		expect(isJsonString('{"a":1}')).toBe(true);
+		expect(isJsonString("[1,2]")).toBe(true);
+		expect(isJsonString("42")).toBe(false);
+		expect(isJsonString("plain log line")).toBe(false);
+	});
+});

--- a/frontend/src/lib/ndjson.test.ts
+++ b/frontend/src/lib/ndjson.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { iterateNDJSONStream } from "./ndjson";
+
+const encoder = new TextEncoder();
+
+function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+	let index = 0;
+	return new ReadableStream({
+		pull(controller) {
+			if (index < chunks.length) {
+				controller.enqueue(chunks[index++]);
+			} else {
+				controller.close();
+			}
+		},
+	});
+}
+
+function streamFromStrings(strings: string[]): ReadableStream<Uint8Array> {
+	return streamFromChunks(strings.map((s) => encoder.encode(s)));
+}
+
+async function collect<T>(gen: AsyncGenerator<T, void, unknown>): Promise<T[]> {
+	const out: T[] = [];
+	for await (const value of gen) {
+		out.push(value);
+	}
+	return out;
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	errorSpy.mockRestore();
+});
+
+describe("iterateNDJSONStream", () => {
+	it("parses one object per newline-terminated line", async () => {
+		const stream = streamFromStrings(['{"n":1}\n{"n":2}\n{"n":3}\n']);
+		const result = await collect<{ n: number }>(iterateNDJSONStream(stream));
+		expect(result).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+	});
+
+	it("yields the trailing line that has no terminating newline", async () => {
+		const stream = streamFromStrings(['{"n":1}\n{"n":2}']);
+		const result = await collect<{ n: number }>(iterateNDJSONStream(stream));
+		expect(result).toEqual([{ n: 1 }, { n: 2 }]);
+	});
+
+	it("reassembles a JSON object split across two chunks", async () => {
+		const stream = streamFromStrings(['{"msg":"hel', 'lo"}\n']);
+		const result = await collect<{ msg: string }>(iterateNDJSONStream(stream));
+		expect(result).toEqual([{ msg: "hello" }]);
+	});
+
+	it("reassembles a line whose newline arrives in a later chunk", async () => {
+		const stream = streamFromStrings(['{"a":1}', "\n", '{"b":2}\n']);
+		const result = await collect<Record<string, number>>(
+			iterateNDJSONStream(stream),
+		);
+		expect(result).toEqual([{ a: 1 }, { b: 2 }]);
+	});
+
+	it("skips blank and whitespace-only lines", async () => {
+		const stream = streamFromStrings(['{"n":1}\n\n   \n{"n":2}\n']);
+		const result = await collect<{ n: number }>(iterateNDJSONStream(stream));
+		expect(result).toEqual([{ n: 1 }, { n: 2 }]);
+	});
+
+	it("skips malformed lines, logs them, and keeps parsing", async () => {
+		const stream = streamFromStrings(['{"n":1}\nnot json\n{"n":2}\n']);
+		const result = await collect<{ n: number }>(iterateNDJSONStream(stream));
+		expect(result).toEqual([{ n: 1 }, { n: 2 }]);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Failed to parse NDJSON line:",
+			"not json",
+			expect.any(SyntaxError),
+		);
+	});
+
+	it("logs when the final unterminated line is malformed", async () => {
+		const stream = streamFromStrings(['{"n":1}\n{oops']);
+		const result = await collect<{ n: number }>(iterateNDJSONStream(stream));
+		expect(result).toEqual([{ n: 1 }]);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Failed to parse final NDJSON line:",
+			"{oops",
+			expect.any(SyntaxError),
+		);
+	});
+
+	it("decodes multibyte UTF-8 characters split across chunk boundaries", async () => {
+		const bytes = encoder.encode('{"m":"café"}\n');
+		// Split inside the two-byte é sequence (é is the 4th char, bytes 9-10).
+		const split = 9;
+		const stream = streamFromChunks([
+			bytes.slice(0, split),
+			bytes.slice(split),
+		]);
+		const result = await collect<{ m: string }>(iterateNDJSONStream(stream));
+		expect(result).toEqual([{ m: "café" }]);
+	});
+
+	it("yields nothing and never reads when the signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const stream = streamFromStrings(['{"n":1}\n']);
+		const result = await collect<{ n: number }>(
+			iterateNDJSONStream(stream, controller.signal),
+		);
+		expect(result).toEqual([]);
+	});
+
+	it("produces no output for an empty stream", async () => {
+		const stream = streamFromStrings([]);
+		const result = await collect(iterateNDJSONStream(stream));
+		expect(result).toEqual([]);
+	});
+});

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { cn, escapeRegExp } from "./utils";
+
+describe("escapeRegExp", () => {
+	it("escapes all regex metacharacters", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: "${}" here are literal regex metacharacters under test, not a template placeholder
+		expect(escapeRegExp(".*+?^${}()|[]\\")).toBe(
+			"\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\",
+		);
+	});
+
+	it("leaves ordinary characters untouched", () => {
+		expect(escapeRegExp("hello world 123")).toBe("hello world 123");
+	});
+
+	it("produces a pattern that matches the input literally", () => {
+		const input = "a.b(c)*";
+		const re = new RegExp(escapeRegExp(input));
+		expect(re.test(input)).toBe(true);
+		// Without escaping, "." and "*" would let this false-positive match.
+		expect(re.test("axbxc")).toBe(false);
+	});
+});
+
+describe("cn", () => {
+	it("merges conflicting tailwind classes, keeping the last one", () => {
+		expect(cn("px-2", "px-4")).toBe("px-4");
+	});
+
+	it("drops falsy and conditional values", () => {
+		expect(cn("a", false, null, undefined, "b")).toBe("a b");
+		expect(cn("base", { active: false, muted: true })).toBe("base muted");
+	});
+});

--- a/server/internal/api/aggregate_logs_handlers_test.go
+++ b/server/internal/api/aggregate_logs_handlers_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseAggregateTargets(t *testing.T) {
+	t.Run("single target with name", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/logs/aggregate?targets=prod~abc123~web", nil)
+		targets, err := parseAggregateTargets(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(targets) != 1 {
+			t.Fatalf("expected 1 target, got %d", len(targets))
+		}
+		if targets[0].Host != "prod" || targets[0].ID != "abc123" || targets[0].Name != "web" {
+			t.Fatalf("unexpected target: %+v", targets[0])
+		}
+	})
+
+	t.Run("name is optional", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/logs/aggregate?targets=prod~abc123", nil)
+		targets, err := parseAggregateTargets(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(targets) != 1 || targets[0].Name != "" {
+			t.Fatalf("expected one nameless target, got %+v", targets)
+		}
+	})
+
+	t.Run("comma-separated in one value", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/logs/aggregate?targets=prod~a~web,staging~b~db", nil)
+		targets, err := parseAggregateTargets(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(targets) != 2 || targets[0].Host != "prod" || targets[1].Host != "staging" {
+			t.Fatalf("unexpected targets: %+v", targets)
+		}
+	})
+
+	t.Run("repeated params merge", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/logs/aggregate?targets=prod~a~web&targets=staging~b~db", nil)
+		targets, err := parseAggregateTargets(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(targets) != 2 {
+			t.Fatalf("expected 2 targets, got %d", len(targets))
+		}
+	})
+
+	t.Run("blank entries are skipped", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/logs/aggregate?targets=prod~a~web,%20,staging~b~db", nil)
+		targets, err := parseAggregateTargets(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(targets) != 2 {
+			t.Fatalf("expected 2 targets after skipping blanks, got %d", len(targets))
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{"missing targets param", "/logs/aggregate"},
+		{"empty targets value", "/logs/aggregate?targets="},
+		{"only whitespace", "/logs/aggregate?targets=%20"},
+		{"missing id", "/logs/aggregate?targets=prod"},
+		{"blank host", "/logs/aggregate?targets=~id~name"},
+		{"blank id", "/logs/aggregate?targets=host~~name"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", tt.path, nil)
+			if _, err := parseAggregateTargets(r); err == nil {
+				t.Fatalf("expected error for %q", tt.path)
+			}
+		})
+	}
+}
+
+func TestParseAggregateTargetsLimit(t *testing.T) {
+	build := func(n int) string {
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = fmt.Sprintf("prod~id%d~name%d", i, i)
+		}
+		return strings.Join(parts, ",")
+	}
+
+	// The documented cap is 20: exactly 20 is accepted, 21 is rejected.
+	r := httptest.NewRequest("GET", "/logs/aggregate?targets="+build(maxAggregateTargets), nil)
+	if targets, err := parseAggregateTargets(r); err != nil {
+		t.Fatalf("expected %d targets to be accepted, got error: %v", maxAggregateTargets, err)
+	} else if len(targets) != maxAggregateTargets {
+		t.Fatalf("expected %d targets, got %d", maxAggregateTargets, len(targets))
+	}
+
+	r = httptest.NewRequest("GET", "/logs/aggregate?targets="+build(maxAggregateTargets+1), nil)
+	if _, err := parseAggregateTargets(r); err == nil {
+		t.Fatalf("expected %d targets to be rejected", maxAggregateTargets+1)
+	}
+}

--- a/server/internal/api/handlers_test.go
+++ b/server/internal/api/handlers_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +39,90 @@ func TestParseLogOptionsLevel(t *testing.T) {
 	r = httptest.NewRequest("GET", "/api/v1/containers/abc/logs/parsed", nil)
 	if got := parseLogOptions(r).Level; got != "" {
 		t.Fatalf("parseLogOptions Level = %q, want empty", got)
+	}
+}
+
+// TestParseLogOptions covers the parameter parsing beyond the level field: the
+// booleans, the string passthroughs, and the tail clamp.
+func TestParseLogOptions(t *testing.T) {
+	r := httptest.NewRequest("GET",
+		"/api/v1/containers/abc/logs/parsed?follow=true&timestamps=1&details=true&stdout=false&stderr=true&since=2026-01-01T00:00:00Z&until=2026-01-02T00:00:00Z&search=oops&tail=50", nil)
+	opts := parseLogOptions(r)
+
+	if !opts.Follow {
+		t.Errorf("Follow = false, want true")
+	}
+	if !opts.Timestamps {
+		t.Errorf("Timestamps = false, want true")
+	}
+	if !opts.Details {
+		t.Errorf("Details = false, want true")
+	}
+	if opts.ShowStdout {
+		t.Errorf("ShowStdout = true, want false")
+	}
+	if !opts.ShowStderr {
+		t.Errorf("ShowStderr = false, want true")
+	}
+	if opts.Since != "2026-01-01T00:00:00Z" || opts.Until != "2026-01-02T00:00:00Z" {
+		t.Errorf("since/until = %q/%q, want the passed values", opts.Since, opts.Until)
+	}
+	if opts.Search != "oops" {
+		t.Errorf("Search = %q, want oops", opts.Search)
+	}
+	if opts.Tail != "50" {
+		t.Errorf("Tail = %q, want 50", opts.Tail)
+	}
+}
+
+func TestParseLogOptionsTailClamp(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/v1/containers/abc/logs/parsed?tail=999999", nil)
+	if got := parseLogOptions(r).Tail; got != "10000" {
+		t.Fatalf("over-max tail = %q, want clamped to 10000", got)
+	}
+}
+
+// TestRunCommandValidation covers the request-body validation in RunCommand,
+// which rejects a missing host, an unparseable body, and a blank command
+// before any Docker call is attempted.
+func TestRunCommandValidation(t *testing.T) {
+	ar := &APIRouter{}
+
+	for _, tt := range []struct {
+		name string
+		host string
+		body string
+	}{
+		{"missing host", "", `{"command":"ls"}`},
+		{"invalid json body", "prod", `{`},
+		{"blank command", "prod", `{"command":"   "}`},
+		{"empty command", "prod", `{"command":""}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := "/api/v1/containers/abc/exec/run"
+			if tt.host != "" {
+				path += "?host=" + tt.host
+			}
+			w := httptest.NewRecorder()
+			ar.RunCommand(w, httptest.NewRequest(http.MethodPost, path, strings.NewReader(tt.body)))
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestGetContainerLogsParsedInvalidSearch proves an uncompilable search regex
+// is rejected with a 400 before the request reaches Docker.
+func TestGetContainerLogsParsedInvalidSearch(t *testing.T) {
+	ar := &APIRouter{}
+	w := httptest.NewRecorder()
+	ar.GetContainerLogsParsed(w, httptest.NewRequest(http.MethodGet,
+		"/api/v1/containers/abc/logs/parsed?host=prod&search=%5B", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a bad search pattern, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid search pattern") {
+		t.Fatalf("expected an invalid-search message, got %q", w.Body.String())
 	}
 }

--- a/server/internal/cli/logs_test.go
+++ b/server/internal/cli/logs_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLogFlagsQuery(t *testing.T) {
+	now := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	t.Run("defaults and normalization", func(t *testing.T) {
+		f := logFlags{tail: 100, level: "error", search: "boom", since: "15m"}
+		q, err := f.query(now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if q.Get("tail") != "100" {
+			t.Errorf("tail = %q, want 100", q.Get("tail"))
+		}
+		if q.Get("level") != "ERROR" {
+			t.Errorf("level = %q, want ERROR (upper-cased)", q.Get("level"))
+		}
+		if q.Get("search") != "boom" {
+			t.Errorf("search = %q, want boom", q.Get("search"))
+		}
+		if q.Get("since") != "2026-01-02T11:45:00Z" {
+			t.Errorf("since = %q, want the resolved relative time", q.Get("since"))
+		}
+	})
+
+	t.Run("empty optional flags are omitted", func(t *testing.T) {
+		f := logFlags{tail: 100}
+		q, err := f.query(now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, key := range []string{"level", "search", "since", "until"} {
+			if _, ok := q[key]; ok {
+				t.Errorf("expected %q to be omitted, got %q", key, q.Get(key))
+			}
+		}
+	})
+
+	t.Run("bad since is an error", func(t *testing.T) {
+		f := logFlags{tail: 100, since: "yesterday"}
+		if _, err := f.query(now); err == nil {
+			t.Fatal("expected an error for an unparseable --since")
+		}
+	})
+
+	t.Run("bad until is an error", func(t *testing.T) {
+		f := logFlags{tail: 100, until: "nope"}
+		if _, err := f.query(now); err == nil {
+			t.Fatal("expected an error for an unparseable --until")
+		}
+	})
+}

--- a/server/internal/cli/mcp.go
+++ b/server/internal/cli/mcp.go
@@ -519,12 +519,12 @@ func asString(v any) string {
 // clampTail defaults a tail/limit to 100 and caps it at mcpMaxTail.
 func clampTail(v int) int { return clampInt(v, 100, mcpMaxTail) }
 
-func clampInt(v, def, max int) int {
+func clampInt(v, def, maximum int) int {
 	if v <= 0 {
 		return def
 	}
-	if v > max {
-		return max
+	if v > maximum {
+		return maximum
 	}
 	return v
 }

--- a/server/internal/cli/mcp_test.go
+++ b/server/internal/cli/mcp_test.go
@@ -57,6 +57,41 @@ func TestMCPToolGating(t *testing.T) {
 	}
 }
 
+func TestClampInt(t *testing.T) {
+	tests := []struct {
+		v, def, maximum, want int
+	}{
+		{0, 100, 500, 100},   // zero -> default
+		{-5, 100, 500, 100},  // negative -> default
+		{50, 100, 500, 50},   // in range passes through
+		{500, 100, 500, 500}, // at max passes through
+		{999, 100, 500, 500}, // over max -> clamped
+	}
+	for _, tt := range tests {
+		if got := clampInt(tt.v, tt.def, tt.maximum); got != tt.want {
+			t.Errorf("clampInt(%d, %d, %d) = %d, want %d", tt.v, tt.def, tt.maximum, got, tt.want)
+		}
+	}
+}
+
+func TestClampTail(t *testing.T) {
+	// clampTail defaults to 100 and caps at mcpMaxTail (500).
+	tests := []struct {
+		in, want int
+	}{
+		{0, 100},
+		{-1, 100},
+		{250, 250},
+		{500, 500},
+		{5000, 500},
+	}
+	for _, tt := range tests {
+		if got := clampTail(tt.in); got != tt.want {
+			t.Errorf("clampTail(%d) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
 // TestMCPActionToolsGatedOff confirms the sensitive tools are absent unless
 // their flag is set — the registration surface is the advertised surface.
 func TestMCPActionToolsGatedOff(t *testing.T) {

--- a/server/internal/cli/table_test.go
+++ b/server/internal/cli/table_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		in   uint64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024, "1.0KiB"},
+		{1536, "1.5KiB"},
+		{1 << 20, "1.0MiB"},
+		{1 << 30, "1.0GiB"},
+		{1 << 40, "1.0TiB"},
+		{1 << 50, "1.0PiB"},
+	}
+	for _, tt := range tests {
+		if got := humanBytes(tt.in); got != tt.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestFormatLogLine(t *testing.T) {
+	ts := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	entry := logEntry{Timestamp: ts, Level: "ERROR", Message: "boom", ContainerName: "web"}
+
+	// Without the name, the container column is omitted.
+	if got := formatLogLine(entry, false); got != "2026-01-02T12:00:00Z ERROR   boom" {
+		t.Errorf("formatLogLine(withName=false) = %q", got)
+	}
+
+	// With the name and a set ContainerName, the [name] column appears.
+	if got := formatLogLine(entry, true); got != "2026-01-02T12:00:00Z ERROR   [web] boom" {
+		t.Errorf("formatLogLine(withName=true) = %q", got)
+	}
+
+	// A zero timestamp renders as "-" instead of the zero time.
+	noTS := logEntry{Level: "INFO", Message: "hi"}
+	if got := formatLogLine(noTS, false); got != "- INFO    hi" {
+		t.Errorf("formatLogLine(zero ts) = %q", got)
+	}
+
+	// withName but no ContainerName falls back to the nameless form.
+	noName := logEntry{Timestamp: ts, Level: "INFO", Message: "hi"}
+	if got := formatLogLine(noName, true); got != "2026-01-02T12:00:00Z INFO    hi" {
+		t.Errorf("formatLogLine(withName, no name) = %q", got)
+	}
+}

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseDockerHosts(t *testing.T) {
+	// Whitespace around entries, names, and hosts is trimmed; multiple hosts
+	// split on commas.
+	t.Setenv("DOCKER_HOSTS", " local = unix:///var/run/docker.sock , remote=ssh://root@10.0.0.1 ")
+
+	got := parseDockerHosts()
+	want := []DockerHost{
+		{Name: "local", Host: "unix:///var/run/docker.sock"},
+		{Name: "remote", Host: "ssh://root@10.0.0.1"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseDockerHosts() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseDockerHostsHostMayContainEquals(t *testing.T) {
+	// SplitN on "=" with limit 2 keeps an "=" inside the host value intact.
+	t.Setenv("DOCKER_HOSTS", "local=tcp://host:2375?opt=a=b")
+
+	got := parseDockerHosts()
+	want := []DockerHost{{Name: "local", Host: "tcp://host:2375?opt=a=b"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseDockerHosts() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseDockerHostsEmpty(t *testing.T) {
+	t.Setenv("DOCKER_HOSTS", "")
+	if got := parseDockerHosts(); len(got) != 0 {
+		t.Fatalf("expected no hosts when DOCKER_HOSTS is unset, got %+v", got)
+	}
+}
+
+func TestParseCoolifyHostConfigs(t *testing.T) {
+	// Trailing slashes on the API URL are trimmed; fields and entries are
+	// whitespace-trimmed.
+	t.Setenv("COOLIFY_CONFIGS", " a | https://coolify-a.com/ | tokenA , b|https://coolify-b.com|tokenB ")
+
+	got := parseCoolifyHostConfigs()
+	want := []CoolifyHostConfig{
+		{HostName: "a", APIURL: "https://coolify-a.com", APIToken: "tokenA"},
+		{HostName: "b", APIURL: "https://coolify-b.com", APIToken: "tokenB"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseCoolifyHostConfigs() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseCoolifyHostConfigsEmpty(t *testing.T) {
+	t.Setenv("COOLIFY_CONFIGS", "")
+	if got := parseCoolifyHostConfigs(); len(got) != 0 {
+		t.Fatalf("expected no configs when COOLIFY_CONFIGS is unset, got %+v", got)
+	}
+}

--- a/server/internal/config/manager_test.go
+++ b/server/internal/config/manager_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newManagerWithFile writes fc to a temp config file, points CONFIG_PATH at it,
+// and returns a fresh Manager that loaded it.
+func newManagerWithFile(t *testing.T, fc FileConfig) *Manager {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	data, err := json.Marshal(fc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("CONFIG_PATH", path)
+	return NewManager()
+}
+
+func TestMergeDefaultsWhenNothingConfigured(t *testing.T) {
+	m := newManagerWithFile(t, FileConfig{})
+
+	cfg := m.Config()
+	if len(cfg.DockerHosts) != 1 || cfg.DockerHosts[0].Name != "local" {
+		t.Fatalf("expected a single default local host, got %+v", cfg.DockerHosts)
+	}
+	sources := m.Sources()
+	if sources.DockerHosts != SourceDefault {
+		t.Fatalf("DockerHosts source = %q, want %q", sources.DockerHosts, SourceDefault)
+	}
+	if sources.CoolifyHosts != SourceDefault {
+		t.Fatalf("CoolifyHosts source = %q, want %q", sources.CoolifyHosts, SourceDefault)
+	}
+	if sources.ReadOnly != SourceDefault {
+		t.Fatalf("ReadOnly source = %q, want %q", sources.ReadOnly, SourceDefault)
+	}
+	if cfg.ReadOnly {
+		t.Fatal("ReadOnly should default to false")
+	}
+}
+
+func TestMergeFileOnly(t *testing.T) {
+	m := newManagerWithFile(t, FileConfig{
+		DockerHosts: []DockerHost{{Name: "file-host", Host: "tcp://filehost:2375"}},
+	})
+
+	cfg := m.Config()
+	if len(cfg.DockerHosts) != 1 || cfg.DockerHosts[0].Name != "file-host" {
+		t.Fatalf("expected the file host, got %+v", cfg.DockerHosts)
+	}
+	if got := m.Sources().DockerHosts; got != SourceFile {
+		t.Fatalf("DockerHosts source = %q, want %q", got, SourceFile)
+	}
+}
+
+func TestMergeEnvOnly(t *testing.T) {
+	t.Setenv("DOCKER_HOSTS", "env-host=tcp://envhost:2375")
+	m := newManagerWithFile(t, FileConfig{})
+
+	cfg := m.Config()
+	if len(cfg.DockerHosts) != 1 || cfg.DockerHosts[0].Name != "env-host" {
+		t.Fatalf("expected the env host, got %+v", cfg.DockerHosts)
+	}
+	if got := m.Sources().DockerHosts; got != SourceEnv {
+		t.Fatalf("DockerHosts source = %q, want %q", got, SourceEnv)
+	}
+}
+
+// Env and file hosts combine; on a name collision the env host wins and the
+// section is reported as mixed.
+func TestMergeEnvWinsOnCollision(t *testing.T) {
+	t.Setenv("DOCKER_HOSTS", "local=tcp://envhost:2375")
+	m := newManagerWithFile(t, FileConfig{
+		DockerHosts: []DockerHost{
+			{Name: "local", Host: "tcp://filehost:2375"}, // collides with env "local"
+			{Name: "extra", Host: "tcp://extra:2375"},
+		},
+	})
+
+	cfg := m.Config()
+	byName := map[string]string{}
+	for _, h := range cfg.DockerHosts {
+		byName[h.Name] = h.Host
+	}
+	if len(byName) != 2 {
+		t.Fatalf("expected env local + file extra, got %+v", cfg.DockerHosts)
+	}
+	if byName["local"] != "tcp://envhost:2375" {
+		t.Fatalf("expected env host to win the collision, got %q", byName["local"])
+	}
+	if byName["extra"] != "tcp://extra:2375" {
+		t.Fatalf("expected file-only host to survive, got %q", byName["extra"])
+	}
+	if got := m.Sources().DockerHosts; got != SourceMixed {
+		t.Fatalf("DockerHosts source = %q, want %q", got, SourceMixed)
+	}
+}
+
+func TestUpdateDockerHostsRejectsEnvCollision(t *testing.T) {
+	t.Setenv("DOCKER_HOSTS", "local=tcp://envhost:2375")
+	m := newManagerWithFile(t, FileConfig{})
+
+	err := m.UpdateDockerHosts([]DockerHost{{Name: "local", Host: "tcp://x:2375"}})
+	if err == nil {
+		t.Fatal("expected an error updating a host that collides with an env host")
+	}
+
+	// The rejected update must not be persisted.
+	if got := len(m.FileConfigSnapshot().DockerHosts); got != 0 {
+		t.Fatalf("expected no file hosts after a rejected update, got %d", got)
+	}
+}
+
+func TestUpdateDockerHostsPersistsAndRemerges(t *testing.T) {
+	m := newManagerWithFile(t, FileConfig{})
+
+	hosts := []DockerHost{{Name: "new", Host: "tcp://new:2375"}}
+	if err := m.UpdateDockerHosts(hosts); err != nil {
+		t.Fatalf("UpdateDockerHosts: %v", err)
+	}
+
+	// The merged config reflects the update immediately.
+	cfg := m.Config()
+	if len(cfg.DockerHosts) != 1 || cfg.DockerHosts[0].Name != "new" {
+		t.Fatalf("merged config not updated, got %+v", cfg.DockerHosts)
+	}
+	if got := m.Sources().DockerHosts; got != SourceFile {
+		t.Fatalf("DockerHosts source = %q, want %q", got, SourceFile)
+	}
+
+	// A fresh manager reads the persisted host back from disk.
+	reloaded := NewManager()
+	rc := reloaded.Config()
+	if len(rc.DockerHosts) != 1 || rc.DockerHosts[0].Host != "tcp://new:2375" {
+		t.Fatalf("persisted host did not round-trip, got %+v", rc.DockerHosts)
+	}
+}
+
+func TestUpdateCoolifyHostsRejectsEnvCollision(t *testing.T) {
+	t.Setenv("COOLIFY_CONFIGS", "local|https://coolify.example|token")
+	m := newManagerWithFile(t, FileConfig{})
+
+	err := m.UpdateCoolifyHosts([]CoolifyHostConfig{{HostName: "local", APIURL: "https://x", APIToken: "t"}})
+	if err == nil {
+		t.Fatal("expected an error updating a coolify host that collides with an env host")
+	}
+}
+
+// OnChange callbacks fire with the freshly merged config after an update.
+func TestOnChangeFiresAfterUpdate(t *testing.T) {
+	m := newManagerWithFile(t, FileConfig{})
+
+	var got *Config
+	m.OnChange(func(cfg *Config) { got = cfg })
+
+	if err := m.UpdateReadOnly(true); err != nil {
+		t.Fatalf("UpdateReadOnly: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected OnChange callback to fire")
+	}
+	if !got.ReadOnly {
+		t.Fatal("expected callback to receive the updated (read-only) config")
+	}
+}
+
+func TestUpdateReadOnlyRejectedWhenEnvControlled(t *testing.T) {
+	t.Setenv("READONLY_MODE", "true")
+	m := newManagerWithFile(t, FileConfig{})
+
+	if err := m.UpdateReadOnly(false); err == nil {
+		t.Fatal("expected an error changing read-only mode that is pinned by env")
+	}
+	if !m.Config().ReadOnly {
+		t.Fatal("env-pinned read-only mode must remain true")
+	}
+}

--- a/server/internal/coolify/client_test.go
+++ b/server/internal/coolify/client_test.go
@@ -1,0 +1,302 @@
+package coolify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+)
+
+func TestIsCoolifyDefaultEnvVar(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"COOLIFY_URL", true},
+		{"COOLIFY_", true},
+		{"SOURCE_COMMIT", true},
+		{"DATABASE_URL", false},
+		{"MY_COOLIFY", false},
+		{"source_commit", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsCoolifyDefaultEnvVar(tt.key); got != tt.want {
+			t.Errorf("IsCoolifyDefaultEnvVar(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestExtractResourceInfo(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   *ResourceInfo
+	}{
+		{
+			name:   "not managed",
+			labels: map[string]string{"com.docker.compose.project": "uuid-1"},
+			want:   nil,
+		},
+		{
+			name:   "managed but no uuid",
+			labels: map[string]string{LabelManaged: "true"},
+			want:   nil,
+		},
+		{
+			name:   "application",
+			labels: map[string]string{LabelManaged: "true", "coolify.type": "application", "com.docker.compose.project": "uuid-app"},
+			want:   &ResourceInfo{Type: ResourceTypeApplication, UUID: "uuid-app"},
+		},
+		{
+			name:   "service",
+			labels: map[string]string{LabelManaged: "true", "coolify.type": "service", "com.docker.compose.project": "uuid-svc"},
+			want:   &ResourceInfo{Type: ResourceTypeService, UUID: "uuid-svc"},
+		},
+		{
+			name:   "database",
+			labels: map[string]string{LabelManaged: "true", "coolify.type": "database", "com.docker.compose.project": "uuid-db"},
+			want:   &ResourceInfo{Type: ResourceTypeDatabase, UUID: "uuid-db"},
+		},
+		{
+			name:   "unknown type defaults to application",
+			labels: map[string]string{LabelManaged: "true", "coolify.type": "mystery", "com.docker.compose.project": "uuid-x"},
+			want:   &ResourceInfo{Type: ResourceTypeApplication, UUID: "uuid-x"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractResourceInfo(tt.labels)
+			switch {
+			case tt.want == nil && got != nil:
+				t.Errorf("got %+v, want nil", got)
+			case tt.want != nil && got == nil:
+				t.Errorf("got nil, want %+v", tt.want)
+			case tt.want != nil && (*got != *tt.want):
+				t.Errorf("got %+v, want %+v", *got, *tt.want)
+			}
+		})
+	}
+}
+
+func TestNewMultiClientEmptyReturnsNil(t *testing.T) {
+	if mc := NewMultiClient(nil); mc != nil {
+		t.Errorf("NewMultiClient(nil) = %v, want nil", mc)
+	}
+	if mc := NewMultiClient([]config.CoolifyHostConfig{}); mc != nil {
+		t.Errorf("NewMultiClient(empty) = %v, want nil", mc)
+	}
+}
+
+func TestMultiClientGetClient(t *testing.T) {
+	mc := NewMultiClient([]config.CoolifyHostConfig{
+		{HostName: "hostA", APIURL: "https://a.example", APIToken: "tok-a"},
+	})
+	if mc == nil {
+		t.Fatal("NewMultiClient returned nil for non-empty config")
+	}
+	if c := mc.GetClient("hostA"); c == nil {
+		t.Error("GetClient(hostA) = nil, want client")
+	}
+	if c := mc.GetClient("unknown"); c != nil {
+		t.Error("GetClient(unknown) = client, want nil")
+	}
+
+	// nil receiver must not panic.
+	var nilMC *MultiClient
+	if c := nilMC.GetClient("hostA"); c != nil {
+		t.Error("nil MultiClient GetClient = client, want nil")
+	}
+}
+
+func TestDoRequestSetsAuthHeader(t *testing.T) {
+	var gotAuth, gotContentType, gotMethod string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "secret-token")
+	resp, err := c.doRequest(context.Background(), http.MethodPatch, srv.URL+"/x", []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if gotAuth != "Bearer secret-token" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer secret-token")
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotMethod != http.MethodPatch {
+		t.Errorf("method = %q, want PATCH", gotMethod)
+	}
+	if string(gotBody) != `{"a":1}` {
+		t.Errorf("body = %q, want %q", gotBody, `{"a":1}`)
+	}
+	if string(resp) != `{"ok":true}` {
+		t.Errorf("resp = %q", resp)
+	}
+}
+
+func TestDoRequestNoBodyOmitsContentType(t *testing.T) {
+	var gotContentType = "sentinel"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "tok")
+	if _, err := c.doRequest(context.Background(), http.MethodGet, srv.URL, nil); err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if gotContentType != "" {
+		t.Errorf("Content-Type = %q, want empty for bodyless request", gotContentType)
+	}
+}
+
+func TestDoRequestNon2xxIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "tok")
+	if _, err := c.doRequest(context.Background(), http.MethodGet, srv.URL, nil); err == nil {
+		t.Error("expected error for 500 response, got nil")
+	}
+}
+
+func TestConnectionCallsVersionEndpoint(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "tok")
+	if err := c.TestConnection(context.Background()); err != nil {
+		t.Fatalf("TestConnection error: %v", err)
+	}
+	if gotPath != "/api/v1/version" {
+		t.Errorf("path = %q, want /api/v1/version", gotPath)
+	}
+}
+
+func TestSyncEnvVarsDatabaseUnsupported(t *testing.T) {
+	c := newClient("http://unused.invalid", "tok")
+	resource := &ResourceInfo{Type: ResourceTypeDatabase, UUID: "uuid-db"}
+	err := c.SyncEnvVars(context.Background(), resource, map[string]string{"A": "1"})
+	if err == nil {
+		t.Fatal("expected error syncing database resource, got nil")
+	}
+}
+
+// TestSyncEnvVarsDeletionAndUpsert exercises the full sync flow against a fake
+// Coolify API: it must list existing vars, delete removed non-default vars,
+// preserve Coolify-injected defaults, and bulk-upsert the current set (also
+// excluding defaults). It also verifies the pluralized URL construction.
+func TestSyncEnvVarsDeletionAndUpsert(t *testing.T) {
+	var deleted []string
+	var bulkKeys []string
+	var listPath, bulkPath string
+
+	mux := http.NewServeMux()
+	// Existing env vars in Coolify: KEEP (still present), REMOVED (should be
+	// deleted), COOLIFY_URL (default, must NOT be deleted).
+	mux.HandleFunc("/api/v1/applications/uuid-1/envs", func(w http.ResponseWriter, r *http.Request) {
+		listPath = r.URL.Path
+		existing := []coolifyEnvVar{
+			{UUID: "u-keep", Key: "KEEP"},
+			{UUID: "u-removed", Key: "REMOVED"},
+			{UUID: "u-default", Key: "COOLIFY_URL"},
+		}
+		_ = json.NewEncoder(w).Encode(existing)
+	})
+	// Bulk upsert endpoint.
+	mux.HandleFunc("/api/v1/applications/uuid-1/envs/bulk", func(w http.ResponseWriter, r *http.Request) {
+		bulkPath = r.URL.Path
+		var payload bulkEnvPayload
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		for _, e := range payload.Data {
+			bulkKeys = append(bulkKeys, e.Key)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	// Per-var delete endpoint: capture the UUID from the path.
+	mux.HandleFunc("/api/v1/applications/uuid-1/envs/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			// path: /api/v1/applications/uuid-1/envs/<uuid>
+			deleted = append(deleted, r.URL.Path[len("/api/v1/applications/uuid-1/envs/"):])
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newClient(srv.URL, "tok")
+	resource := &ResourceInfo{Type: ResourceTypeApplication, UUID: "uuid-1"}
+	newVars := map[string]string{
+		"KEEP":         "v1",
+		"NEW":          "v2",
+		"COOLIFY_BILT": "should-be-excluded", // default prefix, excluded from upsert
+	}
+	if err := c.SyncEnvVars(context.Background(), resource, newVars); err != nil {
+		t.Fatalf("SyncEnvVars error: %v", err)
+	}
+
+	// URL pluralization: "application" -> "applications".
+	if listPath != "/api/v1/applications/uuid-1/envs" {
+		t.Errorf("list path = %q", listPath)
+	}
+	if bulkPath != "/api/v1/applications/uuid-1/envs/bulk" {
+		t.Errorf("bulk path = %q", bulkPath)
+	}
+
+	// Only REMOVED should be deleted. COOLIFY_URL (default) must be preserved,
+	// KEEP is still present.
+	if len(deleted) != 1 || deleted[0] != "u-removed" {
+		t.Errorf("deleted = %v, want [u-removed]", deleted)
+	}
+
+	// Bulk upsert must contain KEEP and NEW, but exclude the COOLIFY_ default.
+	sort.Strings(bulkKeys)
+	want := []string{"KEEP", "NEW"}
+	if len(bulkKeys) != len(want) {
+		t.Fatalf("bulk keys = %v, want %v", bulkKeys, want)
+	}
+	for i := range want {
+		if bulkKeys[i] != want[i] {
+			t.Errorf("bulk keys = %v, want %v", bulkKeys, want)
+			break
+		}
+	}
+}
+
+func TestListEnvVarsParsesResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"uuid":"u1","key":"A"},{"uuid":"u2","key":"B"}]`))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "tok")
+	got, err := c.listEnvVars(context.Background(), &ResourceInfo{Type: ResourceTypeService, UUID: "uuid-s"})
+	if err != nil {
+		t.Fatalf("listEnvVars error: %v", err)
+	}
+	if len(got) != 2 || got[0].Key != "A" || got[1].UUID != "u2" {
+		t.Errorf("listEnvVars = %+v", got)
+	}
+}

--- a/server/internal/docker/logs_options_test.go
+++ b/server/internal/docker/logs_options_test.go
@@ -1,0 +1,43 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+	"github.com/docker/docker/api/types/container"
+)
+
+// buildLogsOptions must map every LogOptions field onto the SDK options, and
+// take Follow/Timestamps from its arguments (not from the struct) so the same
+// options can drive both historical and follow requests.
+func TestBuildLogsOptions(t *testing.T) {
+	opts := models.LogOptions{
+		Details:    true,
+		Since:      "1700000000",
+		Until:      "1700009999",
+		Tail:       "100",
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true, // must be ignored; the follow argument wins
+	}
+
+	got := buildLogsOptions(opts, false, true)
+	want := container.LogsOptions{
+		Follow:     false,
+		Timestamps: true,
+		Details:    true,
+		Since:      "1700000000",
+		Until:      "1700009999",
+		Tail:       "100",
+		ShowStdout: true,
+		ShowStderr: true,
+	}
+	if got != want {
+		t.Fatalf("buildLogsOptions() = %+v, want %+v", got, want)
+	}
+
+	// The follow and timestamps flags come strictly from the arguments.
+	if follow := buildLogsOptions(opts, true, false); !follow.Follow || follow.Timestamps {
+		t.Fatalf("expected follow=true timestamps=false from args, got %+v", follow)
+	}
+}

--- a/server/internal/docker/stats.go
+++ b/server/internal/docker/stats.go
@@ -240,8 +240,14 @@ func calculateMemoryStats(stats *container.StatsResponse) (percent float64, usag
 	usage = stats.MemoryStats.Usage
 	limit = stats.MemoryStats.Limit
 
-	if cache, ok := stats.MemoryStats.Stats["cache"]; ok && usage > cache {
-		usage -= cache
+	// Subtract reclaimable page cache so the figure matches `docker stats`.
+	// cgroup v1 reports it as total_inactive_file, cgroup v2 (the modern
+	// default) as inactive_file; using only the old "cache" key over-reported
+	// memory on v2 hosts, where that key is absent.
+	if v, ok := stats.MemoryStats.Stats["total_inactive_file"]; ok && v < usage {
+		usage -= v
+	} else if v, ok := stats.MemoryStats.Stats["inactive_file"]; ok && v < usage {
+		usage -= v
 	}
 
 	if limit > 0 {

--- a/server/internal/docker/stats_mem_test.go
+++ b/server/internal/docker/stats_mem_test.go
@@ -6,15 +6,17 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
-func TestCalculateMemoryStatsSubtractsCache(t *testing.T) {
+// cgroup v1 reports reclaimable page cache as total_inactive_file; it is
+// subtracted so the figure matches `docker stats`.
+func TestCalculateMemoryStatsCgroupV1(t *testing.T) {
 	var stats container.StatsResponse
 	stats.MemoryStats.Usage = 100
 	stats.MemoryStats.Limit = 200
-	stats.MemoryStats.Stats = map[string]uint64{"cache": 30}
+	stats.MemoryStats.Stats = map[string]uint64{"total_inactive_file": 30}
 
 	percent, usage, limit := calculateMemoryStats(&stats)
 	if usage != 70 {
-		t.Fatalf("usage = %d, want 70 (cache subtracted)", usage)
+		t.Fatalf("usage = %d, want 70 (total_inactive_file subtracted)", usage)
 	}
 	if limit != 200 {
 		t.Fatalf("limit = %d, want 200", limit)
@@ -24,16 +26,44 @@ func TestCalculateMemoryStatsSubtractsCache(t *testing.T) {
 	}
 }
 
-// A cache value larger than usage must not underflow the unsigned usage.
-func TestCalculateMemoryStatsCacheLargerThanUsageIgnored(t *testing.T) {
+// cgroup v2 (the modern default) reports it as inactive_file. Before this was
+// handled, the "cache" key was absent so nothing was subtracted and memory was
+// over-reported by the size of the page cache.
+func TestCalculateMemoryStatsCgroupV2(t *testing.T) {
+	var stats container.StatsResponse
+	stats.MemoryStats.Usage = 100
+	stats.MemoryStats.Limit = 200
+	stats.MemoryStats.Stats = map[string]uint64{"inactive_file": 40}
+
+	_, usage, _ := calculateMemoryStats(&stats)
+	if usage != 60 {
+		t.Fatalf("usage = %d, want 60 (inactive_file subtracted)", usage)
+	}
+}
+
+// The old raw cgroup-v1 "cache" key is no longer used on its own.
+func TestCalculateMemoryStatsIgnoresRawCache(t *testing.T) {
+	var stats container.StatsResponse
+	stats.MemoryStats.Usage = 100
+	stats.MemoryStats.Limit = 200
+	stats.MemoryStats.Stats = map[string]uint64{"cache": 30}
+
+	_, usage, _ := calculateMemoryStats(&stats)
+	if usage != 100 {
+		t.Fatalf("usage = %d, want 100 (raw cache is not subtracted)", usage)
+	}
+}
+
+// A reclaimable value larger than usage must not underflow the unsigned usage.
+func TestCalculateMemoryStatsInactiveLargerThanUsageIgnored(t *testing.T) {
 	var stats container.StatsResponse
 	stats.MemoryStats.Usage = 20
 	stats.MemoryStats.Limit = 200
-	stats.MemoryStats.Stats = map[string]uint64{"cache": 50}
+	stats.MemoryStats.Stats = map[string]uint64{"inactive_file": 50}
 
 	_, usage, _ := calculateMemoryStats(&stats)
 	if usage != 20 {
-		t.Fatalf("usage = %d, want 20 (cache subtraction skipped to avoid underflow)", usage)
+		t.Fatalf("usage = %d, want 20 (subtraction skipped to avoid underflow)", usage)
 	}
 }
 

--- a/server/internal/docker/stats_mem_test.go
+++ b/server/internal/docker/stats_mem_test.go
@@ -1,0 +1,71 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+func TestCalculateMemoryStatsSubtractsCache(t *testing.T) {
+	var stats container.StatsResponse
+	stats.MemoryStats.Usage = 100
+	stats.MemoryStats.Limit = 200
+	stats.MemoryStats.Stats = map[string]uint64{"cache": 30}
+
+	percent, usage, limit := calculateMemoryStats(&stats)
+	if usage != 70 {
+		t.Fatalf("usage = %d, want 70 (cache subtracted)", usage)
+	}
+	if limit != 200 {
+		t.Fatalf("limit = %d, want 200", limit)
+	}
+	if percent != 35.0 { // 70/200
+		t.Fatalf("percent = %f, want 35.0", percent)
+	}
+}
+
+// A cache value larger than usage must not underflow the unsigned usage.
+func TestCalculateMemoryStatsCacheLargerThanUsageIgnored(t *testing.T) {
+	var stats container.StatsResponse
+	stats.MemoryStats.Usage = 20
+	stats.MemoryStats.Limit = 200
+	stats.MemoryStats.Stats = map[string]uint64{"cache": 50}
+
+	_, usage, _ := calculateMemoryStats(&stats)
+	if usage != 20 {
+		t.Fatalf("usage = %d, want 20 (cache subtraction skipped to avoid underflow)", usage)
+	}
+}
+
+func TestCalculateMemoryStatsZeroLimit(t *testing.T) {
+	var stats container.StatsResponse
+	stats.MemoryStats.Usage = 100
+	stats.MemoryStats.Limit = 0
+
+	percent, usage, limit := calculateMemoryStats(&stats)
+	if percent != 0 {
+		t.Fatalf("percent = %f, want 0 with a zero limit (no divide by zero)", percent)
+	}
+	if usage != 100 || limit != 0 {
+		t.Fatalf("usage/limit = %d/%d, want 100/0", usage, limit)
+	}
+}
+
+func TestNumCPUs(t *testing.T) {
+	online := &container.StatsResponse{}
+	online.CPUStats.OnlineCPUs = 8
+	if got := numCPUs(online); got != 8 {
+		t.Fatalf("numCPUs with OnlineCPUs = %f, want 8", got)
+	}
+
+	percpu := &container.StatsResponse{}
+	percpu.CPUStats.CPUUsage.PercpuUsage = []uint64{1, 2, 3, 4}
+	if got := numCPUs(percpu); got != 4 {
+		t.Fatalf("numCPUs falling back to PercpuUsage = %f, want 4", got)
+	}
+
+	none := &container.StatsResponse{}
+	if got := numCPUs(none); got != 1 {
+		t.Fatalf("numCPUs with no info = %f, want 1", got)
+	}
+}

--- a/server/internal/services/registry_test.go
+++ b/server/internal/services/registry_test.go
@@ -1,0 +1,136 @@
+package services
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/AmoabaKelvin/logdeck/internal/auth"
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/coolify"
+	"github.com/AmoabaKelvin/logdeck/internal/docker"
+)
+
+func TestNewRegistryGetters(t *testing.T) {
+	dc := &docker.MultiHostClient{}
+	cc := &coolify.MultiClient{}
+	as := &auth.Service{}
+	cfg := &config.Config{ReadOnly: true}
+
+	r := NewRegistry(dc, cc, as, cfg)
+
+	if r.Docker() != dc {
+		t.Error("Docker() did not return the injected client")
+	}
+	if r.Coolify() != cc {
+		t.Error("Coolify() did not return the injected client")
+	}
+	if r.Auth() != as {
+		t.Error("Auth() did not return the injected service")
+	}
+	if r.Config() != cfg {
+		t.Error("Config() did not return the injected config")
+	}
+}
+
+func TestSwapDockerReturnsOld(t *testing.T) {
+	old := &docker.MultiHostClient{}
+	r := NewRegistry(old, nil, nil, nil)
+
+	next := &docker.MultiHostClient{}
+	returned := r.SwapDocker(next)
+
+	if returned != old {
+		t.Error("SwapDocker did not return the previous client")
+	}
+	if r.Docker() != next {
+		t.Error("Docker() did not reflect the swapped-in client")
+	}
+}
+
+func TestSwapCoolifyAndAuth(t *testing.T) {
+	r := NewRegistry(nil, nil, nil, nil)
+
+	cc := &coolify.MultiClient{}
+	r.SwapCoolify(cc)
+	if r.Coolify() != cc {
+		t.Error("SwapCoolify did not take effect")
+	}
+
+	as := &auth.Service{}
+	r.SwapAuth(as)
+	if r.Auth() != as {
+		t.Error("SwapAuth did not take effect")
+	}
+}
+
+func TestUpdateConfig(t *testing.T) {
+	r := NewRegistry(nil, nil, nil, &config.Config{ReadOnly: false})
+	next := &config.Config{ReadOnly: true}
+	r.UpdateConfig(next)
+	if r.Config() != next {
+		t.Error("UpdateConfig did not take effect")
+	}
+}
+
+// TestRegistryConcurrentReadSwapNoRace runs concurrent readers against a stream
+// of swaps. Under `go test -race` this fails if the RWMutex is dropped or a
+// reader observes a torn pointer. Each Get must return one of the two valid,
+// fully-constructed clients, never a partial state.
+func TestRegistryConcurrentReadSwapNoRace(t *testing.T) {
+	a := &docker.MultiHostClient{}
+	b := &docker.MultiHostClient{}
+	r := NewRegistry(a, nil, nil, nil)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers flip the docker client back and forth.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			toggle := a
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if toggle == a {
+						toggle = b
+					} else {
+						toggle = a
+					}
+					r.SwapDocker(toggle)
+				}
+			}
+		}()
+	}
+
+	// Readers must always see one of the two valid pointers.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					got := r.Docker()
+					if got != a && got != b {
+						t.Errorf("reader observed unexpected client %p", got)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	// Let the goroutines race for a while.
+	for i := 0; i < 5000; i++ {
+		r.Coolify()
+		r.Config()
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/server/internal/system/stats_test.go
+++ b/server/internal/system/stats_test.go
@@ -1,0 +1,78 @@
+package system
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestStatsJSONContract locks the wire field names the frontend depends on.
+func TestStatsJSONContract(t *testing.T) {
+	s := SystemStats{
+		HostInfo: HostInfo{
+			Hostname:        "box",
+			Platform:        "linux",
+			PlatformVersion: "12",
+			KernelVersion:   "6.1",
+			Arch:            "arm64",
+			Uptime:          3600,
+		},
+		Usage: Usage{
+			CPUPercent:    12.5,
+			MemoryPercent: 40.0,
+			MemoryTotal:   1000,
+			MemoryUsed:    400,
+		},
+	}
+
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if _, ok := got["hostInfo"]; !ok {
+		t.Error("missing hostInfo key")
+	}
+	if _, ok := got["usage"]; !ok {
+		t.Error("missing usage key")
+	}
+
+	var usage map[string]json.RawMessage
+	if err := json.Unmarshal(got["usage"], &usage); err != nil {
+		t.Fatalf("unmarshal usage error: %v", err)
+	}
+	for _, key := range []string{"cpuPercent", "memoryPercent", "memoryTotal", "memoryUsed"} {
+		if _, ok := usage[key]; !ok {
+			t.Errorf("usage missing %q key", key)
+		}
+	}
+}
+
+// TestInitNoHostProc verifies Init leaves HOST_PROC untouched when /host/proc
+// is not mounted (the normal case outside a container). Skipped in the unlikely
+// event the test host actually has /host/proc.
+func TestInitNoHostProc(t *testing.T) {
+	if _, err := os.Stat("/host/proc"); err == nil {
+		t.Skip("/host/proc exists on this host; positive path not covered here")
+	}
+
+	orig, had := os.LookupEnv("HOST_PROC")
+	os.Unsetenv("HOST_PROC")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("HOST_PROC", orig)
+		} else {
+			os.Unsetenv("HOST_PROC")
+		}
+	})
+
+	Init()
+
+	if v, ok := os.LookupEnv("HOST_PROC"); ok {
+		t.Errorf("Init set HOST_PROC=%q with no /host/proc present", v)
+	}
+}


### PR DESCRIPTION
A test-coverage and correctness pass, targeted with `go test -cover` data rather than a blind sweep.

Coverage added for previously-untested logic:
- `coolify` 0 → 86%, `services` 0 → 100% (registry hot-swaps, incl. a `-race` test), `config` 41 → 70%
- targeted tests for `api`/`cli`/`docker` logic (aggregate parsing, CLI query building, param clamping, `RunCommand` validation, memory-stat math)
- frontend: `ndjson`, `json-format`, `utils`, log-export helpers

One correctness fix (found during the review, proven by tests): container **memory was over-reported on cgroup v2 hosts** — it subtracted the v1-only `cache` field, absent on cgroup v2 (the modern default), so page cache counted as used. Now matches `docker stats` (subtract `total_inactive_file` on v1, `inactive_file` on v2).

Other minor findings surfaced but not applied (see conversation). Only the `clampInt` parameter rename and the memory fix change production code.