### PR TITLE
refactor(mcp): drop the --allow-* flags; the token is the boundary

### DIFF
--- a/docs/app/docs/features/page.tsx
+++ b/docs/app/docs/features/page.tsx
@@ -197,8 +197,8 @@ const features: Feature[] = [
     items: [
       "Stdio MCP server (logdeck mcp) for Claude Desktop, Cursor, Claude Code, and other clients",
       "Read tools for containers, logs, cross-container search, events, stats, and stored history",
-      "Capability follows the API token: a read-scoped token cannot mutate anything",
-      "Actions are opt-in: start/stop/restart, plus --allow-destructive (remove) and --allow-exec (run_command)",
+      "Action tools for lifecycle, removal, one-shot exec, environment variables, and settings",
+      "Capability follows the API token, with no flags to configure: a read-scoped token cannot mutate anything, an admin token has the same reach it does in the UI",
       "Reuses the same HTTP API as the web UI and CLI — no new server, no new auth",
     ],
     href: "/docs/mcp",

--- a/docs/app/docs/mcp/page.tsx
+++ b/docs/app/docs/mcp/page.tsx
@@ -51,43 +51,37 @@ const readTools = [
 const actionTools = [
   {
     name: "start_container / stop_container / restart_container",
-    gate: "always registered (needs an admin token to run)",
     summary: "Reversible lifecycle actions.",
   },
   {
     name: "remove_container",
-    gate: "--allow-destructive",
-    summary: "Remove a container. Marked destructive so clients prompt harder.",
+    summary:
+      "Remove a container. Irreversible, and marked destructive so clients prompt harder.",
   },
   {
     name: "run_command",
-    gate: "--allow-exec",
     summary:
       "Run one non-interactive command in a container and return separate stdout, stderr, and the exit code.",
   },
   {
     name: "get_env / set_env",
-    gate: "--allow-env",
     summary:
       "Read and replace a container's environment variables. Values commonly hold secrets, and a write recreates the container, so it restarts with a new ID.",
   },
   {
     name: "get_settings / set_read_only / set_log_storage",
-    gate: "--allow-settings",
     summary:
       "Read settings, toggle server-wide read-only mode, and change log persistence and its retention caps.",
   },
   {
     name: "set_docker_hosts / set_coolify_hosts",
-    gate: "--allow-settings",
     summary:
       "Replace the configured hosts. Each takes the complete list rather than merging, so read get_settings first.",
   },
   {
     name: "set_auth / list_api_tokens / create_api_token / delete_api_token",
-    gate: "--allow-settings",
     summary:
-      "Change authentication and manage API tokens. Disabling auth leaves the server open to anyone who can reach it, so enable this tier deliberately.",
+      "Change authentication and manage API tokens. Disabling auth leaves the server open to anyone who can reach it.",
   },
 ];
 
@@ -152,8 +146,7 @@ export default function McpPage() {
         <p className="my-4 text-base">
           The server reads its connection from <code>LOGDECK_URL</code> and{" "}
           <code>LOGDECK_TOKEN</code> (or a saved CLI context). On startup it
-          prints, to stderr, which tool tiers are live — for example{" "}
-          <code>MCP: read + lifecycle enabled</code> — and warns if the token is
+          prints the server it is serving to stderr, and warns if the token is
           not a scoped <code>ldk_</code> API token.
         </p>
 
@@ -174,9 +167,10 @@ export default function McpPage() {
             <a href="/docs/configuration">scoped API tokens</a>.
           </li>
           <li>
-            An <strong>admin token</strong> can additionally run the action
-            tools you have enabled. You opt into that by choosing which token to
-            configure.
+            An <strong>admin token</strong> can do everything an admin can do,
+            including exec, environment variables, and settings — the same reach
+            it has in the CLI and the web UI. You opt into that simply by
+            choosing which token to configure.
           </li>
         </ul>
 
@@ -199,13 +193,12 @@ export default function McpPage() {
 
       <div className="prose prose-neutral dark:prose-invert max-w-none">
         <h2 className="mb-4 mt-10 text-3xl font-bold tracking-tight">
-          Actions are opt-in
+          Action tools
         </h2>
         <p className="mb-4 text-base">
-          Action tools are off by default and enabled with flags on the{" "}
-          <code>logdeck mcp</code> command. Even with a flag set, a read token
-          still cannot run them — the flag only decides which tools are
-          advertised.
+          These need an admin token. There are no flags to set: hand the
+          assistant the token you want it to have, exactly as you would for the
+          CLI.
         </p>
       </div>
 
@@ -213,9 +206,6 @@ export default function McpPage() {
         {actionTools.map((tool) => (
           <div key={tool.name} className="space-y-1">
             <h3 className="font-mono text-base font-semibold">{tool.name}</h3>
-            <p className="text-xs font-medium text-muted-foreground">
-              {tool.gate}
-            </p>
             <p className="text-sm text-muted-foreground">{tool.summary}</p>
           </div>
         ))}
@@ -223,21 +213,12 @@ export default function McpPage() {
 
       <div className="prose prose-neutral dark:prose-invert max-w-none">
         <p className="my-4 text-base">
-          Pass <code>--allow-all</code> to enable every action tier at once:
-        </p>
-      </div>
-
-      <CodeBlock
-        language="json"
-        code={`"args": ["mcp", "--allow-destructive", "--allow-exec"]`}
-      />
-
-      <div className="prose prose-neutral dark:prose-invert max-w-none">
-        <p className="my-4 text-base">
           Client confirmation prompts are a convenience, not a security boundary
-          — the token scope and these flags are. A read-scoped token cannot use
-          any action tool no matter which flags are set: the server rejects
-          every mutation, and denies the env and settings surfaces outright.
+          — the token scope is. A read-scoped token cannot use any action tool:
+          the server rejects every mutation, and denies the env and settings
+          surfaces outright. Destructive tools carry the protocol&apos;s
+          destructive hint, so a well-behaved client prompts harder before
+          running them.
         </p>
 
         <h2 className="mb-4 mt-10 text-3xl font-bold tracking-tight">Notes</h2>

--- a/server/internal/cli/mcp.go
+++ b/server/internal/cli/mcp.go
@@ -24,89 +24,47 @@ const mcpAPITokenPrefix = "ldk_"
 // allows 10000, which is too large for a model's context window.
 const mcpMaxTail = 500
 
-// mcpOptions selects which action tiers are advertised. The read and lifecycle
-// tiers are always registered; these gate the sensitive ones.
-type mcpOptions struct {
-	destructive bool // remove_container
-	exec        bool // run_command
-	env         bool // get_env, set_env
-	settings    bool // settings reads and writes
-}
-
 const mcpLong = `Run a Model Context Protocol server over stdio so an AI assistant can
 query and manage LogDeck through the same HTTP API the CLI uses.
 
-Read and lifecycle (start/stop/restart) tools are always registered. Sensitive
-tools are opt-in:
-  --allow-destructive   register remove_container
-  --allow-exec          register run_command (one-shot exec in a container)
-  --allow-env           register get_env / set_env (env vars hold secrets, and
-                        writing them recreates the container)
-  --allow-settings      register settings reads and writes, including hosts,
-                        authentication, and API tokens
-  --allow-all           register all of the above
+Every tool is registered, and your API token decides what actually works — the
+same way it does for the CLI and the web UI. A read-scoped token can read logs,
+stats, events, and container details, and the server rejects it on every
+mutation and on environment variables and settings outright. An admin token can
+do everything an admin can do, including exec and removing containers.
 
-The token scope is the hard boundary and is enforced by the server: a read-only
-API token is rejected on every mutation, and on env and settings entirely,
-regardless of these flags. The flags only control which tools are advertised.`
+Hand an assistant a read-scoped token from LogDeck Settings if you want it to
+look but not touch.`
 
 func newMCPCmd(a *app) *cobra.Command {
-	var allowDestructive, allowExec, allowEnv, allowSettings, allowAll bool
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "mcp",
 		Short: "Run a Model Context Protocol server over stdio",
 		Long:  mcpLong,
 		Args:  cobra.NoArgs,
 		RunE: a.run(func(cmd *cobra.Command, args []string) error {
-			opts := mcpOptions{
-				destructive: allowDestructive || allowAll,
-				exec:        allowExec || allowAll,
-				env:         allowEnv || allowAll,
-				settings:    allowSettings || allowAll,
-			}
-
 			if a.conn.token != "" && !strings.HasPrefix(a.conn.token, mcpAPITokenPrefix) {
 				fmt.Fprintln(os.Stderr, "MCP: warning: token is not an ldk_ API token; it looks like an admin session token. Prefer a scoped API token from LogDeck Settings.")
 			}
 
 			server := mcp.NewServer(&mcp.Implementation{Name: "logdeck", Version: cmd.Root().Version}, nil)
-			registerMCPTools(server, a, opts)
+			registerMCPTools(server, a)
 
-			tiers := []string{"read", "lifecycle"}
-			if opts.destructive {
-				tiers = append(tiers, "destructive")
-			}
-			if opts.exec {
-				tiers = append(tiers, "exec")
-			}
-			if opts.env {
-				tiers = append(tiers, "env")
-			}
-			if opts.settings {
-				tiers = append(tiers, "settings")
-			}
-			fmt.Fprintf(os.Stderr, "MCP: %s enabled - server %s\n", strings.Join(tiers, " + "), a.conn.url)
+			fmt.Fprintf(os.Stderr, "MCP: serving %s - your API token's scope decides what works\n", a.conn.url)
 
 			return server.Run(cmd.Context(), &mcp.StdioTransport{})
 		}),
 	}
-
-	cmd.Flags().BoolVar(&allowDestructive, "allow-destructive", false, "register remove_container")
-	cmd.Flags().BoolVar(&allowExec, "allow-exec", false, "register run_command (one-shot exec)")
-	cmd.Flags().BoolVar(&allowEnv, "allow-env", false, "register get_env and set_env")
-	cmd.Flags().BoolVar(&allowSettings, "allow-settings", false, "register settings reads and writes, including auth and API tokens")
-	cmd.Flags().BoolVar(&allowAll, "allow-all", false, "register all action tools (destructive + exec + env + settings)")
-	return cmd
 }
 
-// registerMCPTools registers the tool set for the given tiers and returns the
-// names it registered, so flag gating can be unit-tested without a live server.
-func registerMCPTools(s *mcp.Server, a *app, opts mcpOptions) []string {
+// registerMCPTools registers every tool and returns the names it registered, so
+// the set can be unit-tested without a live server. Nothing is gated here: the
+// server enforces what the caller's token scope allows.
+func registerMCPTools(s *mcp.Server, a *app) []string {
 	var names []string
 	register := func(t *mcp.Tool) { names = append(names, t.Name) }
 
-	// --- Read tier (always registered) ---
+	// --- Reads ---
 
 	type listContainersInput struct {
 		State string `json:"state,omitempty" jsonschema:"filter by state: running, exited, paused, restarting, dead"`
@@ -394,31 +352,15 @@ func registerMCPTools(s *mcp.Server, a *app, opts mcpOptions) []string {
 	})
 	register(tool)
 
-	// --- Lifecycle tier (always registered) ---
+	// --- Actions ---
 
 	registerAction(s, a, register, "start_container", "start", "started", "Start a stopped container.", lifecycleAnnot())
 	registerAction(s, a, register, "stop_container", "stop", "stopped", "Stop a running container.", lifecycleAnnot())
 	registerAction(s, a, register, "restart_container", "restart", "restarted", "Restart a container.", lifecycleAnnot())
-
-	// --- Destructive tier ---
-
-	if opts.destructive {
-		registerAction(s, a, register, "remove_container", "remove", "removed", "Remove a container. This is irreversible.", destructiveAnnot())
-	}
-
-	// --- Exec tier ---
-
-	if opts.exec {
-		registerRunCommand(s, a, register)
-	}
-
-	if opts.env {
-		registerEnvTools(s, a, register)
-	}
-
-	if opts.settings {
-		registerSettingsTools(s, a, register)
-	}
+	registerAction(s, a, register, "remove_container", "remove", "removed", "Remove a container. This is irreversible.", destructiveAnnot())
+	registerRunCommand(s, a, register)
+	registerEnvTools(s, a, register)
+	registerSettingsTools(s, a, register)
 
 	return names
 }

--- a/server/internal/cli/mcp_test.go
+++ b/server/internal/cli/mcp_test.go
@@ -7,71 +7,58 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// readAndLifecycleTools are registered regardless of the action flags. A read
-// token still cannot mutate — the server enforces that — but the lifecycle
-// tools are always advertised.
-var readAndLifecycleTools = []string{
+// allTools is the complete surface. Nothing is gated client-side: the caller's
+// token scope is what decides, and the server enforces it.
+var allTools = []string{
+	// reads
 	"list_containers", "get_logs", "search_logs", "inspect_container",
 	"list_events", "container_stats", "host_stats",
 	"list_images", "list_volumes", "list_networks",
 	"history_search", "history_status", "history_containers",
+	// container actions
 	"start_container", "stop_container", "restart_container",
-}
-
-// envTools and settingsTools are advertised only behind --allow-env and
-// --allow-settings. The server denies both surfaces to read-scoped tokens
-// regardless; the flags decide what is offered to an admin-token client.
-var envTools = []string{"get_env", "set_env"}
-
-var settingsTools = []string{
+	"remove_container", "run_command",
+	// env
+	"get_env", "set_env",
+	// settings
 	"get_settings", "set_read_only", "set_log_storage",
 	"set_docker_hosts", "set_coolify_hosts", "set_auth",
 	"list_api_tokens", "create_api_token", "delete_api_token",
 }
 
-func registeredTools(t *testing.T, opts mcpOptions) []string {
+func registeredTools(t *testing.T) []string {
 	t.Helper()
 	s := mcp.NewServer(&mcp.Implementation{Name: "logdeck", Version: "test"}, nil)
-	names := registerMCPTools(s, &app{}, opts)
+	names := registerMCPTools(s, &app{})
 	sort.Strings(names)
 	return names
 }
 
-func TestMCPToolGating(t *testing.T) {
-	tests := []struct {
-		name  string
-		opts  mcpOptions
-		extra []string
-	}{
-		{name: "default", opts: mcpOptions{}},
-		{name: "destructive", opts: mcpOptions{destructive: true}, extra: []string{"remove_container"}},
-		{name: "exec", opts: mcpOptions{exec: true}, extra: []string{"run_command"}},
-		{name: "env", opts: mcpOptions{env: true}, extra: envTools},
-		{name: "settings", opts: mcpOptions{settings: true}, extra: settingsTools},
-		{
-			name: "all",
-			opts: mcpOptions{destructive: true, exec: true, env: true, settings: true},
-			extra: append(append([]string{"remove_container", "run_command"},
-				envTools...), settingsTools...),
-		},
+func TestMCPRegistersEveryTool(t *testing.T) {
+	want := append([]string{}, allTools...)
+	sort.Strings(want)
+
+	got := registeredTools(t)
+
+	if len(got) != len(want) {
+		t.Fatalf("registered %d tools, want %d\n got:  %v\n want: %v", len(got), len(want), got, want)
 	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("tool set mismatch\n got:  %v\n want: %v", got, want)
+		}
+	}
+}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			want := append(append([]string{}, readAndLifecycleTools...), tc.extra...)
-			sort.Strings(want)
-
-			got := registeredTools(t, tc.opts)
-
-			if len(got) != len(want) {
-				t.Fatalf("registered %d tools, want %d\n got:  %v\n want: %v", len(got), len(want), got, want)
-			}
-			for i := range want {
-				if got[i] != want[i] {
-					t.Fatalf("tool set mismatch\n got:  %v\n want: %v", got, want)
-				}
-			}
-		})
+// Tool names are a client-facing contract: a rename silently breaks anyone's
+// saved prompts, so a change here should be deliberate.
+func TestMCPToolNamesAreUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for _, name := range registeredTools(t) {
+		if seen[name] {
+			t.Errorf("duplicate tool name registered: %s", name)
+		}
+		seen[name] = true
 	}
 }
 
@@ -110,15 +97,16 @@ func TestClampTail(t *testing.T) {
 	}
 }
 
-// TestMCPActionToolsGatedOff confirms the sensitive tools are absent unless
-// their flag is set — the registration surface is the advertised surface.
-func TestMCPActionToolsGatedOff(t *testing.T) {
-	got := registeredTools(t, mcpOptions{})
-	for _, name := range []string{"remove_container", "run_command"} {
-		for _, have := range got {
-			if have == name {
-				t.Errorf("%s must not be registered without its flag", name)
-			}
+// The mcp command takes no flags: capability comes from the token, not from
+// how the server was launched.
+func TestMCPCommandHasNoCapabilityFlags(t *testing.T) {
+	cmd := newMCPCmd(&app{})
+	if f := cmd.Flags().Lookup("allow-all"); f != nil {
+		t.Error("allow-all flag is back; the token scope is the boundary")
+	}
+	for _, name := range []string{"allow-destructive", "allow-exec", "allow-env", "allow-settings"} {
+		if f := cmd.Flags().Lookup(name); f != nil {
+			t.Errorf("%s flag is back; the token scope is the boundary", name)
 		}
 	}
 }


### PR DESCRIPTION
Removes the five `--allow-*` flags. Every tool is registered; the API token decides what works — the same way it does for the CLI and the web UI.

The flags were a second permission layer on top of the scoped tokens that already exist:
- They added no security. They're client-side and the operator sets them, so nothing an attacker would notice.
- They were inconsistent. The same admin token can exec from the CLI and do anything in the UI without asking twice; only MCP demanded a second yes.
- Their real effect was a silently crippled assistant: an ungated tool isn't hidden behind a helpful error, it's simply absent, so the model says "I can't do that" and the operator has no idea why. Anyone who hits that once sets `--allow-all` forever anyway.

Want a read-only assistant? Hand it a read-scoped token — that's what scoped tokens are for, and the server enforces it on every mutation plus the env and settings surfaces outright.

Kept the things that restrict nothing: `destructiveHint` annotations so clients prompt harder on remove/exec/`set_auth`, and the warning when the token isn't a scoped `ldk_` one.

Verified live: 29 tools register with no flags, `--help` carries none, banner reads `MCP: serving <url> - your API token's scope decides what works`. Build, vet, tests, lint (0 issues), docs build all green.