### PR TITLE
fix(logstore): reconcile recoverable gaps immediately

### DIFF
--- a/server/internal/logstore/logstore_test.go
+++ b/server/internal/logstore/logstore_test.go
@@ -741,6 +741,32 @@ func TestStoreRequestsRecoverableSubscription(t *testing.T) {
 	store.Wait()
 }
 
+func TestRecoveryHintTriggersImmediateBackfill(t *testing.T) {
+	store := newTestStore(t)
+	hub := &fakeHub{}
+	engine := newFakeEngine(containerInfo("local", "aaa", "web", baseTime))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		store.Wait()
+	}()
+
+	store.start(ctx, hub, func() Engine { return engine })
+	waitFor(t, "initial backfill", func() bool { return engine.calls("aaa") == 1 })
+
+	if ok := hub.hint(logstream.RecoveryHint{
+		Host: "local", ContainerID: "aaa",
+	}); !ok {
+		t.Fatal("store did not register a recoverable subscription")
+	}
+
+	// syncInterval is 15 seconds. The ordinary test deadline is five seconds,
+	// so this can pass only through the event-driven recovery wake.
+	waitFor(t, "recovery backfill before the periodic sync", func() bool {
+		return engine.calls("aaa") >= 2
+	})
+}
+
 // TestBackfillDedupAtBoundary re-reads a generation whose watermark already
 // covers part of the engine's output: the overlapping lines must not be stored
 // twice, and the lines that are genuinely new must land.

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -138,6 +138,10 @@ type Store struct {
 
 	// backfillState is owned by the sync loop.
 	backfillSem chan struct{}
+	// reconcileCh coalesces loss and lifecycle notices into an immediate
+	// lifecycle pass. The periodic sync remains the safety net, but recoverable
+	// gaps should not sit pending until its next tick.
+	reconcileCh chan struct{}
 }
 
 // DBPath returns the log database path that sits next to the config file
@@ -221,6 +225,7 @@ func Open(path string, limits Limits) (*Store, error) {
 		refresh:     make(map[genKey]uint64),
 		invalidated: make(map[genKey]struct{}),
 		backfillSem: make(chan struct{}, maxConcurrentBackfills),
+		reconcileCh: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -328,6 +333,16 @@ func (s *Store) recover(hint logstream.RecoveryHint) {
 	s.markGap(key, hint.Earliest.UnixNano())
 }
 
+// requestReconcile wakes the lifecycle loop without ever blocking a live-log
+// delivery goroutine. One pending wake is sufficient: a reconciliation reads
+// every outstanding generation marker.
+func (s *Store) requestReconcile() {
+	select {
+	case s.reconcileCh <- struct{}{}:
+	default:
+	}
+}
+
 // resumePoint is one generation's persisted per-stream backfill watermarks.
 type resumePoint struct {
 	stdoutWM    int64
@@ -399,13 +414,18 @@ type gapMark struct {
 // the notice version even if a repeated line has the same timestamp.
 func (s *Store) markGap(key genKey, tsNS int64) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	mark := s.gaps[key]
+	wasPending := mark.version != 0
 	mark.version++
 	if mark.from == 0 || tsNS < mark.from {
 		mark.from = tsNS
 	}
 	s.gaps[key] = mark
+	s.mu.Unlock()
+
+	if !wasPending {
+		s.requestReconcile()
+	}
 }
 
 // gapAt reports the generation's outstanding gap, or 0 when it has none.
@@ -433,8 +453,13 @@ func (s *Store) clearGap(key genKey, healed gapMark) {
 
 func (s *Store) markRefresh(key genKey) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	wasPending := s.refresh[key] != 0
 	s.refresh[key]++
+	s.mu.Unlock()
+
+	if !wasPending {
+		s.requestReconcile()
+	}
 }
 
 func (s *Store) refreshAt(key genKey) uint64 {

--- a/server/internal/logstore/sync.go
+++ b/server/internal/logstore/sync.go
@@ -53,7 +53,19 @@ func (s *Store) syncLoop(ctx context.Context, source func() Engine) {
 				}
 			default:
 				track.complete(s, res.key)
+				// A newer loss/lifecycle notice may have arrived while this
+				// finite engine read was in flight. Its version deliberately
+				// survives complete; wake a follow-up read now instead of
+				// waiting for the periodic lifecycle poll.
+				if s.gapAt(res.key) != 0 || s.refreshAt(res.key) != 0 {
+					s.requestReconcile()
+				}
 			}
+		case <-s.reconcileCh:
+			if ctx.Err() != nil {
+				return
+			}
+			s.sync(ctx, source(), track, results)
 		case <-ticker.C:
 			// select picks a ready case at random: a tick can win over a Done that
 			// is ready too.


### PR DESCRIPTION
This pull request was automatically closed when its head branch was renamed. The branch now contains only the product recovery fix; a clean replacement pull request will be opened from `fix/logstore-immediate-recovery` after validation completes.