### PR TITLE
feat(mcp): env + settings tiers, and fix env edits on Podman

### DIFF
--- a/docs/app/docs/mcp/page.tsx
+++ b/docs/app/docs/mcp/page.tsx
@@ -65,6 +65,30 @@ const actionTools = [
     summary:
       "Run one non-interactive command in a container and return separate stdout, stderr, and the exit code.",
   },
+  {
+    name: "get_env / set_env",
+    gate: "--allow-env",
+    summary:
+      "Read and replace a container's environment variables. Values commonly hold secrets, and a write recreates the container, so it restarts with a new ID.",
+  },
+  {
+    name: "get_settings / set_read_only / set_log_storage",
+    gate: "--allow-settings",
+    summary:
+      "Read settings, toggle server-wide read-only mode, and change log persistence and its retention caps.",
+  },
+  {
+    name: "set_docker_hosts / set_coolify_hosts",
+    gate: "--allow-settings",
+    summary:
+      "Replace the configured hosts. Each takes the complete list rather than merging, so read get_settings first.",
+  },
+  {
+    name: "set_auth / list_api_tokens / create_api_token / delete_api_token",
+    gate: "--allow-settings",
+    summary:
+      "Change authentication and manage API tokens. Disabling auth leaves the server open to anyone who can reach it, so enable this tier deliberately.",
+  },
 ];
 
 export default function McpPage() {
@@ -210,9 +234,10 @@ export default function McpPage() {
 
       <div className="prose prose-neutral dark:prose-invert max-w-none">
         <p className="my-4 text-base">
-          Environment-variable and settings writes are intentionally not exposed
-          as tools. Client confirmation prompts are a convenience, not a
-          security boundary — the token scope and these flags are.
+          Client confirmation prompts are a convenience, not a security boundary
+          — the token scope and these flags are. A read-scoped token cannot use
+          any action tool no matter which flags are set: the server rejects
+          every mutation, and denies the env and settings surfaces outright.
         </p>
 
         <h2 className="mb-4 mt-10 text-3xl font-bold tracking-tight">Notes</h2>

--- a/server/internal/cli/mcp.go
+++ b/server/internal/cli/mcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -28,6 +29,8 @@ const mcpMaxTail = 500
 type mcpOptions struct {
 	destructive bool // remove_container
 	exec        bool // run_command
+	env         bool // get_env, set_env
+	settings    bool // settings reads and writes
 }
 
 const mcpLong = `Run a Model Context Protocol server over stdio so an AI assistant can
@@ -37,17 +40,18 @@ Read and lifecycle (start/stop/restart) tools are always registered. Sensitive
 tools are opt-in:
   --allow-destructive   register remove_container
   --allow-exec          register run_command (one-shot exec in a container)
+  --allow-env           register get_env / set_env (env vars hold secrets, and
+                        writing them recreates the container)
+  --allow-settings      register settings reads and writes, including hosts,
+                        authentication, and API tokens
   --allow-all           register all of the above
 
 The token scope is the hard boundary and is enforced by the server: a read-only
-API token is rejected on every mutation regardless of these flags, which only
-control which tools are advertised.
-
-Environment-variable and settings writes are intentionally not exposed in this
-version.`
+API token is rejected on every mutation, and on env and settings entirely,
+regardless of these flags. The flags only control which tools are advertised.`
 
 func newMCPCmd(a *app) *cobra.Command {
-	var allowDestructive, allowExec, allowAll bool
+	var allowDestructive, allowExec, allowEnv, allowSettings, allowAll bool
 
 	cmd := &cobra.Command{
 		Use:   "mcp",
@@ -58,6 +62,8 @@ func newMCPCmd(a *app) *cobra.Command {
 			opts := mcpOptions{
 				destructive: allowDestructive || allowAll,
 				exec:        allowExec || allowAll,
+				env:         allowEnv || allowAll,
+				settings:    allowSettings || allowAll,
 			}
 
 			if a.conn.token != "" && !strings.HasPrefix(a.conn.token, mcpAPITokenPrefix) {
@@ -74,6 +80,12 @@ func newMCPCmd(a *app) *cobra.Command {
 			if opts.exec {
 				tiers = append(tiers, "exec")
 			}
+			if opts.env {
+				tiers = append(tiers, "env")
+			}
+			if opts.settings {
+				tiers = append(tiers, "settings")
+			}
 			fmt.Fprintf(os.Stderr, "MCP: %s enabled - server %s\n", strings.Join(tiers, " + "), a.conn.url)
 
 			return server.Run(cmd.Context(), &mcp.StdioTransport{})
@@ -82,7 +94,9 @@ func newMCPCmd(a *app) *cobra.Command {
 
 	cmd.Flags().BoolVar(&allowDestructive, "allow-destructive", false, "register remove_container")
 	cmd.Flags().BoolVar(&allowExec, "allow-exec", false, "register run_command (one-shot exec)")
-	cmd.Flags().BoolVar(&allowAll, "allow-all", false, "register all action tools (destructive + exec)")
+	cmd.Flags().BoolVar(&allowEnv, "allow-env", false, "register get_env and set_env")
+	cmd.Flags().BoolVar(&allowSettings, "allow-settings", false, "register settings reads and writes, including auth and API tokens")
+	cmd.Flags().BoolVar(&allowAll, "allow-all", false, "register all action tools (destructive + exec + env + settings)")
 	return cmd
 }
 
@@ -398,7 +412,204 @@ func registerMCPTools(s *mcp.Server, a *app, opts mcpOptions) []string {
 		registerRunCommand(s, a, register)
 	}
 
+	if opts.env {
+		registerEnvTools(s, a, register)
+	}
+
+	if opts.settings {
+		registerSettingsTools(s, a, register)
+	}
+
 	return names
+}
+
+// registerEnvTools registers container environment-variable access. The server
+// denies /env to read-scoped tokens because the values are secrets, and a write
+// recreates the container, so set_env is marked destructive.
+func registerEnvTools(s *mcp.Server, a *app, register func(*mcp.Tool)) {
+	tool := &mcp.Tool{Name: "get_env", Description: "Read a container's environment variables. These commonly hold secrets.", Annotations: readOnlyAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in containerRef) (*mcp.CallToolResult, any, error) {
+		container, err := a.resolve(ctx, in.Container, in.Host)
+		if err != nil {
+			return nil, nil, err
+		}
+		var resp struct {
+			Env map[string]string `json:"env"`
+		}
+		if err := a.client.get(ctx, "/containers/"+container.ID+"/env", url.Values{"host": {container.Host}}, &resp); err != nil {
+			return nil, nil, err
+		}
+		return mcpJSON(resp)
+	})
+	register(tool)
+
+	type setEnvInput struct {
+		Container string            `json:"container" jsonschema:"container name or ID"`
+		Host      string            `json:"host,omitempty" jsonschema:"host name (disambiguates duplicate names)"`
+		Env       map[string]string `json:"env" jsonschema:"the complete variable map to apply; it replaces the container's existing environment, so read it with get_env first"`
+	}
+	tool = &mcp.Tool{Name: "set_env", Description: "Replace a container's environment variables. The container is recreated to apply them, so it restarts and gets a new ID.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in setEnvInput) (*mcp.CallToolResult, any, error) {
+		if len(in.Env) == 0 {
+			return nil, nil, fmt.Errorf("env is required and must be the complete variable map")
+		}
+		container, err := a.resolve(ctx, in.Container, in.Host)
+		if err != nil {
+			return nil, nil, err
+		}
+		var resp map[string]any
+		if err := a.client.put(ctx, "/containers/"+container.ID+"/env", url.Values{"host": {container.Host}}, map[string]any{"env": in.Env}, &resp); err != nil {
+			return nil, nil, err
+		}
+		return mcpJSON(resp)
+	})
+	register(tool)
+}
+
+// registerSettingsTools registers the LogDeck settings surface. The server
+// denies the whole /settings group to read-scoped tokens: it exposes host
+// topology, the token inventory, and the auth configuration.
+func registerSettingsTools(s *mcp.Server, a *app, register func(*mcp.Tool)) {
+	tool := &mcp.Tool{Name: "get_settings", Description: "Read LogDeck settings: Docker and Coolify hosts, auth state, read-only mode, and log-storage retention, each with the source it came from.", Annotations: readOnlyAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return getJSON(ctx, a, "/settings", nil)
+	})
+	register(tool)
+
+	type readOnlyInput struct {
+		Value bool `json:"value" jsonschema:"true blocks every mutating request server-wide"`
+	}
+	tool = &mcp.Tool{Name: "set_read_only", Description: "Turn LogDeck's server-wide read-only mode on or off.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in readOnlyInput) (*mcp.CallToolResult, any, error) {
+		return putJSON(ctx, a, "/settings/read-only", map[string]any{"value": in.Value})
+	})
+	register(tool)
+
+	type logStorageInput struct {
+		Enabled        *bool `json:"enabled,omitempty" jsonschema:"turn log persistence on or off"`
+		PerContainerMB *int  `json:"perContainerMB,omitempty" jsonschema:"per-container retention cap in MB"`
+		TotalMB        *int  `json:"totalMB,omitempty" jsonschema:"total retention cap in MB across all containers"`
+	}
+	tool = &mcp.Tool{Name: "set_log_storage", Description: "Update log persistence: enable or disable it, or change the retention caps. Omitted fields are left unchanged. Lowering a cap makes the next sweep evict stored logs.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in logStorageInput) (*mcp.CallToolResult, any, error) {
+		body := map[string]any{}
+		if in.Enabled != nil {
+			body["enabled"] = *in.Enabled
+		}
+		if in.PerContainerMB != nil {
+			body["perContainerMB"] = *in.PerContainerMB
+		}
+		if in.TotalMB != nil {
+			body["totalMB"] = *in.TotalMB
+		}
+		if len(body) == 0 {
+			return nil, nil, fmt.Errorf("set at least one of enabled, perContainerMB, or totalMB")
+		}
+		return putJSON(ctx, a, "/settings/log-storage", body)
+	})
+	register(tool)
+
+	type dockerHost struct {
+		Name string `json:"name" jsonschema:"host label shown in the UI"`
+		Host string `json:"host" jsonschema:"engine address, e.g. unix:///var/run/docker.sock or ssh://user@box"`
+	}
+	type dockerHostsInput struct {
+		Hosts []dockerHost `json:"hosts" jsonschema:"the complete host list; it replaces the configured hosts, so read get_settings first. Hosts pinned by environment variables are rejected"`
+	}
+	tool = &mcp.Tool{Name: "set_docker_hosts", Description: "Replace the configured Docker/Podman hosts. This is the whole list, not a merge.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in dockerHostsInput) (*mcp.CallToolResult, any, error) {
+		return putJSON(ctx, a, "/settings/docker-hosts", map[string]any{"hosts": in.Hosts})
+	})
+	register(tool)
+
+	type coolifyHost struct {
+		HostName string `json:"hostName" jsonschema:"the Docker host name this Coolify config belongs to"`
+		APIURL   string `json:"apiURL" jsonschema:"Coolify API base URL"`
+		APIToken string `json:"apiToken" jsonschema:"Coolify API token"`
+	}
+	type coolifyHostsInput struct {
+		Hosts []coolifyHost `json:"hosts" jsonschema:"the complete Coolify host list; it replaces the configured entries"`
+	}
+	tool = &mcp.Tool{Name: "set_coolify_hosts", Description: "Replace the Coolify host configuration. This is the whole list, not a merge.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in coolifyHostsInput) (*mcp.CallToolResult, any, error) {
+		return putJSON(ctx, a, "/settings/coolify-hosts", map[string]any{"hosts": in.Hosts})
+	})
+	register(tool)
+
+	type authInput struct {
+		Enabled       bool   `json:"enabled" jsonschema:"false disables login for the whole server"`
+		AdminUsername string `json:"adminUsername" jsonschema:"admin username"`
+		NewPassword   string `json:"newPassword,omitempty" jsonschema:"set a new admin password; omit to keep the current one"`
+	}
+	tool = &mcp.Tool{Name: "set_auth", Description: "Change LogDeck's authentication: enable or disable login, set the admin username, or set a new password. Disabling it leaves the server open to anyone who can reach it.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in authInput) (*mcp.CallToolResult, any, error) {
+		body := map[string]any{"enabled": in.Enabled, "adminUsername": in.AdminUsername}
+		if in.NewPassword != "" {
+			body["newPassword"] = in.NewPassword
+		}
+		return putJSON(ctx, a, "/settings/auth", body)
+	})
+	register(tool)
+
+	tool = &mcp.Tool{Name: "list_api_tokens", Description: "List API tokens with their name, scope, and prefix. The secrets themselves are never stored and cannot be read back.", Annotations: readOnlyAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return getJSON(ctx, a, "/settings/api-tokens", nil)
+	})
+	register(tool)
+
+	type createTokenInput struct {
+		Name  string `json:"name" jsonschema:"a label for the token"`
+		Scope string `json:"scope,omitempty" jsonschema:"admin (full access) or read (read-only); defaults to admin"`
+	}
+	tool = &mcp.Tool{Name: "create_api_token", Description: "Create an API token. The secret is returned once and cannot be retrieved again.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in createTokenInput) (*mcp.CallToolResult, any, error) {
+		if strings.TrimSpace(in.Name) == "" {
+			return nil, nil, fmt.Errorf("name is required")
+		}
+		body := map[string]any{"name": in.Name}
+		if in.Scope != "" {
+			body["scope"] = in.Scope
+		}
+		var resp map[string]any
+		if err := a.client.post(ctx, "/settings/api-tokens", nil, body, &resp); err != nil {
+			return nil, nil, err
+		}
+		return mcpJSON(resp)
+	})
+	register(tool)
+
+	type deleteTokenInput struct {
+		Prefix string `json:"prefix" jsonschema:"the token's prefix, as shown by list_api_tokens"`
+	}
+	tool = &mcp.Tool{Name: "delete_api_token", Description: "Revoke an API token by its prefix. Revocation takes effect immediately.", Annotations: destructiveAnnot()}
+	mcp.AddTool(s, tool, func(ctx context.Context, _ *mcp.CallToolRequest, in deleteTokenInput) (*mcp.CallToolResult, any, error) {
+		if strings.TrimSpace(in.Prefix) == "" {
+			return nil, nil, fmt.Errorf("prefix is required")
+		}
+		if err := a.client.do(ctx, http.MethodDelete, "/settings/api-tokens/"+url.PathEscape(in.Prefix), nil, nil, nil); err != nil {
+			return nil, nil, err
+		}
+		return mcpJSON(map[string]string{"message": "token revoked", "prefix": in.Prefix})
+	})
+	register(tool)
+}
+
+// getJSON and putJSON decode an endpoint's JSON body straight into a tool
+// result, for the settings tools whose shapes the CLI does not model.
+func getJSON(ctx context.Context, a *app, path string, query url.Values) (*mcp.CallToolResult, any, error) {
+	var resp map[string]any
+	if err := a.client.get(ctx, path, query, &resp); err != nil {
+		return nil, nil, err
+	}
+	return mcpJSON(resp)
+}
+
+func putJSON(ctx context.Context, a *app, path string, body any) (*mcp.CallToolResult, any, error) {
+	var resp map[string]any
+	if err := a.client.put(ctx, path, nil, body, &resp); err != nil {
+		return nil, nil, err
+	}
+	return mcpJSON(resp)
 }
 
 // containerRef is the shared input for tools that target one container.

--- a/server/internal/cli/mcp_test.go
+++ b/server/internal/cli/mcp_test.go
@@ -18,6 +18,17 @@ var readAndLifecycleTools = []string{
 	"start_container", "stop_container", "restart_container",
 }
 
+// envTools and settingsTools are advertised only behind --allow-env and
+// --allow-settings. The server denies both surfaces to read-scoped tokens
+// regardless; the flags decide what is offered to an admin-token client.
+var envTools = []string{"get_env", "set_env"}
+
+var settingsTools = []string{
+	"get_settings", "set_read_only", "set_log_storage",
+	"set_docker_hosts", "set_coolify_hosts", "set_auth",
+	"list_api_tokens", "create_api_token", "delete_api_token",
+}
+
 func registeredTools(t *testing.T, opts mcpOptions) []string {
 	t.Helper()
 	s := mcp.NewServer(&mcp.Implementation{Name: "logdeck", Version: "test"}, nil)
@@ -35,7 +46,14 @@ func TestMCPToolGating(t *testing.T) {
 		{name: "default", opts: mcpOptions{}},
 		{name: "destructive", opts: mcpOptions{destructive: true}, extra: []string{"remove_container"}},
 		{name: "exec", opts: mcpOptions{exec: true}, extra: []string{"run_command"}},
-		{name: "all", opts: mcpOptions{destructive: true, exec: true}, extra: []string{"remove_container", "run_command"}},
+		{name: "env", opts: mcpOptions{env: true}, extra: envTools},
+		{name: "settings", opts: mcpOptions{settings: true}, extra: settingsTools},
+		{
+			name: "all",
+			opts: mcpOptions{destructive: true, exec: true, env: true, settings: true},
+			extra: append(append([]string{"remove_container", "run_command"},
+				envTools...), settingsTools...),
+		},
 	}
 
 	for _, tc := range tests {

--- a/server/internal/docker/container.go
+++ b/server/internal/docker/container.go
@@ -207,10 +207,24 @@ func recreateContainerWithEnv(ctx context.Context, apiClient containerRecreateAP
 		}
 	}
 
+	// Podman reports a CPU limit as both NanoCpus and CpuQuota/CpuPeriod, but
+	// rejects a create that carries both ("NanoCpus conflicts with CpuPeriod and
+	// CpuQuota"). They express the same limit, and the quota/period pair is what
+	// the resource-update path writes on Podman, so NanoCpus is the one to drop.
+	// Copy the host config rather than mutate the shared InspectResponse.
+	hostConfig := inspect.HostConfig
+	if hostConfig != nil {
+		clone := *hostConfig
+		if clone.NanoCPUs > 0 && clone.CPUQuota > 0 {
+			clone.NanoCPUs = 0
+		}
+		hostConfig = &clone
+	}
+
 	resp, err := apiClient.ContainerCreate(
 		ctx,
 		&newConfig,
-		inspect.HostConfig,
+		hostConfig,
 		networking,
 		nil,
 		containerName,

--- a/server/internal/docker/container_test.go
+++ b/server/internal/docker/container_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 type fakeRecreateAPI struct {
-	calls         []string
-	stopErr       error
-	renameErr     error
-	createErr     error
-	startErrOn    string   // container ID whose start should fail
-	lastCreateEnv []string // env passed to the last ContainerCreate call
+	calls                []string
+	stopErr              error
+	renameErr            error
+	createErr            error
+	startErrOn           string                // container ID whose start should fail
+	lastCreateEnv        []string              // env passed to the last ContainerCreate call
+	lastCreateHostConfig *container.HostConfig // host config passed to the last ContainerCreate call
 }
 
 func (f *fakeRecreateAPI) ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error {
@@ -34,6 +35,7 @@ func (f *fakeRecreateAPI) ContainerRename(ctx context.Context, containerID, newC
 func (f *fakeRecreateAPI) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
 	f.calls = append(f.calls, "create "+containerName)
 	f.lastCreateEnv = config.Env
+	f.lastCreateHostConfig = hostConfig
 	if f.createErr != nil {
 		return container.CreateResponse{}, f.createErr
 	}
@@ -179,5 +181,61 @@ func TestRecreateContainerWithEnv(t *testing.T) {
 				t.Fatalf("expected replacement created with env [A=2], got %v", tt.api.lastCreateEnv)
 			}
 		})
+	}
+}
+
+// Podman reports a CPU limit as both NanoCpus and CpuQuota/CpuPeriod, but its
+// create rejects a host config carrying both ("NanoCpus conflicts with
+// CpuPeriod and CpuQuota"), which broke every env edit on a container whose CPU
+// limit had been set. The replacement must carry the quota/period pair alone.
+func TestRecreateContainerWithEnvDropsConflictingNanoCpus(t *testing.T) {
+	inspect := testInspectResponse(true)
+	inspect.HostConfig = &container.HostConfig{
+		Resources: container.Resources{
+			NanoCPUs:  500000000, // 0.5 CPU, the same limit the pair below expresses
+			CPUQuota:  50000,
+			CPUPeriod: 100000,
+			Memory:    256 * 1024 * 1024,
+		},
+	}
+
+	api := &fakeRecreateAPI{}
+	if _, err := recreateContainerWithEnv(context.Background(), api, inspect, []string{"A=2"}); err != nil {
+		t.Fatalf("recreateContainerWithEnv() error = %v", err)
+	}
+
+	got := api.lastCreateHostConfig
+	if got == nil {
+		t.Fatal("no host config passed to ContainerCreate")
+	}
+	if got.NanoCPUs != 0 {
+		t.Errorf("NanoCpus = %d, want 0 (it conflicts with the quota/period pair)", got.NanoCPUs)
+	}
+	if got.CPUQuota != 50000 || got.CPUPeriod != 100000 {
+		t.Errorf("quota/period = %d/%d, want 50000/100000 (the limit must survive)", got.CPUQuota, got.CPUPeriod)
+	}
+	if got.Memory != 256*1024*1024 {
+		t.Errorf("Memory = %d, want it carried over unchanged", got.Memory)
+	}
+	// The caller's inspect must not be mutated.
+	if inspect.HostConfig.NanoCPUs != 500000000 {
+		t.Error("recreate mutated the caller's HostConfig")
+	}
+}
+
+// A Docker container sets only NanoCpus, with no quota/period; that limit must
+// be left alone.
+func TestRecreateContainerWithEnvKeepsNanoCpusWhenUnambiguous(t *testing.T) {
+	inspect := testInspectResponse(true)
+	inspect.HostConfig = &container.HostConfig{
+		Resources: container.Resources{NanoCPUs: 1000000000},
+	}
+
+	api := &fakeRecreateAPI{}
+	if _, err := recreateContainerWithEnv(context.Background(), api, inspect, []string{"A=2"}); err != nil {
+		t.Fatalf("recreateContainerWithEnv() error = %v", err)
+	}
+	if api.lastCreateHostConfig.NanoCPUs != 1000000000 {
+		t.Errorf("NanoCpus = %d, want 1000000000 preserved", api.lastCreateHostConfig.NanoCPUs)
 	}
 }


### PR DESCRIPTION
Completes the MCP action surface with the two tiers that were deferred, both off by default:

- `--allow-env` — `get_env`, `set_env`
- `--allow-settings` — `get_settings`, `set_read_only`, `set_log_storage`, `set_docker_hosts`, `set_coolify_hosts`, `set_auth`, `list_api_tokens`, `create_api_token`, `delete_api_token`

The safety model is unchanged: flags only decide what's *advertised*. A read-scoped token still cannot use any of it — the server rejects every mutation and denies the env and settings surfaces outright. `set_env` is marked destructive since applying it recreates the container.

**Also fixes a real bug this surfaced.** Driving `set_env` against a live Podman container failed with `NanoCpus conflicts with CpuPeriod and CpuQuota`. Podman reports a CPU limit as *both* representations but rejects a create carrying both, and the env-update recreate passed the inspected HostConfig through verbatim — so **editing env vars was broken on any Podman container whose CPU limit had been set, including from the web UI**. The recreate now drops `NanoCPUs` when the quota/period pair is present. The regression test fails on the previous code.

Verified live against real Podman: `set_env` applied (`MCP_TEST` present in the container), the CPU limit survived the recreate, and `get_env`/`get_settings`/`list_api_tokens`/`set_log_storage` all return real data. Build, vet, tests, lint (0 issues) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in MCP tools for environment variables, settings, logs, host configuration, authentication, and API token management.
  - Added `--allow-env` and `--allow-settings` options, included in `--allow-all`.
  - Updated MCP documentation with tool tiers, enablement flags, and security guidance.

- **Bug Fixes**
  - Improved container recreation compatibility with Podman CPU limits.
  - Preserved existing resource settings while avoiding conflicting CPU configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->