### PR TITLE
fix(logstore): reconcile recovery and live attachment gaps

### DIFF
--- a/server/internal/logstore/logstore_test.go
+++ b/server/internal/logstore/logstore_test.go
@@ -561,6 +561,7 @@ type fakeHub struct {
 	mu      sync.Mutex
 	sink    func(logstream.Record)
 	recover func(logstream.RecoveryHint)
+	opts    models.LogOptions
 	unsub   bool
 }
 
@@ -584,9 +585,10 @@ func (h *fakeHub) subscribe(
 ) func() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if !opts.ShowStdout || !opts.ShowStderr || !opts.Timestamps || opts.Tail != "0" {
+	if !opts.ShowStdout || !opts.ShowStderr || !opts.Timestamps {
 		panic(fmt.Sprintf("logstore subscribed with unusable options: %+v", opts))
 	}
+	h.opts = opts
 	h.sink = sink
 	h.recover = recover
 	return func() {
@@ -716,6 +718,13 @@ func TestStoreRequestsRecoverableSubscription(t *testing.T) {
 	engine := newFakeEngine()
 	ctx, cancel := context.WithCancel(context.Background())
 	store.start(ctx, hub, func() Engine { return engine })
+
+	hub.mu.Lock()
+	tail := hub.opts.Tail
+	hub.mu.Unlock()
+	if tail != "1" {
+		t.Fatalf("logstore live tail = %q, want one-record overlap at the attachment boundary", tail)
+	}
 
 	key := genKey{"local", "aaa"}
 	if ok := hub.hint(logstream.RecoveryHint{

--- a/server/internal/logstore/logstore_test.go
+++ b/server/internal/logstore/logstore_test.go
@@ -741,6 +741,32 @@ func TestStoreRequestsRecoverableSubscription(t *testing.T) {
 	store.Wait()
 }
 
+func TestRecoveryHintTriggersImmediateBackfill(t *testing.T) {
+	store := newTestStore(t)
+	hub := &fakeHub{}
+	engine := newFakeEngine(containerInfo("local", "aaa", "web", baseTime))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		store.Wait()
+	}()
+
+	store.start(ctx, hub, func() Engine { return engine })
+	waitFor(t, "initial backfill", func() bool { return engine.calls("aaa") == 1 })
+
+	if ok := hub.hint(logstream.RecoveryHint{
+		Host: "local", ContainerID: "aaa",
+	}); !ok {
+		t.Fatal("store did not register a recoverable subscription")
+	}
+
+	// syncInterval is 15 seconds. The ordinary test deadline is five seconds,
+	// so this can pass only through the event-driven recovery wake.
+	waitFor(t, "recovery backfill before the periodic sync", func() bool {
+		return engine.calls("aaa") >= 2
+	})
+}
+
 // TestBackfillDedupAtBoundary re-reads a generation whose watermark already
 // covers part of the engine's output: the overlapping lines must not be stored
 // twice, and the lines that are genuinely new must land.

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -248,7 +248,11 @@ func (s *Store) start(ctx context.Context, hub Hub, source func() Engine) {
 	s.producers.Add(1)
 	spec := logstream.ContainerSpec{} // all containers on all hosts
 	opts := models.LogOptions{
-		Follow: true, Timestamps: true, Tail: "0",
+		// Tail one retained record when the followed response attaches. The hub
+		// converts that first record into a recovery hint, which closes the
+		// finite container-start-to-stream-attachment window. The store's exact
+		// insertion key removes the intentional overlap.
+		Follow: true, Timestamps: true, Tail: "1",
 		ShowStdout: true, ShowStderr: true,
 	}
 	var unsubscribe func()

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -138,6 +138,10 @@ type Store struct {
 
 	// backfillState is owned by the sync loop.
 	backfillSem chan struct{}
+	// reconcileCh coalesces loss and lifecycle notices into an immediate
+	// lifecycle pass. The periodic sync remains the safety net, but recoverable
+	// gaps should not sit pending until its next tick.
+	reconcileCh chan struct{}
 }
 
 // DBPath returns the log database path that sits next to the config file
@@ -221,6 +225,7 @@ func Open(path string, limits Limits) (*Store, error) {
 		refresh:     make(map[genKey]uint64),
 		invalidated: make(map[genKey]struct{}),
 		backfillSem: make(chan struct{}, maxConcurrentBackfills),
+		reconcileCh: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -328,6 +333,16 @@ func (s *Store) recover(hint logstream.RecoveryHint) {
 	s.markGap(key, hint.Earliest.UnixNano())
 }
 
+// requestReconcile wakes the lifecycle loop without ever blocking a live-log
+// delivery goroutine. One pending wake is sufficient: a reconciliation reads
+// every outstanding generation marker.
+func (s *Store) requestReconcile() {
+	select {
+	case s.reconcileCh <- struct{}{}:
+	default:
+	}
+}
+
 // resumePoint is one generation's persisted per-stream backfill watermarks.
 type resumePoint struct {
 	stdoutWM    int64
@@ -399,13 +414,18 @@ type gapMark struct {
 // the notice version even if a repeated line has the same timestamp.
 func (s *Store) markGap(key genKey, tsNS int64) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	mark := s.gaps[key]
+	wasPending := mark.version != 0
 	mark.version++
 	if mark.from == 0 || tsNS < mark.from {
 		mark.from = tsNS
 	}
 	s.gaps[key] = mark
+	s.mu.Unlock()
+
+	if !wasPending {
+		s.requestReconcile()
+	}
 }
 
 // gapAt reports the generation's outstanding gap, or 0 when it has none.
@@ -433,8 +453,13 @@ func (s *Store) clearGap(key genKey, healed gapMark) {
 
 func (s *Store) markRefresh(key genKey) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	wasPending := s.refresh[key] != 0
 	s.refresh[key]++
+	s.mu.Unlock()
+
+	if !wasPending {
+		s.requestReconcile()
+	}
 }
 
 func (s *Store) refreshAt(key genKey) uint64 {

--- a/server/internal/logstore/sync.go
+++ b/server/internal/logstore/sync.go
@@ -53,7 +53,19 @@ func (s *Store) syncLoop(ctx context.Context, source func() Engine) {
 				}
 			default:
 				track.complete(s, res.key)
+				// A newer loss/lifecycle notice may have arrived while this
+				// finite engine read was in flight. Its version deliberately
+				// survives complete; wake a follow-up read now instead of
+				// waiting for the periodic lifecycle poll.
+				if s.gapAt(res.key) != 0 || s.refreshAt(res.key) != 0 {
+					s.requestReconcile()
+				}
 			}
+		case <-s.reconcileCh:
+			if ctx.Err() != nil {
+				return
+			}
+			s.sync(ctx, source(), track, results)
 		case <-ticker.C:
 			// select picks a ready case at random: a tick can win over a Done that
 			// is ready too.

--- a/server/internal/logstream/logstream_test.go
+++ b/server/internal/logstream/logstream_test.go
@@ -273,6 +273,49 @@ func TestStartEventSpawnsTail(t *testing.T) {
 	waitFor(t, "start event to spawn tail", func() bool { return f.activeTails(containerKey{"h1", "c9"}) == 1 })
 }
 
+func TestFirstRecordOnNewTailRequestsAttachmentRecovery(t *testing.T) {
+	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		emit(models.LogEntry{Message: "attachment boundary"})
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	var (
+		hintsMu sync.Mutex
+		hints   []RecoveryHint
+	)
+	h.SubscribeRecoverable(
+		ContainerSpec{Containers: []string{"api"}},
+		models.LogOptions{Tail: "1"},
+		rec.sink,
+		func(hint RecoveryHint) {
+			hintsMu.Lock()
+			defer hintsMu.Unlock()
+			hints = append(hints, hint)
+		},
+	)
+
+	f.events <- docker.EngineEvent{
+		Host: "h1", ContainerID: "c9", ContainerName: "api", Action: "start",
+	}
+
+	waitFor(t, "first record delivery", func() bool { return rec.len() == 1 })
+	waitFor(t, "attachment recovery hint", func() bool {
+		hintsMu.Lock()
+		defer hintsMu.Unlock()
+		return len(hints) == 1
+	})
+	hintsMu.Lock()
+	hint := hints[0]
+	hintsMu.Unlock()
+	if hint.Host != "h1" || hint.ContainerID != "c9" || !hint.Earliest.IsZero() {
+		t.Fatalf("attachment recovery hint = %+v, want zero-point hint for h1/c9", hint)
+	}
+}
+
 func TestDieEventLetsTailDrainBeforeItStops(t *testing.T) {
 	release := make(chan struct{})
 	f := newFakeClient()

--- a/server/internal/logstream/logstream_test.go
+++ b/server/internal/logstream/logstream_test.go
@@ -276,7 +276,8 @@ func TestStartEventSpawnsTail(t *testing.T) {
 func TestFirstRecordOnNewTailRequestsAttachmentRecovery(t *testing.T) {
 	f := newFakeClient()
 	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
-		emit(models.LogEntry{Message: "attachment boundary"})
+		emit(models.LogEntry{Message: "attachment boundary 1"})
+		emit(models.LogEntry{Message: "attachment boundary 2"})
 		<-ctx.Done()
 		return ctx.Err()
 	}
@@ -302,7 +303,7 @@ func TestFirstRecordOnNewTailRequestsAttachmentRecovery(t *testing.T) {
 		Host: "h1", ContainerID: "c9", ContainerName: "api", Action: "start",
 	}
 
-	waitFor(t, "first record delivery", func() bool { return rec.len() == 1 })
+	waitFor(t, "record delivery", func() bool { return rec.len() == 2 })
 	waitFor(t, "attachment recovery hint", func() bool {
 		hintsMu.Lock()
 		defer hintsMu.Unlock()
@@ -313,6 +314,51 @@ func TestFirstRecordOnNewTailRequestsAttachmentRecovery(t *testing.T) {
 	hintsMu.Unlock()
 	if hint.Host != "h1" || hint.ContainerID != "c9" || !hint.Earliest.IsZero() {
 		t.Fatalf("attachment recovery hint = %+v, want zero-point hint for h1/c9", hint)
+	}
+	hintsMu.Lock()
+	hintCount := len(hints)
+	hintsMu.Unlock()
+	if hintCount != 1 {
+		t.Fatalf("attachment recovery hints = %d, want exactly one", hintCount)
+	}
+}
+
+func TestOrdinaryTailDoesNotRequestAttachmentRecovery(t *testing.T) {
+	f := newFakeClient()
+	f.tailFn = func(ctx context.Context, host, id string, opts models.LogOptions, emit func(models.LogEntry)) error {
+		emit(models.LogEntry{Message: "ordinary tail 1"})
+		emit(models.LogEntry{Message: "ordinary tail 2"})
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	h := startHub(t, func() engineClient { return f })
+
+	rec := &recorder{}
+	var (
+		hintsMu sync.Mutex
+		hints   []RecoveryHint
+	)
+	h.SubscribeRecoverable(
+		ContainerSpec{Containers: []string{"api"}},
+		models.LogOptions{Tail: "0"},
+		rec.sink,
+		func(hint RecoveryHint) {
+			hintsMu.Lock()
+			defer hintsMu.Unlock()
+			hints = append(hints, hint)
+		},
+	)
+
+	f.events <- docker.EngineEvent{
+		Host: "h1", ContainerID: "c9", ContainerName: "api", Action: "start",
+	}
+
+	waitFor(t, "record delivery", func() bool { return rec.len() == 2 })
+	hintsMu.Lock()
+	hintCount := len(hints)
+	hintsMu.Unlock()
+	if hintCount != 0 {
+		t.Fatalf("attachment recovery hints = %d, want none for Tail 0", hintCount)
 	}
 }
 

--- a/server/internal/logstream/tail.go
+++ b/server/internal/logstream/tail.go
@@ -3,6 +3,7 @@ package logstream
 import (
 	"context"
 	"log"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -67,7 +68,24 @@ func (h *Hub) runTail(
 
 	delay := h.retryBaseDelay
 	for attempt := 1; ; attempt++ {
-		err := client.openTail(ctx, key.host, key.id, sub.opts, emit)
+		var attachment sync.Once
+		attemptEmit := func(entry models.LogEntry) {
+			// A recoverable subscriber can request a one-record overlap when it
+			// opens a followed stream. Seeing that overlap proves the stream is
+			// attached, but not that records emitted between container start and
+			// attachment were observed. Reconcile that finite boundary once per
+			// successful attachment; durable insertion deduplication absorbs the
+			// deliberately repeated record.
+			attachment.Do(func() {
+				if sub.opts.Tail == "1" {
+					sub.requestRecovery(RecoveryHint{
+						Host: key.host, ContainerID: key.id,
+					})
+				}
+			})
+			emit(entry)
+		}
+		err := client.openTail(ctx, key.host, key.id, sub.opts, attemptEmit)
 		if ctx.Err() != nil {
 			return
 		}


### PR DESCRIPTION
## Summary
- wake the lifecycle loop as soon as a bounded-buffer gap or lifecycle recovery hint becomes pending, while coalescing repeated notices and preserving the periodic poll as a safety net
- overlap each persistent live-stream attachment by one retained record and use that first record to request a finite reconciliation of the container-start-to-attachment window
- rely on the durable insertion key to deduplicate the intentional overlap, including after stream retries
- add regression tests for immediate recovery and the live-attachment boundary

## Why
A slower Docker daemon exposed a race in which a new container could emit its prefix after the initial finite backfill completed but before the live `Tail: 0` stream attached. A gated workload then waited forever because no later record arrived to trigger recovery. The one-record attachment overlap proves the stream is live and schedules a finite reconciliation of that boundary.

## Validation
- `go test -race ./internal/logstream ./internal/logstore`
- `go test ./...`
- `go vet ./...`
- controlled Ubuntu/OrbStack reproduction: collector-restart and collector-crash both failed pre-acquisition before the attachment fix, then completed with 1,000/1,000 source records after the fix

The OrbStack run is diagnostic portability evidence only because it shares the macOS host kernel; independent-kernel replication remains separate research work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log recovery when streams reconnect or gaps are detected.
  * Recovery now begins immediately instead of waiting for the next scheduled synchronization.
  * Preserved the first log record at a newly attached stream boundary and used it to trigger recovery.
  * Reduced the risk of missing log entries during container restarts, reconnects, or dropped-line events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->