### PR TITLE
fix(logstore): preserve initial backfill boundary

### DIFF
--- a/server/internal/logstore/backfill.go
+++ b/server/internal/logstore/backfill.go
@@ -90,7 +90,13 @@ func (s *Store) backfill(ctx context.Context, engine Engine, info models.Contain
 	})
 
 	excluded := unreadableDriverErr(tailErr)
-	done := ingestMsg{kind: msgDone, key: key, name: name, project: project}
+	done := ingestMsg{
+		kind:     msgDone,
+		key:      key,
+		name:     name,
+		project:  project,
+		complete: tailErr == nil,
+	}
 	if excluded {
 		done.reason = tailErr.Error()
 	}
@@ -117,18 +123,23 @@ func (s *Store) backfill(ctx context.Context, engine Engine, info models.Contain
 func (s *Store) backfillSince(ctx context.Context, key genKey, createdUnix int64) (string, error) {
 	point, ok := s.takeResume(key)
 	if !ok {
+		var initialDone int
 		err := s.db.QueryRowContext(ctx,
-			"SELECT stdout_wm_ns, stderr_wm_ns FROM containers WHERE host = ? AND container_id = ?",
+			`SELECT stdout_wm_ns, stderr_wm_ns, initial_backfill_done
+			 FROM containers WHERE host = ? AND container_id = ?`,
 			key.host, key.id,
-		).Scan(&point.stdoutWM, &point.stderrWM)
+		).Scan(&point.stdoutWM, &point.stderrWM, &initialDone)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return "", err
 		}
+		point.initialDone = initialDone != 0
 	}
 
 	since := time.Unix(createdUnix, 0)
-	if wm := watermark(point.stdoutWM, point.stderrWM); wm != 0 {
-		since = time.Unix(0, wm).Add(-backfillOverlap)
+	if point.initialDone {
+		if wm := watermark(point.stdoutWM, point.stderrWM); wm != 0 {
+			since = time.Unix(0, wm).Add(-backfillOverlap)
+		}
 	}
 	if gap := s.gapAt(key); gap != 0 {
 		if from := time.Unix(0, gap).Add(-backfillOverlap); from.Before(since) {

--- a/server/internal/logstore/ingest.go
+++ b/server/internal/logstore/ingest.go
@@ -46,8 +46,11 @@ type ingestMsg struct {
 
 	line line // msgLine
 
-	// msgDone: non-empty when the generation is excluded from persistence.
-	reason string
+	// msgDone fields. complete is true only when the engine read reached EOF
+	// successfully. A transiently failed read must leave the generation's
+	// initial backfill pending so a retry still starts from creation.
+	complete bool
+	reason   string // non-empty when the generation is excluded from persistence
 }
 
 // lineFromEntry converts a parsed hub/tail entry into a storable line. The
@@ -222,6 +225,12 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 		}
 
 		if msg.kind == msgDone {
+			if msg.complete {
+				if _, err := tx.ExecContext(ctx,
+					"UPDATE containers SET initial_backfill_done = 1 WHERE id = ?", ref); err != nil {
+					return err
+				}
+			}
 			if msg.reason != "" {
 				if _, err := tx.ExecContext(ctx,
 					"UPDATE containers SET excluded_reason = ? WHERE id = ?", msg.reason, ref); err != nil {

--- a/server/internal/logstore/logstore_test.go
+++ b/server/internal/logstore/logstore_test.go
@@ -66,6 +66,20 @@ func writeEntries(t *testing.T, s *Store, key genKey, name string, entries ...mo
 	}
 }
 
+// markInitialBackfillDone models the ordered completion marker the writer
+// commits after every record from a successful engine read.
+func markInitialBackfillDone(t *testing.T, s *Store, key genKey, name string) {
+	t.Helper()
+	if err := s.commit([]ingestMsg{{
+		kind:     msgDone,
+		key:      key,
+		name:     name,
+		complete: true,
+	}}, map[genKey]int64{}); err != nil {
+		t.Fatalf("mark initial backfill done: %v", err)
+	}
+}
+
 func markRemoved(t *testing.T, s *Store, key genKey) {
 	t.Helper()
 	if _, err := s.db.Exec(
@@ -253,6 +267,7 @@ func TestWatermarkMath(t *testing.T) {
 		entryAt(baseTime.Add(5*time.Second), "stdout", "out 2"),
 		entryAt(baseTime.Add(time.Second), "stderr", "err 1"),
 	)
+	markInitialBackfillDone(t, store, key, "web")
 
 	var stdoutWM, stderrWM int64
 	if err := store.db.QueryRow(
@@ -678,6 +693,7 @@ func TestBackfillDedupAtBoundary(t *testing.T) {
 		entryAt(baseTime.Add(time.Second), "stderr", "line 2 on stderr"),
 	}
 	writeEntries(t, store, key, "web", stored...)
+	markInitialBackfillDone(t, store, key, "web")
 
 	engine := newFakeEngine(containerInfo("local", "aaa", "web", baseTime.Add(-time.Minute)))
 	// The engine re-emits everything from the requested "since", which overlaps
@@ -755,6 +771,16 @@ func TestNewGenerationBackfillsFromCreation(t *testing.T) {
 	if since := engine.opts("aaa").Since; since != created.UTC().Format(time.RFC3339Nano) {
 		t.Fatalf("Since = %s, want container creation time %s", since, created.UTC().Format(time.RFC3339Nano))
 	}
+	var initialDone int
+	if err := store.db.QueryRow(
+		"SELECT initial_backfill_done FROM containers WHERE host = ? AND container_id = ?",
+		"local", "aaa",
+	).Scan(&initialDone); err != nil {
+		t.Fatalf("read initial backfill marker: %v", err)
+	}
+	if initialDone != 1 {
+		t.Fatal("successful engine read did not durably mark the initial backfill complete")
+	}
 
 	containers, err := store.ListContainers(context.Background())
 	if err != nil {
@@ -762,6 +788,57 @@ func TestNewGenerationBackfillsFromCreation(t *testing.T) {
 	}
 	if len(containers) != 1 || containers[0].Image != "app:latest" || containers[0].ComposeProject != "demostack" {
 		t.Fatalf("engine metadata was not recorded: %+v", containers)
+	}
+}
+
+// A live tail can attach after a container has already emitted records but
+// before the lifecycle sync discovers the generation. Those live records
+// create the database row and advance its watermark. The generation has still
+// never had its initial backfill, so resuming from that live watermark would
+// permanently skip the earlier engine-retained records.
+func TestLiveWriteBeforeFirstBackfillStillStartsAtCreation(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "aaa"}
+	created := baseTime.Add(-time.Hour)
+
+	writeEntries(t, store, key, "web",
+		entryAt(baseTime, "stdout", "live tail attached after earlier records"),
+	)
+
+	since, err := store.backfillSince(context.Background(), key, created.Unix())
+	if err != nil {
+		t.Fatalf("backfillSince: %v", err)
+	}
+	want := created.UTC().Format(time.RFC3339Nano)
+	if since != want {
+		t.Fatalf("first backfill Since = %s, want container creation time %s: early retained records are skipped",
+			since, want)
+	}
+}
+
+func TestFailedInitialBackfillDoesNotAdvanceTheDurableMarker(t *testing.T) {
+	store := newTestStore(t)
+	engine := newFakeEngine(containerInfo("local", "aaa", "web", baseTime))
+	engine.tail = func(_, _ string, _ models.LogOptions, _ func(models.LogEntry)) error {
+		return errors.New("temporary engine read failure")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	store.start(ctx, &fakeHub{}, func() Engine { return engine })
+	waitFor(t, "failed backfill attempt", func() bool { return engine.calls("aaa") == 1 })
+	time.Sleep(2 * batchInterval)
+	cancel()
+	store.Wait()
+
+	var initialDone int
+	if err := store.db.QueryRow(
+		"SELECT initial_backfill_done FROM containers WHERE host = ? AND container_id = ?",
+		"local", "aaa",
+	).Scan(&initialDone); err != nil {
+		t.Fatalf("read initial backfill marker: %v", err)
+	}
+	if initialDone != 0 {
+		t.Fatal("failed engine read marked the initial backfill complete")
 	}
 }
 
@@ -913,6 +990,15 @@ func TestMigrationFromV1AddsTheForeignKey(t *testing.T) {
 	if version != schemaVersion {
 		t.Fatalf("user_version = %d, want %d", version, schemaVersion)
 	}
+	var initialDone int
+	if err := store.db.QueryRow(
+		"SELECT initial_backfill_done FROM containers WHERE id = 1",
+	).Scan(&initialDone); err != nil {
+		t.Fatalf("read migrated initial backfill marker: %v", err)
+	}
+	if initialDone != 0 {
+		t.Fatal("legacy generation was assumed complete instead of scheduling one safe creation-time reread")
+	}
 
 	page, err := store.Query(context.Background(), LogQuery{Container: "web"})
 	if err != nil {
@@ -1025,6 +1111,7 @@ func TestRestartDoesNotLoseTheDowntimeWindow(t *testing.T) {
 		t.Fatalf("Open: %v", err)
 	}
 	writeEntries(t, previous, key, "web", entryAt(baseTime, "stdout", "before the restart"))
+	markInitialBackfillDone(t, previous, key, "web")
 	if err := previous.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -1220,6 +1307,7 @@ func TestDroppedLinesAreReReadFromTheEngine(t *testing.T) {
 
 	// The next backfill resumes from the drop, even though the watermark is newer.
 	writeEntries(t, store, key, "web", entryAt(baseTime.Add(2*time.Minute), "stdout", "later line"))
+	markInitialBackfillDone(t, store, key, "web")
 	since, err := store.backfillSince(context.Background(), key, 0)
 	if err != nil {
 		t.Fatalf("backfillSince: %v", err)

--- a/server/internal/logstore/schema.go
+++ b/server/internal/logstore/schema.go
@@ -8,7 +8,7 @@ import (
 
 // schemaVersion is the current schema generation, tracked in PRAGMA
 // user_version. Bump it and add a migration step when the schema changes.
-const schemaVersion = 2
+const schemaVersion = 3
 
 // schemaV1 is the initial schema.
 //
@@ -74,6 +74,19 @@ ALTER TABLE log_lines_v2 RENAME TO log_lines;
 CREATE INDEX log_lines_container_ts ON log_lines(container_ref, ts_ns);
 `
 
+// schemaV3 distinguishes generations whose engine history has been read at
+// least once from generations known only through live ingestion. Without this
+// durable bit, a live line can advance the watermark before the first
+// lifecycle sync and make that first backfill skip earlier retained records.
+//
+// Existing rows deliberately migrate as incomplete. They are re-read once
+// from container creation after upgrade; the insert deduplication makes that
+// safe, and a one-time extra read is preferable to preserving an unknown gap.
+const schemaV3 = `
+ALTER TABLE containers
+ADD COLUMN initial_backfill_done INTEGER NOT NULL DEFAULT 0;
+`
+
 // initSchema creates the schema on a fresh database and is a no-op on an
 // already-current one. Unknown (newer) versions are rejected rather than
 // silently downgraded. A fresh database walks the same migration path as an
@@ -105,6 +118,11 @@ func initSchema(ctx context.Context, db *sql.DB) error {
 	if version < 2 {
 		if _, err := tx.ExecContext(ctx, schemaV2); err != nil {
 			return fmt.Errorf("migrate schema to version 2: %w", err)
+		}
+	}
+	if version < 3 {
+		if _, err := tx.ExecContext(ctx, schemaV3); err != nil {
+			return fmt.Errorf("migrate schema to version 3: %w", err)
 		}
 	}
 

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -297,8 +297,9 @@ func (s *Store) sink(rec logstream.Record) {
 
 // resumePoint is one generation's persisted per-stream backfill watermarks.
 type resumePoint struct {
-	stdoutWM int64
-	stderrWM int64
+	stdoutWM    int64
+	stderrWM    int64
+	initialDone bool
 }
 
 // snapshotResume records every generation's persisted resume point. It runs
@@ -307,7 +308,9 @@ type resumePoint struct {
 // last few seconds.
 func (s *Store) snapshotResume(ctx context.Context) error {
 	rows, err := s.db.QueryContext(ctx,
-		"SELECT host, container_id, stdout_wm_ns, stderr_wm_ns FROM containers")
+		`SELECT host, container_id, stdout_wm_ns, stderr_wm_ns,
+		        initial_backfill_done
+		 FROM containers`)
 	if err != nil {
 		return err
 	}
@@ -317,12 +320,20 @@ func (s *Store) snapshotResume(ctx context.Context) error {
 	defer s.mu.Unlock()
 	for rows.Next() {
 		var (
-			key   genKey
-			point resumePoint
+			key         genKey
+			point       resumePoint
+			initialDone int
 		)
-		if err := rows.Scan(&key.host, &key.id, &point.stdoutWM, &point.stderrWM); err != nil {
+		if err := rows.Scan(
+			&key.host,
+			&key.id,
+			&point.stdoutWM,
+			&point.stderrWM,
+			&initialDone,
+		); err != nil {
 			return err
 		}
+		point.initialDone = initialDone != 0
 		s.resume[key] = point
 	}
 	return rows.Err()


### PR DESCRIPTION
## Summary
- persist whether each container generation has completed its first engine backfill
- keep first backfills anchored to container creation even when live ingestion advances watermarks first
- mark completion only after an ordered engine read succeeds; failed reads remain safely retryable
- migrate existing generations as incomplete so they receive one safe, deduplicated reread after upgrade

## Validation
- `go test ./... -count=1`
- `go test -race ./internal/logstore -count=1`
- `go vet ./internal/logstore`
- real Docker regression: 10 newly started containers × 2,000 sequenced records; all 20,000 records recovered with zero missing prefixes

## Notes
- schema version advances from 2 to 3
- existing generations are reread once from creation after migration; inserts remain deduplicated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log backfill resumption to avoid skipping logs written before the first completed backfill.
  * Failed initial log reads no longer mark backfill as complete.
  * Backfill completion state is now preserved reliably across restarts.

* **Database**
  * Added an automatic migration for tracking initial backfill completion in existing installations.

* **Tests**
  * Added coverage for backfill resumption, completion persistence, failed reads, and database migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->