### PR TITLE
fix(logstore): recover live stream gaps

### DIFF
--- a/server/internal/logstore/logstore_test.go
+++ b/server/internal/logstore/logstore_test.go
@@ -558,23 +558,43 @@ func TestOpenFromConfigUnwritablePathDisablesStore(t *testing.T) {
 // --- pipeline fakes ---------------------------------------------------------
 
 type fakeHub struct {
-	mu    sync.Mutex
-	sink  func(logstream.Record)
-	unsub bool
+	mu      sync.Mutex
+	sink    func(logstream.Record)
+	recover func(logstream.RecoveryHint)
+	unsub   bool
 }
 
 func (h *fakeHub) Subscribe(_ logstream.ContainerSpec, opts models.LogOptions, sink func(logstream.Record)) func() {
+	return h.subscribe(opts, sink, nil)
+}
+
+func (h *fakeHub) SubscribeRecoverable(
+	_ logstream.ContainerSpec,
+	opts models.LogOptions,
+	sink func(logstream.Record),
+	recover func(logstream.RecoveryHint),
+) func() {
+	return h.subscribe(opts, sink, recover)
+}
+
+func (h *fakeHub) subscribe(
+	opts models.LogOptions,
+	sink func(logstream.Record),
+	recover func(logstream.RecoveryHint),
+) func() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if !opts.ShowStdout || !opts.ShowStderr || !opts.Timestamps || opts.Tail != "0" {
 		panic(fmt.Sprintf("logstore subscribed with unusable options: %+v", opts))
 	}
 	h.sink = sink
+	h.recover = recover
 	return func() {
 		h.mu.Lock()
 		defer h.mu.Unlock()
 		h.unsub = true
 		h.sink = nil
+		h.recover = nil
 	}
 }
 
@@ -585,6 +605,17 @@ func (h *fakeHub) emit(rec logstream.Record) {
 	if sink != nil {
 		sink(rec)
 	}
+}
+
+func (h *fakeHub) hint(hint logstream.RecoveryHint) bool {
+	h.mu.Lock()
+	recover := h.recover
+	h.mu.Unlock()
+	if recover == nil {
+		return false
+	}
+	recover(hint)
+	return true
 }
 
 type fakeEngine struct {
@@ -677,6 +708,37 @@ func countLines(t *testing.T, s *Store) int {
 		t.Fatalf("count lines: %v", err)
 	}
 	return count
+}
+
+func TestStoreRequestsRecoverableSubscription(t *testing.T) {
+	store := newTestStore(t)
+	hub := &fakeHub{}
+	engine := newFakeEngine()
+	ctx, cancel := context.WithCancel(context.Background())
+	store.start(ctx, hub, func() Engine { return engine })
+
+	key := genKey{"local", "aaa"}
+	if ok := hub.hint(logstream.RecoveryHint{
+		Host: key.host, ContainerID: key.id,
+	}); !ok {
+		cancel()
+		store.Wait()
+		t.Fatal("store used the lossy subscription API; stream gaps cannot trigger engine recovery")
+	}
+	if got := store.refreshAt(key); got != 1 {
+		t.Fatalf("lifecycle recovery marker = %d, want 1", got)
+	}
+
+	dropped := baseTime.Add(time.Minute)
+	hub.hint(logstream.RecoveryHint{
+		Host: key.host, ContainerID: key.id, Earliest: dropped,
+	})
+	if got := store.gapAt(key); got != dropped.UnixNano() {
+		t.Fatalf("dropped-record gap = %d, want %d", got, dropped.UnixNano())
+	}
+
+	cancel()
+	store.Wait()
 }
 
 // TestBackfillDedupAtBoundary re-reads a generation whose watermark already
@@ -1332,6 +1394,68 @@ func TestDroppedLinesAreReReadFromTheEngine(t *testing.T) {
 	}
 	if track.schedule(store, key, false) {
 		t.Fatal("a healed generation must not be re-read forever")
+	}
+}
+
+func TestRecoveryNoticeDuringBackfillIsNotClearedByThatBackfill(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "aaa"}
+	track := newBackfillTracker()
+
+	if !track.schedule(store, key, false) {
+		t.Fatal("initial backfill was not scheduled")
+	}
+	store.markRefresh(key)
+	if track.schedule(store, key, false) {
+		t.Fatal("a second backfill started while one was already in flight")
+	}
+
+	delete(track.inFlight, key)
+	track.complete(store, key)
+	if got := store.refreshAt(key); got == 0 {
+		t.Fatal("an older in-flight backfill cleared a lifecycle notice that arrived after it started")
+	}
+	if !track.schedule(store, key, false) {
+		t.Fatal("the lifecycle notice did not schedule a follow-up backfill")
+	}
+
+	delete(track.inFlight, key)
+	track.complete(store, key)
+	if got := store.refreshAt(key); got != 0 {
+		t.Fatalf("completed follow-up left lifecycle marker %d pending", got)
+	}
+	if track.schedule(store, key, false) {
+		t.Fatal("healed lifecycle boundary scheduled another backfill")
+	}
+}
+
+func TestRepeatedGapTimestampDuringBackfillRemainsPending(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "aaa"}
+	track := newBackfillTracker()
+	ts := baseTime.UnixNano()
+
+	store.markGap(key, ts)
+	if !track.schedule(store, key, false) {
+		t.Fatal("first gap did not schedule a backfill")
+	}
+	// The same record can be dropped again while the read is in flight. Its
+	// timestamp is identical, but the older read did not necessarily cover it.
+	store.markGap(key, ts)
+
+	delete(track.inFlight, key)
+	track.complete(store, key)
+	if got := store.gapAt(key); got != ts {
+		t.Fatalf("older backfill cleared repeated gap: got %d, want %d", got, ts)
+	}
+	if !track.schedule(store, key, false) {
+		t.Fatal("repeated gap did not schedule a follow-up backfill")
+	}
+
+	delete(track.inFlight, key)
+	track.complete(store, key)
+	if got := store.gapAt(key); got != 0 {
+		t.Fatalf("follow-up backfill left gap %d pending", got)
 	}
 }
 

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -59,6 +59,19 @@ type Hub interface {
 	Subscribe(spec logstream.ContainerSpec, opts models.LogOptions, sink func(logstream.Record)) func()
 }
 
+// RecoverableHub is implemented by the production logstream hub. Keeping it
+// separate from Hub preserves simple test and alert subscribers while letting
+// the store request engine rereads for upstream buffer loss and lifecycle
+// boundaries.
+type RecoverableHub interface {
+	SubscribeRecoverable(
+		spec logstream.ContainerSpec,
+		opts models.LogOptions,
+		sink func(logstream.Record),
+		recover func(logstream.RecoveryHint),
+	) func()
+}
+
 // Engine is the slice of *docker.MultiHostClient the store needs: container
 // listings for lifecycle tracking and a callback tail for backfill.
 type Engine interface {
@@ -104,10 +117,14 @@ type Store struct {
 	// resume holds every generation's persisted backfill resume point as it
 	// stood before live ingestion started; see snapshotResume.
 	resume map[genKey]resumePoint
-	// gaps holds, per generation, the earliest timestamp the sink had to drop.
-	// The sync loop re-reads the engine from there, so a full ingest buffer
-	// costs latency rather than history.
-	gaps map[genKey]int64
+	// gaps holds, per generation, the earliest timestamp a bounded buffer had
+	// to drop. Its version changes on every notice, even when the timestamp is
+	// identical, so a loss during an in-flight reread cannot be cleared by that
+	// older read completing.
+	gaps map[genKey]gapMark
+	// refresh is the versioned lifecycle-boundary signal. A zero-timestamp
+	// recovery hint rereads from the durable watermark.
+	refresh map[genKey]uint64
 	// invalidated holds the generations DeleteContainer removed, until the
 	// writer has dropped them from its ref cache. See DeleteContainer.
 	invalidated map[genKey]struct{}
@@ -200,7 +217,8 @@ func Open(path string, limits Limits) (*Store, error) {
 		ingestCh:    make(chan ingestMsg, ingestBuffer),
 		retainCh:    make(chan struct{}, 1),
 		resume:      make(map[genKey]resumePoint),
-		gaps:        make(map[genKey]int64),
+		gaps:        make(map[genKey]gapMark),
+		refresh:     make(map[genKey]uint64),
 		invalidated: make(map[genKey]struct{}),
 		backfillSem: make(chan struct{}, maxConcurrentBackfills),
 	}, nil
@@ -223,11 +241,17 @@ func (s *Store) start(ctx context.Context, hub Hub, source func() Engine) {
 
 	// The hub sink is a producer: it must stop before ingestCh is closed.
 	s.producers.Add(1)
-	unsubscribe := hub.Subscribe(
-		logstream.ContainerSpec{}, // all containers on all hosts
-		models.LogOptions{Follow: true, Timestamps: true, Tail: "0", ShowStdout: true, ShowStderr: true},
-		s.sink,
-	)
+	spec := logstream.ContainerSpec{} // all containers on all hosts
+	opts := models.LogOptions{
+		Follow: true, Timestamps: true, Tail: "0",
+		ShowStdout: true, ShowStderr: true,
+	}
+	var unsubscribe func()
+	if recoverable, ok := hub.(RecoverableHub); ok {
+		unsubscribe = recoverable.SubscribeRecoverable(spec, opts, s.sink, s.recover)
+	} else {
+		unsubscribe = hub.Subscribe(spec, opts, s.sink)
+	}
 
 	s.workers.Add(1)
 	go func() {
@@ -295,6 +319,15 @@ func (s *Store) sink(rec logstream.Record) {
 	}
 }
 
+func (s *Store) recover(hint logstream.RecoveryHint) {
+	key := genKey{host: hint.Host, id: hint.ContainerID}
+	if hint.Earliest.IsZero() {
+		s.markRefresh(key)
+		return
+	}
+	s.markGap(key, hint.Earliest.UnixNano())
+}
+
 // resumePoint is one generation's persisted per-stream backfill watermarks.
 type resumePoint struct {
 	stdoutWM    int64
@@ -357,29 +390,64 @@ func (s *Store) clearResume(key genKey) {
 	delete(s.resume, key)
 }
 
-// markGap records the earliest dropped timestamp for a generation.
+type gapMark struct {
+	from    int64
+	version uint64
+}
+
+// markGap records the earliest dropped timestamp for a generation and advances
+// the notice version even if a repeated line has the same timestamp.
 func (s *Store) markGap(key genKey, tsNS int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if from, ok := s.gaps[key]; !ok || tsNS < from {
-		s.gaps[key] = tsNS
+	mark := s.gaps[key]
+	mark.version++
+	if mark.from == 0 || tsNS < mark.from {
+		mark.from = tsNS
 	}
+	s.gaps[key] = mark
 }
 
 // gapAt reports the generation's outstanding gap, or 0 when it has none.
 func (s *Store) gapAt(key genKey) int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.gaps[key].from
+}
+
+func (s *Store) gapSnapshot(key genKey) gapMark {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.gaps[key]
 }
 
-// clearGap retires a healed gap, unless an even older line was dropped while
-// the backfill was running.
-func (s *Store) clearGap(key genKey, healed int64) {
+// clearGap retires only the exact notice version a backfill captured. A new
+// drop during that read remains pending even when it has the same timestamp.
+func (s *Store) clearGap(key genKey, healed gapMark) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.gaps[key] == healed {
+	if s.gaps[key].version == healed.version {
 		delete(s.gaps, key)
+	}
+}
+
+func (s *Store) markRefresh(key genKey) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refresh[key]++
+}
+
+func (s *Store) refreshAt(key genKey) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refresh[key]
+}
+
+func (s *Store) clearRefresh(key genKey, healed uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.refresh[key] == healed {
+		delete(s.refresh, key)
 	}
 }
 

--- a/server/internal/logstore/sync.go
+++ b/server/internal/logstore/sync.go
@@ -69,18 +69,20 @@ func (s *Store) syncLoop(ctx context.Context, source func() Engine) {
 // generations have been read, which are being read, how many times reading them
 // has failed, and which dropped-line gap the current read is healing.
 type backfillTracker struct {
-	attempts map[genKey]int
-	done     map[genKey]bool
-	inFlight map[genKey]bool
-	healing  map[genKey]int64
+	attempts   map[genKey]int
+	done       map[genKey]bool
+	inFlight   map[genKey]bool
+	healing    map[genKey]gapMark
+	refreshing map[genKey]uint64
 }
 
 func newBackfillTracker() *backfillTracker {
 	return &backfillTracker{
-		attempts: make(map[genKey]int),
-		done:     make(map[genKey]bool),
-		inFlight: make(map[genKey]bool),
-		healing:  make(map[genKey]int64),
+		attempts:   make(map[genKey]int),
+		done:       make(map[genKey]bool),
+		inFlight:   make(map[genKey]bool),
+		healing:    make(map[genKey]gapMark),
+		refreshing: make(map[genKey]uint64),
 	}
 }
 
@@ -88,8 +90,11 @@ func newBackfillTracker() *backfillTracker {
 // is read once; a fresh dropped-line gap makes it eligible again with a fresh
 // retry budget, so a spent budget can never block gap healing.
 func (t *backfillTracker) schedule(s *Store, key genKey, excluded bool) bool {
-	if gap := s.gapAt(key); gap != 0 && gap != t.healing[key] {
-		t.healing[key] = gap
+	gap := s.gapSnapshot(key)
+	refresh := s.refreshAt(key)
+	newGap := gap.version != 0 && gap.version != t.healing[key].version
+	newRefresh := refresh != 0 && refresh != t.refreshing[key]
+	if newGap || newRefresh {
 		delete(t.done, key)
 		delete(t.attempts, key)
 	}
@@ -97,6 +102,12 @@ func (t *backfillTracker) schedule(s *Store, key genKey, excluded bool) bool {
 		return false
 	}
 	t.inFlight[key] = true
+	if gap.version != 0 {
+		t.healing[key] = gap
+	}
+	if refresh != 0 {
+		t.refreshing[key] = refresh
+	}
 	return true
 }
 
@@ -106,9 +117,13 @@ func (t *backfillTracker) complete(s *Store, key genKey) {
 	t.done[key] = true
 	delete(t.attempts, key)
 	s.clearResume(key)
-	if healed := t.healing[key]; healed != 0 {
+	if healed := t.healing[key]; healed.version != 0 {
 		s.clearGap(key, healed)
 		delete(t.healing, key)
+	}
+	if refreshed := t.refreshing[key]; refreshed != 0 {
+		s.clearRefresh(key, refreshed)
+		delete(t.refreshing, key)
 	}
 }
 

--- a/server/internal/logstream/logstream.go
+++ b/server/internal/logstream/logstream.go
@@ -40,6 +40,16 @@ type Record struct {
 	Entry         models.LogEntry
 }
 
+// RecoveryHint tells a persistence subscriber that the live stream may have
+// skipped engine-retained records. Earliest is set when the exact oldest
+// dropped record is known. A zero value means reread from the subscriber's
+// durable watermark, as at a container lifecycle boundary.
+type RecoveryHint struct {
+	Host        string
+	ContainerID string
+	Earliest    time.Time
+}
+
 // ContainerSpec selects containers to tail. All dimensions are optional and
 // ANDed together; an empty slice matches everything in that dimension.
 type ContainerSpec struct {
@@ -178,10 +188,34 @@ func (h *Hub) Subscribe(spec ContainerSpec, opts models.LogOptions, sink func(Re
 	return unsubscribe
 }
 
+// SubscribeRecoverable is Subscribe plus recovery notifications for subscribers
+// that can reread the engine, such as the persistent log store. The callback
+// must return promptly. Ordinary live consumers use Subscribe and accept
+// bounded-buffer loss.
+func (h *Hub) SubscribeRecoverable(
+	spec ContainerSpec,
+	opts models.LogOptions,
+	sink func(Record),
+	recover func(RecoveryHint),
+) (unsubscribe func()) {
+	opts.Follow = true
+	_, unsubscribe = h.subscribeRecoverable(spec, opts, sink, recover)
+	return unsubscribe
+}
+
 // subscribe is the internal form of Subscribe that also exposes the
 // subscription handle (used by tests to observe drop counters).
 func (h *Hub) subscribe(spec ContainerSpec, opts models.LogOptions, sink func(Record)) (*subscription, func()) {
-	sub := newSubscription(spec, opts, sink)
+	return h.subscribeRecoverable(spec, opts, sink, nil)
+}
+
+func (h *Hub) subscribeRecoverable(
+	spec ContainerSpec,
+	opts models.LogOptions,
+	sink func(Record),
+	recover func(RecoveryHint),
+) (*subscription, func()) {
+	sub := newSubscription(spec, opts, sink, recover)
 	registered := h.do(func() {
 		h.subs[sub] = struct{}{}
 		go sub.deliverLoop()
@@ -306,8 +340,10 @@ func (h *Hub) requestList() {
 	}()
 }
 
-// handleEvent is the fast path: start spawns matching tails immediately,
-// die/destroy cancel them, rename is treated as destroy plus a re-list.
+// handleEvent is the fast path: start spawns matching tails immediately;
+// die/destroy let the engine response drain and ask recoverable subscribers for
+// a final reread; rename cancels and re-lists because the selection metadata
+// changed.
 func (h *Hub) handleEvent(ev docker.EngineEvent) {
 	base, _, _ := strings.Cut(ev.Action, ": ")
 	switch base {
@@ -315,8 +351,15 @@ func (h *Hub) handleEvent(ev docker.EngineEvent) {
 		name := strings.TrimPrefix(ev.ContainerName, "/")
 		key := containerKey{host: ev.Host, id: ev.ContainerID}
 		for sub := range h.subs {
-			if _, ok := sub.tails[key]; ok {
-				continue
+			if current, ok := sub.tails[key]; ok {
+				if !current.draining.Load() {
+					continue
+				}
+				// A fast restart can arrive before the old followed response
+				// reaches EOF. Its recovery marker is already set; replace it
+				// now so the new run is tailed without waiting for resync.
+				current.cancel()
+				delete(sub.tails, key)
 			}
 			if !sub.spec.Matches(ev.Host, name, ev.Labels) {
 				continue
@@ -324,7 +367,15 @@ func (h *Hub) handleEvent(ev docker.EngineEvent) {
 			h.spawnTail(sub, key, name, ev.Labels)
 		}
 	case "die", "destroy":
-		h.cancelTails(containerKey{host: ev.Host, id: ev.ContainerID})
+		key := containerKey{host: ev.Host, id: ev.ContainerID}
+		for sub := range h.subs {
+			if current, ok := sub.tails[key]; ok {
+				current.draining.Store(true)
+				sub.requestRecovery(RecoveryHint{
+					Host: key.host, ContainerID: key.id,
+				})
+			}
+		}
 	case "rename":
 		h.cancelTails(containerKey{host: ev.Host, id: ev.ContainerID})
 		h.requestList()
@@ -398,6 +449,9 @@ func (h *Hub) handleList(res listResult) {
 			if meta, ok := running[key]; ok && sub.spec.Matches(key.host, meta.name, meta.labels) {
 				continue
 			}
+			sub.requestRecovery(RecoveryHint{
+				Host: key.host, ContainerID: key.id,
+			})
 			t.cancel()
 			delete(sub.tails, key)
 		}
@@ -421,6 +475,9 @@ func (h *Hub) handleTailExit(ex tailExit) {
 		return
 	}
 	if current, ok := ex.sub.tails[ex.key]; ok && current == ex.t {
+		ex.sub.requestRecovery(RecoveryHint{
+			Host: ex.key.host, ContainerID: ex.key.id,
+		})
 		delete(ex.sub.tails, ex.key)
 	}
 }

--- a/server/internal/logstream/logstream_test.go
+++ b/server/internal/logstream/logstream_test.go
@@ -273,8 +273,17 @@ func TestStartEventSpawnsTail(t *testing.T) {
 	waitFor(t, "start event to spawn tail", func() bool { return f.activeTails(containerKey{"h1", "c9"}) == 1 })
 }
 
-func TestDieEventCancelsTail(t *testing.T) {
+func TestDieEventLetsTailDrainBeforeItStops(t *testing.T) {
+	release := make(chan struct{})
 	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		<-release
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		emit(models.LogEntry{Message: "final buffered record"})
+		return nil
+	}
 	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
 	h := startHub(t, func() engineClient { return f })
 
@@ -284,12 +293,55 @@ func TestDieEventCancelsTail(t *testing.T) {
 	waitFor(t, "tail to start", func() bool { return f.activeTails(key) == 1 })
 
 	f.set(map[string][]models.ContainerInfo{"h1": {}}, nil)
-	f.events <- docker.EngineEvent{Host: "h1", ContainerID: "c1", ContainerName: "web", Action: "die"}
-
-	waitFor(t, "die event to cancel tail", func() bool { return f.activeTails(key) == 0 })
-	if n := f.totalStarts(key); n != 1 {
-		t.Errorf("tail restarted after die: %d starts", n)
+	handled := make(chan struct{})
+	if !h.do(func() {
+		h.handleEvent(docker.EngineEvent{
+			Host: "h1", ContainerID: "c1", ContainerName: "web", Action: "die",
+		})
+		close(handled)
+	}) {
+		t.Fatal("hub stopped before processing die event")
 	}
+	<-handled
+
+	// Allow the Docker response to finish only after the event was handled. If
+	// die cancelled the tail, the final record is discarded.
+	close(release)
+
+	waitFor(t, "final buffered record to drain", func() bool { return rec.len() == 1 })
+	waitFor(t, "cleanly ended tail to stop", func() bool { return f.activeTails(key) == 0 })
+	if n := f.totalStarts(key); n != 1 {
+		t.Errorf("cleanly ended tail restarted after die: %d starts", n)
+	}
+}
+
+func TestStartAfterDieReplacesDrainingTail(t *testing.T) {
+	f := newFakeClient()
+	f.set(map[string][]models.ContainerInfo{"h1": {ctr("c1", "web", "running", nil)}}, nil)
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	h.Subscribe(ContainerSpec{}, models.LogOptions{}, rec.sink)
+	key := containerKey{"h1", "c1"}
+	waitFor(t, "first run tail", func() bool { return f.activeTails(key) == 1 })
+
+	handled := make(chan struct{})
+	if !h.do(func() {
+		h.handleEvent(docker.EngineEvent{
+			Host: "h1", ContainerID: "c1", ContainerName: "web", Action: "die",
+		})
+		h.handleEvent(docker.EngineEvent{
+			Host: "h1", ContainerID: "c1", ContainerName: "web", Action: "start",
+		})
+		close(handled)
+	}) {
+		t.Fatal("hub stopped before processing restart events")
+	}
+	<-handled
+
+	waitFor(t, "new run tail", func() bool {
+		return f.totalStarts(key) == 2 && f.activeTails(key) == 1
+	})
 }
 
 func TestUnsubscribeCancelsAndIsIdempotent(t *testing.T) {
@@ -354,10 +406,23 @@ func TestSlowSinkDropsOldestAndTailKeepsReading(t *testing.T) {
 
 	gate := make(chan struct{})
 	rec := &recorder{}
-	sub, unsubscribe := h.subscribe(ContainerSpec{}, models.LogOptions{}, func(r Record) {
-		<-gate
-		rec.sink(r)
-	})
+	var (
+		hintsMu sync.Mutex
+		hints   []RecoveryHint
+	)
+	sub, unsubscribe := h.subscribeRecoverable(
+		ContainerSpec{},
+		models.LogOptions{},
+		func(r Record) {
+			<-gate
+			rec.sink(r)
+		},
+		func(hint RecoveryHint) {
+			hintsMu.Lock()
+			defer hintsMu.Unlock()
+			hints = append(hints, hint)
+		},
+	)
 	defer unsubscribe()
 
 	// The tail must finish all pushes while the sink is stuck: it never blocks.
@@ -370,6 +435,12 @@ func TestSlowSinkDropsOldestAndTailKeepsReading(t *testing.T) {
 	drops := sub.drops.Load()
 	if drops < uint64(total-ringSize-1) {
 		t.Fatalf("drop counter = %d, want >= %d", drops, total-ringSize-1)
+	}
+	hintsMu.Lock()
+	hintCount := len(hints)
+	hintsMu.Unlock()
+	if hintCount != int(drops) {
+		t.Fatalf("recovery hints = %d, want one for each of %d dropped records", hintCount, drops)
 	}
 
 	close(gate)

--- a/server/internal/logstream/subscription.go
+++ b/server/internal/logstream/subscription.go
@@ -23,6 +23,9 @@ type subscription struct {
 	spec ContainerSpec
 	opts models.LogOptions
 	sink func(Record)
+	// recover is set only for subscribers that can reread the engine. It must
+	// return promptly; push calls it on the tail goroutine.
+	recover func(RecoveryHint)
 
 	// tails is owned exclusively by the hub's run loop goroutine.
 	tails map[containerKey]*tail
@@ -39,11 +42,17 @@ type subscription struct {
 	delivered chan struct{} // closed when the delivery goroutine exits
 }
 
-func newSubscription(spec ContainerSpec, opts models.LogOptions, sink func(Record)) *subscription {
+func newSubscription(
+	spec ContainerSpec,
+	opts models.LogOptions,
+	sink func(Record),
+	recover func(RecoveryHint),
+) *subscription {
 	s := &subscription{
 		spec:      spec,
 		opts:      opts,
 		sink:      sink,
+		recover:   recover,
 		tails:     make(map[containerKey]*tail),
 		buf:       make([]Record, ringSize),
 		delivered: make(chan struct{}),
@@ -61,7 +70,9 @@ func (s *subscription) push(r Record) {
 		return
 	}
 	dropped := false
+	var lost Record
 	if s.count == len(s.buf) {
+		lost = s.buf[s.head]
 		s.buf[s.head] = Record{}
 		s.head = (s.head + 1) % len(s.buf)
 		s.count--
@@ -73,9 +84,22 @@ func (s *subscription) push(r Record) {
 	s.mu.Unlock()
 
 	if dropped {
+		s.requestRecovery(RecoveryHint{
+			Host:        lost.Host,
+			ContainerID: lost.ContainerID,
+			Earliest:    lost.Entry.Timestamp,
+		})
 		if n := s.drops.Add(1); n%dropLogEvery == 0 {
 			log.Printf("logstream: subscription %+v dropped %d records (slow sink)", s.spec, n)
 		}
+	}
+}
+
+// requestRecovery is intentionally called without s.mu held: the receiver may
+// take its own lock, and a persistence callback must never stall buffer access.
+func (s *subscription) requestRecovery(hint RecoveryHint) {
+	if s.recover != nil {
+		s.recover(hint)
 	}
 }
 

--- a/server/internal/logstream/tail.go
+++ b/server/internal/logstream/tail.go
@@ -3,6 +3,7 @@ package logstream
 import (
 	"context"
 	"log"
+	"sync/atomic"
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
@@ -14,7 +15,8 @@ const maxTailAttempts = 5
 
 // tail is the run loop's handle to one tail goroutine.
 type tail struct {
-	cancel context.CancelFunc
+	cancel   context.CancelFunc
+	draining atomic.Bool // set by the run loop after die/destroy
 }
 
 // spawnTail starts a tail goroutine for one (subscription, container) pair.
@@ -31,7 +33,7 @@ func (h *Hub) spawnTail(sub *subscription, key containerKey, name string, labels
 	go func() {
 		defer h.tailWg.Done()
 		defer cancel()
-		h.runTail(ctx, client, sub, key, name, labels)
+		h.runTail(ctx, client, sub, t, key, name, labels)
 		// Tell the loop this tail is gone so resync can respawn it. Skipped
 		// on shutdown, when the loop is no longer receiving.
 		select {
@@ -44,7 +46,15 @@ func (h *Hub) spawnTail(sub *subscription, key containerKey, name string, labels
 // runTail opens the log tail and keeps it open while desired, retrying with
 // exponential backoff when the stream ends prematurely. Returns when ctx is
 // cancelled (tail no longer desired) or after maxTailAttempts.
-func (h *Hub) runTail(ctx context.Context, client engineClient, sub *subscription, key containerKey, name string, labels map[string]string) {
+func (h *Hub) runTail(
+	ctx context.Context,
+	client engineClient,
+	sub *subscription,
+	t *tail,
+	key containerKey,
+	name string,
+	labels map[string]string,
+) {
 	emit := func(entry models.LogEntry) {
 		sub.push(Record{
 			Host:          key.host,
@@ -59,6 +69,13 @@ func (h *Hub) runTail(ctx context.Context, client engineClient, sub *subscriptio
 	for attempt := 1; ; attempt++ {
 		err := client.openTail(ctx, key.host, key.id, sub.opts, emit)
 		if ctx.Err() != nil {
+			return
+		}
+		// A clean EOF after die/destroy means Docker drained the followed
+		// response. Without a lifecycle boundary, preserve the existing retry
+		// behavior: a daemon or proxy can close an otherwise-live stream with a
+		// plain EOF, and waiting for the minute resync would create a long gap.
+		if err == nil && t.draining.Load() {
 			return
 		}
 		if attempt >= maxTailAttempts {


### PR DESCRIPTION
## Summary

- report recoverable loss whenever the live subscription ring buffer evicts a record
- keep a stopped container's tail alive long enough to drain buffered output, while still replacing that tail on a fast restart
- schedule bounded Docker backfills from the exact oldest dropped timestamp, or from the durable watermark when lifecycle timing makes that boundary unknown
- version recovery notices so a notice arriving during an in-flight backfill cannot be cleared by that older read

## Why

The live tail previously had two silent-loss paths:

1. a `die`/`destroy` event cancelled the tail immediately, so records already buffered by Docker could be lost
2. the subscription ring intentionally dropped its oldest record under sustained backpressure, but LogStore was not told to repair that gap

This keeps the non-blocking stream design while making both cases recoverable from Docker's durable log source.

## Validation

- `go test ./... -count=1`
- `go test -race ./internal/logstream ./internal/logstore -count=1`
- `go vet ./internal/logstream ./internal/logstore`
- real Docker exit stress: LogStore had 16,503 / 100,000 records immediately after exit and recovered to exactly 100,000 without restarting LogDeck; no missing or duplicate sequence numbers
- real Docker live-burst stress: LogStore had 49,934 / 100,000 records immediately after the burst and recovered to exactly 100,000 while the container remained running; no missing or duplicate sequence numbers

## Stack

This PR is intentionally based on #104. Merge #104 first, then retarget or merge this PR into `main`.