### PR TITLE
Compress stored log history into sealed blocks

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-chi/cors v1.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/websocket v1.5.3
+	github.com/klauspost/compress v1.19.1
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/shirou/gopsutil/v4 v4.25.10

--- a/server/go.sum
+++ b/server/go.sum
@@ -60,6 +60,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
+github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/server/internal/logstore/block.go
+++ b/server/internal/logstore/block.go
@@ -1,0 +1,373 @@
+package logstore
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// A sealed block holds blockLines consecutive lines of one generation as a
+// single compressed blob, which is what makes stored history cheap: the
+// per-row overhead of SQLite disappears, and a thousand lines of the same
+// container compress against each other rather than alone.
+//
+// Inside a block the fields are grouped rather than interleaved — every
+// timestamp, then every level, then every message — because a run of similar
+// values compresses far better than the same values scattered between
+// unrelated bytes. Timestamps are stored as deltas for the same reason.
+//
+// The engine's timestamp prefix is lifted out of the raw line and rebuilt on
+// read. The store's contract is that a stored line is byte-for-byte what the
+// engine sent (see lineFromEntry), so packing verifies the rebuild: a
+// timestamp that would not survive the round trip keeps its line verbatim
+// instead. fixedNanoLayout, unlike time.RFC3339Nano, keeps trailing zeros in
+// the fraction, which is what Docker and Podman emit.
+const (
+	// blockLines is how many lines seal into one block. Measured across real
+	// container and application logs, 1000 sits at the knee: 250 gives up about
+	// a fifth of the compression, and 4000 buys under a tenth more while
+	// quadrupling how much a point read has to decompress.
+	blockLines = 1000
+	// fixedNanoLayout is RFC 3339 with the fraction always nine digits.
+	fixedNanoLayout = "2006-01-02T15:04:05.000000000Z07:00"
+	// blockFormatV1 tags the payload layout so a future format can be told
+	// apart without guessing.
+	blockFormatV1 = 1
+	// dedupFPR is the false-positive rate of a block's line-key filter. A false
+	// positive only costs one needless decompression, never a wrong answer, so
+	// a loose rate is the right trade: the filter exists to keep backfill from
+	// decompressing blocks that obviously cannot hold the line.
+	dedupFPR = 0.02
+)
+
+// blockCodec compresses and decompresses block payloads. The zstd encoder and
+// decoder are safe for concurrent use, so one codec serves the writer and every
+// reader.
+type blockCodec struct {
+	enc *zstd.Encoder
+	dec *zstd.Decoder
+}
+
+// blockWindow bounds the compressor's match window. A block holds a thousand
+// lines — a few hundred KB at most — so a window this size still sees the whole
+// block, while the library's default would size itself for streaming input and
+// hold far more state than the store ever needs.
+const blockWindow = 1 << 20 // 1 MiB
+
+func newBlockCodec() (*blockCodec, error) {
+	// Both defaults scale their internal state with GOMAXPROCS, which on a
+	// many-core host reserves hundreds of megabytes for a store whose whole
+	// point is running on a small VPS. Sealing happens only on the writer
+	// goroutine, so one encoder is all there is to use; the decoder is bounded
+	// to the database's connection pool, which is what caps concurrent readers.
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedDefault),
+		zstd.WithEncoderConcurrency(1),
+		zstd.WithWindowSize(blockWindow),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create log block encoder: %w", err)
+	}
+	dec, err := zstd.NewReader(nil,
+		zstd.WithDecoderConcurrency(maxDBConns),
+		zstd.WithDecoderMaxMemory(blockWindow*16),
+	)
+	if err != nil {
+		enc.Close()
+		return nil, fmt.Errorf("create log block decoder: %w", err)
+	}
+	return &blockCodec{enc: enc, dec: dec}, nil
+}
+
+func (c *blockCodec) close() {
+	c.enc.Close()
+	c.dec.Close()
+}
+
+// sealedLine is one line on its way into or out of a block. seq is the store's
+// monotonic line number, which orders lines that share a timestamp.
+type sealedLine struct {
+	seq    int64
+	tsNS   int64
+	stream int
+	level  int
+	raw    string
+}
+
+// blockSummary is everything about a block that is kept in columns, so a query
+// can rule a block in or out without decompressing it.
+type blockSummary struct {
+	tsMinNS   int64
+	tsMaxNS   int64
+	seqMin    int64
+	seqMax    int64
+	lines     int
+	levelMask int64
+	rawBytes  int64
+}
+
+// pack serializes and compresses one block's lines, which must be ordered by
+// (tsNS, seq). It returns the payload, the dedup filter, and the summary.
+func (c *blockCodec) pack(lines []sealedLine) (payload, filter []byte, summary blockSummary, err error) {
+	if len(lines) == 0 {
+		return nil, nil, blockSummary{}, fmt.Errorf("pack empty log block")
+	}
+
+	summary = blockSummary{
+		tsMinNS: lines[0].tsNS,
+		tsMaxNS: lines[len(lines)-1].tsNS,
+		seqMin:  lines[0].seq,
+		seqMax:  lines[len(lines)-1].seq,
+		lines:   len(lines),
+	}
+
+	// bodies[i] is what is stored for line i: the message with its timestamp
+	// prefix removed, or the whole line when the prefix cannot be rebuilt.
+	bodies := make([]string, len(lines))
+	verbatim := make([]byte, len(lines))
+	for i, l := range lines {
+		summary.levelMask |= 1 << uint(l.level)
+		summary.rawBytes += int64(len(l.raw))
+		if body, ok := stripTimestamp(l.raw, l.tsNS); ok {
+			bodies[i] = body
+			continue
+		}
+		bodies[i] = l.raw
+		verbatim[i] = 1
+	}
+
+	var buf []byte
+	buf = append(buf, blockFormatV1)
+	buf = binary.AppendUvarint(buf, uint64(len(lines)))
+
+	// Field runs. Deltas keep the numbers small, and small numbers next to each
+	// other are what the compressor turns into almost nothing.
+	prevTS, prevSeq := int64(0), int64(0)
+	for _, l := range lines {
+		buf = binary.AppendVarint(buf, l.tsNS-prevTS)
+		prevTS = l.tsNS
+	}
+	for _, l := range lines {
+		buf = binary.AppendVarint(buf, l.seq-prevSeq)
+		prevSeq = l.seq
+	}
+	for _, l := range lines {
+		// stream and level both fit in one byte and always travel together.
+		buf = append(buf, byte(l.stream)<<4|byte(l.level&0x0f))
+	}
+	buf = append(buf, verbatim...)
+	for _, body := range bodies {
+		buf = binary.AppendUvarint(buf, uint64(len(body)))
+	}
+	for _, body := range bodies {
+		buf = append(buf, body...)
+	}
+
+	return c.enc.EncodeAll(buf, nil), buildDedupFilter(lines), summary, nil
+}
+
+// unpack decompresses a block back into its lines, rebuilding each raw line
+// exactly as the engine sent it.
+func (c *blockCodec) unpack(payload []byte, scratch []byte) ([]sealedLine, []byte, error) {
+	buf, err := c.dec.DecodeAll(payload, scratch[:0])
+	if err != nil {
+		return nil, scratch, fmt.Errorf("decompress log block: %w", err)
+	}
+	scratch = buf
+
+	r := reader{buf: buf}
+	format := r.byteAt()
+	if format != blockFormatV1 {
+		return nil, scratch, fmt.Errorf("unknown log block format %d", format)
+	}
+	count := int(r.uvarint())
+	if count < 0 || count > blockLines*16 {
+		return nil, scratch, fmt.Errorf("log block claims %d lines", count)
+	}
+
+	lines := make([]sealedLine, count)
+	prevTS, prevSeq := int64(0), int64(0)
+	for i := range lines {
+		prevTS += r.varint()
+		lines[i].tsNS = prevTS
+	}
+	for i := range lines {
+		prevSeq += r.varint()
+		lines[i].seq = prevSeq
+	}
+	for i := range lines {
+		packed := r.byteAt()
+		lines[i].stream = int(packed >> 4)
+		lines[i].level = int(packed & 0x0f)
+	}
+	verbatim := make([]byte, count)
+	for i := range verbatim {
+		verbatim[i] = r.byteAt()
+	}
+	lengths := make([]int, count)
+	for i := range lengths {
+		lengths[i] = int(r.uvarint())
+	}
+	if r.err != nil {
+		return nil, scratch, fmt.Errorf("decode log block: %w", r.err)
+	}
+	for i := range lines {
+		body, err := r.stringOf(lengths[i])
+		if err != nil {
+			return nil, scratch, fmt.Errorf("decode log block: %w", err)
+		}
+		if verbatim[i] == 1 {
+			lines[i].raw = body
+			continue
+		}
+		lines[i].raw = time.Unix(0, lines[i].tsNS).UTC().Format(fixedNanoLayout) + " " + body
+	}
+	return lines, scratch, nil
+}
+
+// stripTimestamp removes the engine's timestamp prefix from raw when — and only
+// when — rebuilding it from tsNS reproduces the original bytes exactly. The
+// store promises that a stored line parses identically to a live one, so a
+// prefix this cannot reproduce is not lifted out at all.
+func stripTimestamp(raw string, tsNS int64) (string, bool) {
+	space := strings.IndexByte(raw, ' ')
+	if space <= 0 {
+		return "", false
+	}
+	if time.Unix(0, tsNS).UTC().Format(fixedNanoLayout) != raw[:space] {
+		return "", false
+	}
+	return raw[space+1:], true
+}
+
+// reader is a bounds-checked cursor over a decoded block.
+type reader struct {
+	buf []byte
+	pos int
+	err error
+}
+
+func (r *reader) byteAt() byte {
+	if r.pos >= len(r.buf) {
+		r.err = errTruncatedBlock
+		return 0
+	}
+	b := r.buf[r.pos]
+	r.pos++
+	return b
+}
+
+func (r *reader) uvarint() uint64 {
+	v, n := binary.Uvarint(r.buf[min(r.pos, len(r.buf)):])
+	if n <= 0 {
+		r.err = errTruncatedBlock
+		return 0
+	}
+	r.pos += n
+	return v
+}
+
+func (r *reader) varint() int64 {
+	v, n := binary.Varint(r.buf[min(r.pos, len(r.buf)):])
+	if n <= 0 {
+		r.err = errTruncatedBlock
+		return 0
+	}
+	r.pos += n
+	return v
+}
+
+func (r *reader) stringOf(n int) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if n < 0 || r.pos+n > len(r.buf) {
+		return "", errTruncatedBlock
+	}
+	s := string(r.buf[r.pos : r.pos+n])
+	r.pos += n
+	return s, nil
+}
+
+var errTruncatedBlock = fmt.Errorf("log block payload is truncated")
+
+// ---- dedup filter ----
+
+// A block's dedup filter answers "could this exact line already be in here?".
+// Backfill re-reads windows the store has already persisted, and the insert
+// path must not store those lines twice. Once a line is sealed it can no longer
+// be found by an index seek, so the filter stands in for one: a negative is
+// proof the line is absent, and a positive means the block is decompressed and
+// checked exactly. Live ingestion never pays for this — its timestamps are
+// newer than every sealed block, so no block is ever consulted.
+
+// lineKey identifies a line the way insertLine's uniqueness check does:
+// timestamp, stream, and the raw bytes.
+func lineKey(tsNS int64, stream int, raw string) uint64 {
+	h := fnv.New64a()
+	var buf [9]byte
+	binary.LittleEndian.PutUint64(buf[:8], uint64(tsNS))
+	buf[8] = byte(stream)
+	h.Write(buf[:])
+	h.Write([]byte(raw))
+	return h.Sum64()
+}
+
+// buildDedupFilter returns a bloom filter over the block's line keys, laid out
+// as a big-endian bit count followed by the bits themselves.
+func buildDedupFilter(lines []sealedLine) []byte {
+	bits := filterBits(len(lines))
+	out := make([]byte, 4+(bits+7)/8)
+	binary.BigEndian.PutUint32(out[:4], uint32(bits))
+	for _, l := range lines {
+		for _, pos := range filterPositions(bits, lineKey(l.tsNS, l.stream, l.raw)) {
+			out[4+pos/8] |= 1 << (pos % 8)
+		}
+	}
+	return out
+}
+
+// filterMayContain reports whether the filter can rule the key out. A malformed
+// or missing filter reports true, which only costs a decompression.
+func filterMayContain(filter []byte, key uint64) bool {
+	if len(filter) < 4 {
+		return true
+	}
+	bits := int(binary.BigEndian.Uint32(filter[:4]))
+	body := filter[4:]
+	if bits <= 0 || len(body) < (bits+7)/8 {
+		return true
+	}
+	for _, pos := range filterPositions(bits, key) {
+		if body[pos/8]&(1<<(pos%8)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// filterPositions returns the bit positions one key occupies. The number of
+// hashes depends only on the target rate, never on the member count, because a
+// reader derives it without knowing how many lines went in.
+func filterPositions(bits int, key uint64) []int {
+	k := max(1, min(int(math.Round(math.Log(1/dedupFPR)/math.Ln2)), 12))
+	h1, h2 := key, key>>32|1
+	out := make([]int, k)
+	for i := range out {
+		out[i] = int((h1 + uint64(i)*h2) % uint64(bits))
+	}
+	return out
+}
+
+func filterBits(n int) int {
+	if n <= 0 {
+		n = 1
+	}
+	bits := int(math.Ceil(float64(n) * math.Log(1/dedupFPR) / (math.Ln2 * math.Ln2)))
+	return max(bits, 64)
+}

--- a/server/internal/logstore/block.go
+++ b/server/internal/logstore/block.go
@@ -59,6 +59,15 @@ type blockCodec struct {
 // hold far more state than the store ever needs.
 const blockWindow = 1 << 20 // 1 MiB
 
+// maxBlockRawBytes caps how much log text one block may hold, whatever the line
+// count. Without it a thousand very long lines would serialize past the
+// decoder's budget below, and the block would be written but never readable
+// again. decoderBudget leaves generous headroom above that cap.
+const (
+	maxBlockRawBytes = 8 << 20  // 8 MiB
+	decoderBudget    = 64 << 20 // 64 MiB
+)
+
 func newBlockCodec() (*blockCodec, error) {
 	// Both defaults scale their internal state with GOMAXPROCS, which on a
 	// many-core host reserves hundreds of megabytes for a store whose whole
@@ -75,7 +84,7 @@ func newBlockCodec() (*blockCodec, error) {
 	}
 	dec, err := zstd.NewReader(nil,
 		zstd.WithDecoderConcurrency(maxDBConns),
-		zstd.WithDecoderMaxMemory(blockWindow*16),
+		zstd.WithDecoderMaxMemory(decoderBudget),
 	)
 	if err != nil {
 		enc.Close()
@@ -118,11 +127,15 @@ func (c *blockCodec) pack(lines []sealedLine) (payload, filter []byte, summary b
 		return nil, nil, blockSummary{}, fmt.Errorf("pack empty log block")
 	}
 
+	// Lines are ordered by timestamp, but sequence numbers are handed out in
+	// arrival order, so a backfill re-read puts older timestamps on larger
+	// sequences. The block's sequence range therefore has to be the real
+	// extremes: the keyset cursor uses it to include or skip this block.
 	summary = blockSummary{
 		tsMinNS: lines[0].tsNS,
 		tsMaxNS: lines[len(lines)-1].tsNS,
 		seqMin:  lines[0].seq,
-		seqMax:  lines[len(lines)-1].seq,
+		seqMax:  lines[0].seq,
 		lines:   len(lines),
 	}
 
@@ -133,6 +146,8 @@ func (c *blockCodec) pack(lines []sealedLine) (payload, filter []byte, summary b
 	for i, l := range lines {
 		summary.levelMask |= 1 << uint(l.level)
 		summary.rawBytes += int64(len(l.raw))
+		summary.seqMin = min(summary.seqMin, l.seq)
+		summary.seqMax = max(summary.seqMax, l.seq)
 		if body, ok := stripTimestamp(l.raw, l.tsNS); ok {
 			bodies[i] = body
 			continue
@@ -156,9 +171,14 @@ func (c *blockCodec) pack(lines []sealedLine) (payload, filter []byte, summary b
 		buf = binary.AppendVarint(buf, l.seq-prevSeq)
 		prevSeq = l.seq
 	}
+	// Each field gets its own run. Packing stream and level into one byte would
+	// cap severity at 15 and truncate silently past it, and a run of one
+	// repeated value compresses to almost nothing anyway.
 	for _, l := range lines {
-		// stream and level both fit in one byte and always travel together.
-		buf = append(buf, byte(l.stream)<<4|byte(l.level&0x0f))
+		buf = append(buf, byte(l.stream))
+	}
+	for _, l := range lines {
+		buf = append(buf, byte(l.level))
 	}
 	buf = append(buf, verbatim...)
 	for _, body := range bodies {
@@ -168,6 +188,10 @@ func (c *blockCodec) pack(lines []sealedLine) (payload, filter []byte, summary b
 		buf = append(buf, body...)
 	}
 
+	if int64(len(buf)) > decoderBudget {
+		return nil, nil, blockSummary{}, fmt.Errorf(
+			"log block serializes to %d bytes, past the %d byte decoder budget", len(buf), decoderBudget)
+	}
 	return c.enc.EncodeAll(buf, nil), buildDedupFilter(lines), summary, nil
 }
 
@@ -201,9 +225,10 @@ func (c *blockCodec) unpack(payload []byte, scratch []byte) ([]sealedLine, []byt
 		lines[i].seq = prevSeq
 	}
 	for i := range lines {
-		packed := r.byteAt()
-		lines[i].stream = int(packed >> 4)
-		lines[i].level = int(packed & 0x0f)
+		lines[i].stream = int(r.byteAt())
+	}
+	for i := range lines {
+		lines[i].level = int(r.byteAt())
 	}
 	verbatim := make([]byte, count)
 	for i := range verbatim {

--- a/server/internal/logstore/block_test.go
+++ b/server/internal/logstore/block_test.go
@@ -1,0 +1,526 @@
+package logstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/AmoabaKelvin/logdeck/internal/config"
+	"github.com/AmoabaKelvin/logdeck/internal/models"
+)
+
+// dockerLine renders a line the way the engine actually hands it over: an
+// RFC 3339 prefix whose fraction always carries nine digits. The suite's
+// rawLine helper uses Go's RFC3339Nano instead, which trims trailing zeros, so
+// the two together cover both sides of the packer's round-trip check.
+func dockerLine(ts time.Time, message string) string {
+	return ts.UTC().Format(fixedNanoLayout) + " " + message
+}
+
+func dockerEntry(ts time.Time, stream, message string) models.LogEntry {
+	return models.ParseLogLine(dockerLine(ts, message), stream)
+}
+
+// writeAndSeal commits entries and then seals whatever full blocks they
+// completed, which is exactly what writeLoop does after every batch.
+func writeAndSeal(t *testing.T, s *Store, key genKey, name string, entries ...models.LogEntry) {
+	t.Helper()
+	state := mustWriterState(t, s)
+	batch := make([]ingestMsg, 0, len(entries))
+	for _, entry := range entries {
+		batch = append(batch, ingestMsg{kind: msgLine, key: key, name: name, line: lineFromEntry(entry)})
+	}
+	if err := s.commit(batch, state); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := s.sealFullBlocks(state); err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+}
+
+// chatty builds n entries a second apart, shaped like a real service log.
+func chatty(n int, ts time.Time, render func(time.Time, string, string) models.LogEntry) []models.LogEntry {
+	entries := make([]models.LogEntry, n)
+	for i := range entries {
+		at := ts.Add(time.Duration(i) * time.Second)
+		entries[i] = render(at, "stdout",
+			fmt.Sprintf("INFO  GET /v1/accounts/%d 200 in %dms", i%997, i%80+3))
+	}
+	return entries
+}
+
+// noisy builds n entries whose bodies barely compress, so a test can reach a
+// retention cap without writing hundreds of thousands of lines. Real container
+// logs compress far better than this; poorly-compressible input is the
+// conservative case for retention.
+func noisy(n int, ts time.Time) []models.LogEntry {
+	const hex = "0123456789abcdef"
+	entries := make([]models.LogEntry, n)
+	state := uint64(0x9e3779b97f4a7c15)
+	token := make([]byte, 96)
+	for i := range entries {
+		for j := range token {
+			state ^= state << 13
+			state ^= state >> 7
+			state ^= state << 17
+			token[j] = hex[state&0xf]
+		}
+		at := ts.Add(time.Duration(i) * time.Millisecond)
+		entries[i] = dockerEntry(at, "stdout", string(token))
+	}
+	return entries
+}
+
+// readAll pages through a container's whole stored history, oldest first.
+func readAll(t *testing.T, s *Store, host, name string) []models.LogEntry {
+	t.Helper()
+	var all []models.LogEntry
+	cursor := ""
+	for round := 0; ; round++ {
+		if round > 500 {
+			t.Fatal("paging did not terminate")
+		}
+		page, err := s.Query(context.Background(), LogQuery{
+			Host: host, Container: name, Limit: 200, Cursor: cursor,
+		})
+		if err != nil {
+			t.Fatalf("Query: %v", err)
+		}
+		all = append(page.Entries, all...)
+		if page.NextCursor == "" {
+			return all
+		}
+		cursor = page.NextCursor
+	}
+}
+
+func countRows(t *testing.T, s *Store, statement string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(statement).Scan(&n); err != nil {
+		t.Fatalf("%s: %v", statement, err)
+	}
+	return n
+}
+
+// TestBlockCodecRebuildsLinesByteForByte is the codec's core promise. A stored
+// line has to come back exactly as the engine sent it, including its timestamp
+// prefix — the parse that turns it into an entry must not be able to drift from
+// the parse the live path runs.
+func TestBlockCodecRebuildsLinesByteForByte(t *testing.T) {
+	codec, err := newBlockCodec()
+	if err != nil {
+		t.Fatalf("newBlockCodec: %v", err)
+	}
+	defer codec.close()
+
+	ts := baseTime
+	lines := []sealedLine{
+		// A nine-digit prefix: the timestamp is lifted out and rebuilt.
+		{seq: 1, tsNS: ts.UnixNano(), stream: streamStdout, level: 3, raw: dockerLine(ts, "started")},
+		// A prefix with the fraction trimmed: the packer cannot reproduce it, so
+		// the line has to be kept whole instead.
+		{seq: 2, tsNS: ts.Add(time.Second).UnixNano(), stream: streamStderr, level: 5,
+			raw: ts.Add(time.Second).UTC().Format(time.RFC3339Nano) + " ERROR boom"},
+		// No prefix at all, from a driver that dropped it.
+		{seq: 3, tsNS: ts.Add(2 * time.Second).UnixNano(), stream: streamStdout, level: 3,
+			raw: "bare line with no timestamp"},
+		// A body that itself contains spaces and looks like a timestamp.
+		{seq: 4, tsNS: ts.Add(3 * time.Second).UnixNano(), stream: streamStdout, level: 3,
+			raw: dockerLine(ts.Add(3*time.Second), "replayed 2026-07-01T12:00:00.000000000Z from queue")},
+		{seq: 5, tsNS: ts.Add(4 * time.Second).UnixNano(), stream: streamStdout, level: 3,
+			raw: dockerLine(ts.Add(4*time.Second), "")},
+	}
+
+	payload, filter, summary, err := codec.pack(lines)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	got, _, err := codec.unpack(payload, nil)
+	if err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+
+	if len(got) != len(lines) {
+		t.Fatalf("unpacked %d lines, want %d", len(got), len(lines))
+	}
+	for i := range lines {
+		if got[i] != lines[i] {
+			t.Errorf("line %d round-tripped as %+v, want %+v", i, got[i], lines[i])
+		}
+	}
+	if summary.tsMinNS != lines[0].tsNS || summary.tsMaxNS != lines[len(lines)-1].tsNS {
+		t.Errorf("summary spans [%d,%d], want [%d,%d]",
+			summary.tsMinNS, summary.tsMaxNS, lines[0].tsNS, lines[len(lines)-1].tsNS)
+	}
+	if summary.lines != len(lines) {
+		t.Errorf("summary counts %d lines, want %d", summary.lines, len(lines))
+	}
+
+	// Every line that went in must be reported as possibly present; that is what
+	// makes the filter safe to use as a dedup pre-check.
+	for _, l := range lines {
+		if !filterMayContain(filter, lineKey(l.tsNS, l.stream, l.raw)) {
+			t.Errorf("dedup filter rules out a line it holds: %q", l.raw)
+		}
+	}
+}
+
+// TestSealingPreservesEveryLineAndShrinksTheStore checks the whole point of the
+// change: history comes back intact, and it costs far less disk than a row per
+// line.
+func TestSealingPreservesEveryLineAndShrinksTheStore(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+	entries := chatty(2500, baseTime, dockerEntry)
+
+	writeAndSeal(t, store, key, "api", entries...)
+
+	if blocks := countRows(t, store, "SELECT COUNT(*) FROM log_blocks"); blocks != 2 {
+		t.Fatalf("sealed %d blocks, want 2 for 2500 lines", blocks)
+	}
+	if hot := countRows(t, store, "SELECT COUNT(*) FROM log_lines"); hot != 500 {
+		t.Fatalf("%d lines left hot, want the 500 that did not fill a block", hot)
+	}
+
+	got := readAll(t, store, "local", "api")
+	if len(got) != len(entries) {
+		t.Fatalf("read back %d lines, want %d", len(got), len(entries))
+	}
+	for i := range entries {
+		if got[i].Raw != entries[i].Raw {
+			t.Fatalf("line %d came back as %q, want %q", i, got[i].Raw, entries[i].Raw)
+		}
+		if !got[i].Timestamp.Equal(entries[i].Timestamp) {
+			t.Fatalf("line %d timestamp %v, want %v", i, got[i].Timestamp, entries[i].Timestamp)
+		}
+	}
+
+	// The sealed bytes must be a small fraction of the text they hold. The
+	// measured ratio on real logs is far better than this; the bar is set low so
+	// the test fails only on a real regression, never on compressor drift.
+	var rawBytes, payloadBytes int64
+	if err := store.db.QueryRow(
+		"SELECT SUM(raw_bytes), SUM(length(payload)) FROM log_blocks").Scan(&rawBytes, &payloadBytes); err != nil {
+		t.Fatalf("measure blocks: %v", err)
+	}
+	if payloadBytes*4 > rawBytes {
+		t.Errorf("sealed payload is %d bytes for %d bytes of log text, want at least 4x smaller",
+			payloadBytes, rawBytes)
+	}
+}
+
+// TestDedupSurvivesSealing is the correctness risk the block layout introduces.
+// Once a line is sealed it can no longer be found by an index seek, so a
+// backfill re-reading a window the store already holds must still be recognised
+// as a duplicate rather than stored twice.
+func TestDedupSurvivesSealing(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+	entries := chatty(1200, baseTime, dockerEntry)
+
+	writeAndSeal(t, store, key, "api", entries...)
+	if blocks := countRows(t, store, "SELECT COUNT(*) FROM log_blocks"); blocks != 1 {
+		t.Fatalf("sealed %d blocks, want 1", blocks)
+	}
+
+	// The engine is re-read from the start, exactly as it is after a restart or
+	// a dropped-line gap.
+	writeAndSeal(t, store, key, "api", entries...)
+
+	got := readAll(t, store, "local", "api")
+	if len(got) != len(entries) {
+		t.Fatalf("after a full re-read the store holds %d lines, want %d", len(got), len(entries))
+	}
+	for i := range entries {
+		if got[i].Raw != entries[i].Raw {
+			t.Fatalf("line %d is %q, want %q", i, got[i].Raw, entries[i].Raw)
+		}
+	}
+}
+
+// TestPagingIsStableAcrossTheSealBoundary walks the whole history one small page
+// at a time. The cursor has to keep working where a page ends inside a sealed
+// block and continues into the hot table, which is what the sequence number is
+// for.
+func TestPagingIsStableAcrossTheSealBoundary(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+	entries := chatty(2300, baseTime, dockerEntry)
+	writeAndSeal(t, store, key, "api", entries...)
+
+	var (
+		seen   []string
+		cursor string
+	)
+	for round := 0; ; round++ {
+		if round > 200 {
+			t.Fatal("paging did not terminate")
+		}
+		page, err := store.Query(context.Background(), LogQuery{
+			Host: "local", Container: "api", Limit: 37, Cursor: cursor,
+		})
+		if err != nil {
+			t.Fatalf("Query: %v", err)
+		}
+		if len(page.Entries) == 0 && page.NextCursor != "" {
+			t.Fatal("an empty page must never carry a cursor")
+		}
+		messages := make([]string, len(page.Entries))
+		for i, e := range page.Entries {
+			messages[i] = e.Raw
+		}
+		seen = append(messages, seen...)
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+
+	if len(seen) != len(entries) {
+		t.Fatalf("paging returned %d lines, want %d", len(seen), len(entries))
+	}
+	for i := range entries {
+		if seen[i] != entries[i].Raw {
+			t.Fatalf("paged line %d is %q, want %q", i, seen[i], entries[i].Raw)
+		}
+	}
+}
+
+// TestFiltersReachIntoSealedBlocks confirms level and search filters see sealed
+// history, not just the hot tail.
+func TestFiltersReachIntoSealedBlocks(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+
+	entries := chatty(1500, baseTime, dockerEntry)
+	// One distinctive error early enough to be sealed.
+	marker := baseTime.Add(50 * time.Second)
+	entries[50] = dockerEntry(marker, "stderr", "ERROR payment gateway unreachable")
+	writeAndSeal(t, store, key, "api", entries...)
+
+	if blocks := countRows(t, store, "SELECT COUNT(*) FROM log_blocks"); blocks == 0 {
+		t.Fatal("nothing was sealed, so this test proves nothing")
+	}
+
+	page, err := store.Query(context.Background(), LogQuery{
+		Host: "local", Container: "api", Search: "payment gateway",
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Fatalf("search found %d entries in sealed history, want 1", len(page.Entries))
+	}
+	if page.Entries[0].Raw != entries[50].Raw {
+		t.Fatalf("search returned %q, want %q", page.Entries[0].Raw, entries[50].Raw)
+	}
+
+	levelled, err := store.Query(context.Background(), LogQuery{
+		Host: "local", Container: "api", Levels: []string{"ERROR"},
+	})
+	if err != nil {
+		t.Fatalf("Query by level: %v", err)
+	}
+	if len(levelled.Entries) != 1 {
+		t.Fatalf("level filter found %d entries in sealed history, want 1", len(levelled.Entries))
+	}
+}
+
+// TestTimeRangeQueriesReadSealedHistory covers the Since/Until path, which rules
+// blocks out by their stored bounds before decompressing anything.
+func TestTimeRangeQueriesReadSealedHistory(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+	entries := chatty(2000, baseTime, dockerEntry)
+	writeAndSeal(t, store, key, "api", entries...)
+
+	since := baseTime.Add(100 * time.Second)
+	until := baseTime.Add(199 * time.Second)
+	page, err := store.Query(context.Background(), LogQuery{
+		Host: "local", Container: "api", Since: since, Until: until, Limit: MaxQueryLimit,
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(page.Entries) != 100 {
+		t.Fatalf("time range returned %d entries, want 100", len(page.Entries))
+	}
+	for _, e := range page.Entries {
+		if e.Timestamp.Before(since) || e.Timestamp.After(until) {
+			t.Fatalf("entry at %v falls outside [%v, %v]", e.Timestamp, since, until)
+		}
+	}
+}
+
+// TestRetentionEvictsSealedBlocks checks that the caps still bound the file once
+// most of the history lives in blocks.
+func TestRetentionEvictsSealedBlocks(t *testing.T) {
+	limits := func() config.ResolvedLogStoreConfig {
+		return config.ResolvedLogStoreConfig{Enabled: true, PerContainerMB: 1, TotalMB: 1}
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "logs.db"), limits)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	key := genKey{"local", "api-1"}
+	// Enough history that the sealed blocks alone exceed the 1 MB cap.
+	for round := range 12 {
+		start := baseTime.Add(time.Duration(round) * 4000 * time.Millisecond)
+		writeAndSeal(t, store, key, "api", noisy(4000, start)...)
+	}
+
+	blocksBefore := countRows(t, store, "SELECT COUNT(*) FROM log_blocks")
+	if blocksBefore == 0 {
+		t.Fatal("nothing was sealed, so this test proves nothing")
+	}
+	var storedBefore int64
+	if err := store.db.QueryRow("SELECT SUM(stored_bytes) FROM containers").Scan(&storedBefore); err != nil {
+		t.Fatalf("read stored_bytes: %v", err)
+	}
+	if storedBefore <= bytesPerMB {
+		t.Fatalf("the store holds %d bytes, under the %d byte cap: nothing would be evicted",
+			storedBefore, bytesPerMB)
+	}
+
+	if err := store.retain(context.Background()); err != nil {
+		t.Fatalf("retain: %v", err)
+	}
+
+	var stored int64
+	if err := store.db.QueryRow("SELECT SUM(stored_bytes) FROM containers").Scan(&stored); err != nil {
+		t.Fatalf("read stored_bytes: %v", err)
+	}
+	if stored > bytesPerMB {
+		t.Fatalf("stored_bytes is %d after retention, want at most %d", stored, bytesPerMB)
+	}
+	if blocksAfter := countRows(t, store, "SELECT COUNT(*) FROM log_blocks"); blocksAfter >= blocksBefore {
+		t.Fatalf("retention kept %d blocks of %d, want it to evict sealed history",
+			blocksAfter, blocksBefore)
+	}
+
+	// What survives must still be readable, and must be the newest history.
+	got := readAll(t, store, "local", "api")
+	if len(got) == 0 {
+		t.Fatal("retention evicted everything")
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Timestamp.Before(got[i-1].Timestamp) {
+			t.Fatalf("surviving history is out of order at %d", i)
+		}
+	}
+}
+
+// TestSealedLinesSurviveAReopen covers the writer's startup state: sequence
+// numbers must continue past everything already sealed, or a reopened store
+// would hand two different lines the same page position.
+func TestSealedLinesSurviveAReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs.db")
+	store, err := Open(path, testLimits)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	key := genKey{"local", "api-1"}
+	first := chatty(1500, baseTime, dockerEntry)
+	writeAndSeal(t, store, key, "api", first...)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := Open(path, testLimits)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+
+	state := mustWriterState(t, reopened)
+	var sealedMax int64
+	if err := reopened.db.QueryRow("SELECT MAX(seq_max) FROM log_blocks").Scan(&sealedMax); err != nil {
+		t.Fatalf("read sealed seq: %v", err)
+	}
+	if state.nextSeq <= sealedMax {
+		t.Fatalf("nextSeq is %d but a sealed line already holds %d", state.nextSeq, sealedMax)
+	}
+
+	second := chatty(600, baseTime.Add(2000*time.Second), dockerEntry)
+	writeAndSeal(t, reopened, key, "api", second...)
+
+	got := readAll(t, reopened, "local", "api")
+	if len(got) != len(first)+len(second) {
+		t.Fatalf("after reopening the store holds %d lines, want %d", len(got), len(first)+len(second))
+	}
+}
+
+// TestMigrationFromV3SealsNothingAndKeepsEveryLine checks the upgrade path: an
+// existing database keeps all of its history, and its rows keep their order.
+func TestMigrationFromV3SealsNothingAndKeepsEveryLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs.db")
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("open raw database: %v", err)
+	}
+
+	for _, statement := range []string{schemaV1, schemaV2, schemaV3} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("build v3 schema: %v", err)
+		}
+	}
+	if _, err := db.Exec("PRAGMA user_version = 3"); err != nil {
+		t.Fatalf("stamp version: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO containers
+		(id, host, container_id, name, first_seen_ms, last_seen_ms)
+		VALUES (1, 'local', 'api-1', 'api', 0, 0)`); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+	want := make([]string, 0, 40)
+	for i := range 40 {
+		at := baseTime.Add(time.Duration(i) * time.Second)
+		raw := dockerLine(at, fmt.Sprintf("line %d", i))
+		want = append(want, raw)
+		if _, err := db.Exec(
+			"INSERT INTO log_lines (container_ref, ts_ns, stream, level, raw) VALUES (1, ?, 0, 3, ?)",
+			at.UnixNano(), raw); err != nil {
+			t.Fatalf("seed line: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded database: %v", err)
+	}
+
+	store, err := Open(path, testLimits)
+	if err != nil {
+		t.Fatalf("open after migration: %v", err)
+	}
+	defer store.Close()
+
+	var version int
+	if err := store.db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		t.Fatalf("read version: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("schema version is %d, want %d", version, schemaVersion)
+	}
+
+	// Migrated rows must carry distinct sequence numbers, or paging would stall.
+	distinct := countRows(t, store, "SELECT COUNT(DISTINCT seq) FROM log_lines")
+	if distinct != len(want) {
+		t.Fatalf("%d distinct sequence numbers across %d migrated rows", distinct, len(want))
+	}
+
+	got := readAll(t, store, "local", "api")
+	if len(got) != len(want) {
+		t.Fatalf("migration kept %d lines, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Raw != want[i] {
+			t.Fatalf("migrated line %d is %q, want %q", i, got[i].Raw, want[i])
+		}
+	}
+}

--- a/server/internal/logstore/block_test.go
+++ b/server/internal/logstore/block_test.go
@@ -634,3 +634,90 @@ func TestBlocksAreCappedByBytesAsWellAsLines(t *testing.T) {
 		}
 	}
 }
+
+// TestStoredBytesMatchesWhatBlocksOccupy pins the accounting symmetry retention
+// depends on: what sealing adds to stored_bytes must be exactly what eviction
+// subtracts per block — payload plus dedup filter — or repeated seal/evict
+// cycles drift the counter until the caps stop meaning anything.
+func TestStoredBytesMatchesWhatBlocksOccupy(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+	writeAndSeal(t, store, key, "api", chatty(2400, baseTime, dockerEntry)...)
+
+	var stored, sealedBytes, hotBytes int64
+	if err := store.db.QueryRow(
+		"SELECT stored_bytes FROM containers WHERE container_id = 'api-1'").Scan(&stored); err != nil {
+		t.Fatalf("read stored_bytes: %v", err)
+	}
+	if err := store.db.QueryRow(
+		"SELECT COALESCE(SUM(length(payload) + length(dedup_filter)), 0) FROM log_blocks").Scan(&sealedBytes); err != nil {
+		t.Fatalf("measure blocks: %v", err)
+	}
+	if err := store.db.QueryRow(
+		"SELECT COALESCE(SUM(length(CAST(raw AS BLOB))), 0) FROM log_lines").Scan(&hotBytes); err != nil {
+		t.Fatalf("measure hot lines: %v", err)
+	}
+
+	if want := sealedBytes + hotBytes; stored != want {
+		t.Fatalf("stored_bytes is %d but the store occupies %d (blocks %d + hot %d)",
+			stored, want, sealedBytes, hotBytes)
+	}
+}
+
+// TestRetentionEvictsOldestAcrossBothTables reproduces the backfill shape that
+// breaks "blocks are always older than hot lines": newer history is sealed, and
+// a backfill then lands *older* lines in the hot table. Eviction asked for a
+// small trim must take the oldest data — the hot backfill — not the newer
+// sealed block.
+func TestRetentionEvictsOldestAcrossBothTables(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+
+	// Newer history, sealed.
+	writeAndSeal(t, store, key, "api", chatty(1000, baseTime, dockerEntry)...)
+	if blocks := countRows(t, store, "SELECT COUNT(*) FROM log_blocks"); blocks != 1 {
+		t.Fatalf("sealed %d blocks, want 1", blocks)
+	}
+
+	// An older window arrives afterwards, as a backfill re-read does. Too few
+	// lines to seal, so they stay hot — and they are the oldest data stored.
+	old := make([]models.LogEntry, 0, 10)
+	for i := range 10 {
+		at := baseTime.Add(-time.Hour + time.Duration(i)*time.Second)
+		old = append(old, dockerEntry(at, "stdout", fmt.Sprintf("OLD backfilled line %d", i)))
+	}
+	writeAndSeal(t, store, key, "api", old...)
+
+	var ref int64
+	if err := store.db.QueryRow(
+		"SELECT id FROM containers WHERE container_id = 'api-1'").Scan(&ref); err != nil {
+		t.Fatalf("resolve generation: %v", err)
+	}
+
+	// Trim a handful of bytes: far less than the block, and coverable entirely
+	// by the old hot lines.
+	if _, err := store.evictOldest(context.Background(), []int64{ref}, 64); err != nil {
+		t.Fatalf("evictOldest: %v", err)
+	}
+
+	if blocks := countRows(t, store, "SELECT COUNT(*) FROM log_blocks"); blocks != 1 {
+		t.Fatalf("eviction deleted the sealed block, which holds the *newest* history")
+	}
+	if hot := countRows(t, store, "SELECT COUNT(*) FROM log_lines"); hot >= 10 {
+		t.Fatalf("eviction left all %d old hot lines untouched", hot)
+	}
+
+	// What survives must be newer than what was evicted: the oldest surviving
+	// line must not postdate any line that was removed. Equivalent check: no
+	// gap — everything still stored is newer than everything gone, so the
+	// oldest survivor is one of the old lines or the block start.
+	got := readAll(t, store, "local", "api")
+	if len(got) == 0 {
+		t.Fatal("eviction removed everything")
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Timestamp.Before(got[i-1].Timestamp) {
+			t.Fatalf("surviving history is out of order at %d", i)
+		}
+	}
+}

--- a/server/internal/logstore/block_test.go
+++ b/server/internal/logstore/block_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,14 +78,21 @@ func noisy(n int, ts time.Time) []models.LogEntry {
 // readAll pages through a container's whole stored history, oldest first.
 func readAll(t *testing.T, s *Store, host, name string) []models.LogEntry {
 	t.Helper()
+	return pageAll(t, s, host, name, 200)
+}
+
+// pageAll is readAll with an explicit page size, so a test can force the cursor
+// to land inside a sealed block rather than between blocks.
+func pageAll(t *testing.T, s *Store, host, name string, limit int) []models.LogEntry {
+	t.Helper()
 	var all []models.LogEntry
 	cursor := ""
 	for round := 0; ; round++ {
-		if round > 500 {
+		if round > 5000 {
 			t.Fatal("paging did not terminate")
 		}
 		page, err := s.Query(context.Background(), LogQuery{
-			Host: host, Container: name, Limit: 200, Cursor: cursor,
+			Host: host, Container: name, Limit: limit, Cursor: cursor,
 		})
 		if err != nil {
 			t.Fatalf("Query: %v", err)
@@ -521,6 +529,108 @@ func TestMigrationFromV3SealsNothingAndKeepsEveryLine(t *testing.T) {
 	for i := range want {
 		if got[i].Raw != want[i] {
 			t.Fatalf("migrated line %d is %q, want %q", i, got[i].Raw, want[i])
+		}
+	}
+}
+
+// TestSealingHandlesOutOfOrderArrival is the case a backfill produces: the
+// store persists live history, then re-reads an older window from the engine, so
+// lines arrive with older timestamps but newer sequence numbers.
+//
+// Two things have to cope with that. A single block can hold a mix of both, so
+// its stored sequence range is not simply its first and last line. And sealed
+// blocks then overlap in time, so reading them newest-first by their end
+// timestamp does not yield lines in timestamp order.
+func TestSealingHandlesOutOfOrderArrival(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+
+	// Live history, not yet a full block.
+	live := chatty(600, baseTime, dockerEntry)
+	writeAndSeal(t, store, key, "api", live...)
+
+	// A backfill of the window *before* it, arriving later and so carrying
+	// larger sequence numbers. This fills the block, and the block it seals
+	// holds both.
+	backfill := make([]models.LogEntry, 0, 600)
+	for i := range 600 {
+		at := baseTime.Add(-time.Duration(600-i) * time.Second)
+		backfill = append(backfill, dockerEntry(at, "stdout", fmt.Sprintf("BACKFILL record %d", i)))
+	}
+	writeAndSeal(t, store, key, "api", backfill...)
+
+	if blocks := countRows(t, store, "SELECT COUNT(*) FROM log_blocks"); blocks == 0 {
+		t.Fatal("nothing was sealed, so this test proves nothing")
+	}
+
+	// A block's stored sequence range must bracket every sequence it holds: the
+	// keyset cursor uses that range to include or skip the block.
+	rows, err := store.db.Query("SELECT rowid, seq_min, seq_max FROM log_blocks")
+	if err != nil {
+		t.Fatalf("read blocks: %v", err)
+	}
+	for rows.Next() {
+		var rowid, seqMin, seqMax int64
+		if err := rows.Scan(&rowid, &seqMin, &seqMax); err != nil {
+			rows.Close()
+			t.Fatalf("scan: %v", err)
+		}
+		if seqMin > seqMax {
+			t.Errorf("block %d stores an inverted sequence range [%d, %d]", rowid, seqMin, seqMax)
+		}
+	}
+	rows.Close()
+
+	want := len(live) + len(backfill)
+	for _, limit := range []int{7, 37, 200} {
+		got := pageAll(t, store, "local", "api", limit)
+		if len(got) != want {
+			t.Fatalf("paging %d at a time returned %d lines, want %d", limit, len(got), want)
+		}
+		for i := 1; i < len(got); i++ {
+			if got[i].Timestamp.Before(got[i-1].Timestamp) {
+				t.Fatalf("paging %d at a time is out of timestamp order at %d: %v before %v",
+					limit, i, got[i].Timestamp, got[i-1].Timestamp)
+			}
+		}
+	}
+}
+
+// TestBlocksAreCappedByBytesAsWellAsLines covers the guard that keeps a
+// container logging very long lines from building a block too large to read
+// back: the block seals on size before it reaches blockLines.
+func TestBlocksAreCappedByBytesAsWellAsLines(t *testing.T) {
+	store := newTestStore(t)
+	key := genKey{"local", "api-1"}
+
+	// 16 KiB a line, so the byte cap is reached well inside one block.
+	body := strings.Repeat("x", 16*1024)
+	entries := make([]models.LogEntry, 0, blockLines)
+	for i := range blockLines {
+		at := baseTime.Add(time.Duration(i) * time.Second)
+		entries = append(entries, dockerEntry(at, "stdout", fmt.Sprintf("%d %s", i, body)))
+	}
+	writeAndSeal(t, store, key, "api", entries...)
+
+	var blocks, maxRaw int
+	if err := store.db.QueryRow(
+		"SELECT COUNT(*), COALESCE(MAX(raw_bytes), 0) FROM log_blocks").Scan(&blocks, &maxRaw); err != nil {
+		t.Fatalf("read blocks: %v", err)
+	}
+	if blocks == 0 {
+		t.Fatal("the byte cap never sealed a block")
+	}
+	if int64(maxRaw) > maxBlockRawBytes {
+		t.Fatalf("a block holds %d bytes, past the %d byte cap", maxRaw, maxBlockRawBytes)
+	}
+
+	got := readAll(t, store, "local", "api")
+	if len(got) != len(entries) {
+		t.Fatalf("read back %d lines, want %d", len(got), len(entries))
+	}
+	for i := range entries {
+		if got[i].Raw != entries[i].Raw {
+			t.Fatalf("line %d did not survive the round trip", i)
 		}
 	}
 }

--- a/server/internal/logstore/ingest.go
+++ b/server/internal/logstore/ingest.go
@@ -644,10 +644,13 @@ func (s *Store) sealOneBlock(ref int64, state *writerState) (int, error) {
 		return 0, err
 	}
 
+	// The filter counts too: eviction frees payload plus filter per block, so
+	// sealing must add exactly that or repeated seal/evict cycles drift
+	// stored_bytes away from what the generation actually occupies.
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE containers
 		SET stored_bytes = max(0, stored_bytes - ? + ?)
-		WHERE id = ?`, summary.rawBytes, int64(len(payload)), ref); err != nil {
+		WHERE id = ?`, summary.rawBytes, int64(len(payload)+len(filter)), ref); err != nil {
 		return 0, err
 	}
 

--- a/server/internal/logstore/ingest.go
+++ b/server/internal/logstore/ingest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/AmoabaKelvin/logdeck/internal/models"
@@ -77,11 +78,109 @@ func lineFromEntry(entry models.LogEntry) line {
 	}
 }
 
+// writerState is everything the single writer goroutine remembers between
+// batches. None of it is shared, so none of it is locked.
+type writerState struct {
+	// refs maps a generation to its containers.id.
+	refs map[genKey]int64
+	// hot counts each generation's unsealed lines, so the writer knows when a
+	// full block's worth has accumulated without counting rows every batch.
+	hot map[int64]int
+	// sealedMaxTS is the newest timestamp each generation has already sealed.
+	// A line newer than that cannot collide with a sealed block, which is what
+	// keeps live ingestion from querying log_blocks at all.
+	sealedMaxTS map[int64]int64
+	// nextSeq hands out the store-wide monotonic line number.
+	nextSeq int64
+	// unpacked caches the most recently decompressed block, held only for the
+	// span of one commit. A backfill re-read walks forward through time, so
+	// consecutive lines usually land in the same block.
+	unpacked      []sealedLine
+	unpackedRowid int64
+	scratch       []byte
+}
+
+func newWriterState() *writerState {
+	return &writerState{
+		refs:          make(map[genKey]int64),
+		hot:           make(map[int64]int),
+		sealedMaxTS:   make(map[int64]int64),
+		unpackedRowid: -1,
+		nextSeq:       1,
+	}
+}
+
+// loadWriterState reads the writer's starting point from the database.
+func (s *Store) loadWriterState() (*writerState, error) {
+	state := newWriterState()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT container_ref, COUNT(*) FROM log_lines GROUP BY container_ref")
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var ref int64
+		var count int
+		if err := rows.Scan(&ref, &count); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		state.hot[ref] = count
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	blocks, err := s.db.QueryContext(ctx,
+		"SELECT container_ref, MAX(ts_max_ns) FROM log_blocks GROUP BY container_ref")
+	if err != nil {
+		return nil, err
+	}
+	for blocks.Next() {
+		var ref, tsMax int64
+		if err := blocks.Scan(&ref, &tsMax); err != nil {
+			blocks.Close()
+			return nil, err
+		}
+		state.sealedMaxTS[ref] = tsMax
+	}
+	blocks.Close()
+	if err := blocks.Err(); err != nil {
+		return nil, err
+	}
+
+	// A reused sequence number would put two different lines at the same keyset
+	// position, so the counter must clear everything either table has ever held.
+	var hotMax, blockMax sql.NullInt64
+	if err := s.db.QueryRowContext(ctx, "SELECT MAX(seq) FROM log_lines").Scan(&hotMax); err != nil {
+		return nil, err
+	}
+	if err := s.db.QueryRowContext(ctx, "SELECT MAX(seq_max) FROM log_blocks").Scan(&blockMax); err != nil {
+		return nil, err
+	}
+	state.nextSeq = max(hotMax.Int64, blockMax.Int64) + 1
+	return state, nil
+}
+
 // writeLoop is the store's single writer. It batches queued messages into one
 // transaction per batchLines rows or batchInterval, whichever comes first, and
 // exits once the queue is closed and drained.
 func (s *Store) writeLoop() {
-	refs := make(map[genKey]int64) // generation -> containers.id
+	state, err := s.loadWriterState()
+	if err != nil {
+		// Starting from a blank slate is not safe: seq would restart at 1 and
+		// collide with stored positions, so refuse to ingest rather than corrupt
+		// the ordering. The store stays readable.
+		log.Printf("logstore: reading writer state failed, ingestion is disabled: %v", err)
+		for range s.ingestCh { //nolint:revive // drain so producers never block
+		}
+		return
+	}
 	batch := make([]ingestMsg, 0, batchLines)
 
 	ticker := time.NewTicker(batchInterval)
@@ -96,7 +195,7 @@ func (s *Store) writeLoop() {
 		if len(batch) == 0 {
 			return
 		}
-		if err := s.commit(batch, refs); err != nil {
+		if err := s.commit(batch, state); err != nil {
 			log.Printf("logstore: write batch failed (%d messages dropped): %v", len(batch), err)
 			// A failed transaction drops the whole batch. Mark every generation it
 			// carried, exactly like the sink's full-queue path: the next sync
@@ -106,6 +205,13 @@ func (s *Store) writeLoop() {
 		}
 		batch = batch[:0]
 		batchesSinceRetain++
+
+		// Sealing is what makes stored history cheap, so it runs on the same
+		// goroutine as ingestion rather than competing with it for the write
+		// lock. A failed seal leaves the lines hot and is retried next batch.
+		if err := s.sealFullBlocks(state); err != nil {
+			log.Printf("logstore: sealing log blocks failed: %v", err)
+		}
 	}
 
 	retain := func() {
@@ -184,9 +290,11 @@ func (s *Store) markBatchGaps(batch []ingestMsg) {
 // INSERT ... RETURNING id hands back a rowid SQLite will hand out again, so
 // caching it eagerly would file the *next* generation's lines against this key
 // — one container's lines landing in another container's timeline.
-func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
+func (s *Store) commit(batch []ingestMsg, state *writerState) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	refs := state.refs
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -198,7 +306,11 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 	// that committed before this transaction began has published its
 	// generations, and the ids it removed leave the cache before they can be
 	// written against.
-	s.dropInvalidated(refs)
+	s.dropInvalidated(state)
+
+	// The cached block belongs to the previous transaction's snapshot; retention
+	// may have deleted it since.
+	state.unpacked, state.unpackedRowid = nil, -1
 
 	// Per-generation aggregates applied once at the end of the transaction.
 	type agg struct {
@@ -208,6 +320,9 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 	}
 	aggs := make(map[int64]*agg)
 	fresh := make(map[genKey]int64) // ids this transaction discovered
+	// newHot counts lines this transaction added, published to the writer's hot
+	// counts only after the commit succeeds.
+	newHot := make(map[int64]int)
 	nowMS := time.Now().UnixMilli()
 	insertedCount := int64(0)
 
@@ -240,7 +355,7 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 			continue
 		}
 
-		inserted, err := insertLine(ctx, tx, ref, msg.line)
+		inserted, err := s.insertLine(ctx, tx, state, ref, msg.line)
 		if err != nil {
 			return err
 		}
@@ -248,6 +363,7 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 			continue
 		}
 		insertedCount++
+		newHot[ref]++
 
 		a := aggs[ref]
 		if a == nil {
@@ -281,9 +397,12 @@ func (s *Store) commit(batch []ingestMsg, refs map[genKey]int64) error {
 	}
 	s.committed.Add(insertedCount)
 
-	// The ids are real only now.
+	// The ids and counts are real only now.
 	for key, ref := range fresh {
 		refs[key] = ref
+	}
+	for ref, count := range newHot {
+		state.hot[ref] += count
 	}
 	return nil
 }
@@ -310,25 +429,35 @@ func upsertGeneration(ctx context.Context, tx *sql.Tx, key genKey, name, project
 	return ref, err
 }
 
-// insertLine stores one line unless an identical (ts_ns, stream, raw) row is
-// already stored for the generation, and reports whether a row was written.
+// insertLine stores one line unless an identical (ts_ns, stream, raw) line is
+// already stored for the generation, hot or sealed, and reports whether a row
+// was written.
 //
 // Every insert is deduplicated, not just backfilled ones: live delivery and a
 // backfill re-read of the same window can reach the writer in either order
 // (the hub buffers records, so a live line can arrive after the backfill that
-// also read it). The check is an index seek on (container_ref, ts_ns), the
-// same B-tree the insert already touches. Note that this never drops a line by
-// timestamp alone — only a byte-identical line on the same stream in the same
-// nanosecond, which is the duplicate we are trying to avoid.
-func insertLine(ctx context.Context, tx *sql.Tx, ref int64, l line) (bool, error) {
+// also read it). Note that this never drops a line by timestamp alone — only a
+// byte-identical line on the same stream in the same nanosecond, which is the
+// duplicate we are trying to avoid.
+func (s *Store) insertLine(ctx context.Context, tx *sql.Tx, state *writerState, ref int64, l line) (bool, error) {
+	sealed, err := s.sealedHasLine(ctx, tx, state, ref, l)
+	if err != nil {
+		return false, err
+	}
+	if sealed {
+		return false, nil
+	}
+
+	// The hot check is an index seek on (container_ref, ts_ns), the same B-tree
+	// the insert already touches.
 	result, err := tx.ExecContext(ctx, `
-		INSERT INTO log_lines (container_ref, ts_ns, stream, level, raw)
-		SELECT ?, ?, ?, ?, ?
+		INSERT INTO log_lines (container_ref, ts_ns, stream, level, raw, seq)
+		SELECT ?, ?, ?, ?, ?, ?
 		WHERE NOT EXISTS (
 			SELECT 1 FROM log_lines
 			WHERE container_ref = ? AND ts_ns = ? AND stream = ? AND raw = ?
 		)`,
-		ref, l.tsNS, l.stream, l.level, l.raw,
+		ref, l.tsNS, l.stream, l.level, l.raw, state.nextSeq,
 		ref, l.tsNS, l.stream, l.raw)
 	if err != nil {
 		return false, err
@@ -337,5 +466,182 @@ func insertLine(ctx context.Context, tx *sql.Tx, ref int64, l line) (bool, error
 	if err != nil {
 		return false, err
 	}
+	if rows > 0 {
+		state.nextSeq++
+	}
 	return rows > 0, nil
+}
+
+// sealedHasLine reports whether a line is already inside one of the
+// generation's sealed blocks.
+//
+// Live ingestion never reaches the database here: its timestamps are newer than
+// anything sealed, which the writer already knows. Only a backfill re-reading a
+// window the store has kept gets this far, and then a block's filter usually
+// rules it out without decompressing.
+func (s *Store) sealedHasLine(ctx context.Context, tx *sql.Tx, state *writerState, ref int64, l line) (bool, error) {
+	if l.tsNS > state.sealedMaxTS[ref] {
+		return false, nil
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT rowid, dedup_filter, payload FROM log_blocks
+		WHERE container_ref = ? AND ts_min_ns <= ? AND ts_max_ns >= ?`,
+		ref, l.tsNS, l.tsNS)
+	if err != nil {
+		return false, err
+	}
+
+	type candidate struct {
+		rowid   int64
+		payload []byte
+	}
+	var candidates []candidate
+	key := lineKey(l.tsNS, l.stream, l.raw)
+	for rows.Next() {
+		var (
+			rowid   int64
+			filter  []byte
+			payload []byte
+		)
+		if err := rows.Scan(&rowid, &filter, &payload); err != nil {
+			rows.Close()
+			return false, err
+		}
+		if !filterMayContain(filter, key) {
+			continue
+		}
+		candidates = append(candidates, candidate{rowid: rowid, payload: payload})
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+
+	for _, c := range candidates {
+		lines := state.unpacked
+		if state.unpackedRowid != c.rowid {
+			var err error
+			lines, state.scratch, err = s.codec.unpack(c.payload, state.scratch)
+			if err != nil {
+				return false, err
+			}
+			state.unpacked, state.unpackedRowid = lines, c.rowid
+		}
+		for _, sl := range lines {
+			if sl.tsNS == l.tsNS && sl.stream == l.stream && sl.raw == l.raw {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// sealFullBlocks compresses every complete run of hot lines into a block. It
+// runs between batches on the writer goroutine, so it never competes with
+// ingestion for SQLite's single write lock.
+func (s *Store) sealFullBlocks(state *writerState) error {
+	for ref, count := range state.hot {
+		for count >= blockLines {
+			sealed, err := s.sealOneBlock(ref, state)
+			if err != nil {
+				return err
+			}
+			if sealed == 0 {
+				// The rows are gone (purged, or evicted by retention); trust the
+				// database over the cached count.
+				delete(state.hot, ref)
+				break
+			}
+			count -= sealed
+			state.hot[ref] = count
+		}
+	}
+	return nil
+}
+
+// sealOneBlock moves a generation's oldest blockLines hot lines into a single
+// compressed row, and reports how many lines it sealed.
+//
+// stored_bytes moves with them: the raw bytes leave and the payload arrives, so
+// the retention caps keep measuring what the generation actually occupies.
+func (s *Store) sealOneBlock(ref int64, state *writerState) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT seq, ts_ns, stream, level, raw FROM log_lines
+		WHERE container_ref = ?
+		ORDER BY ts_ns, seq
+		LIMIT ?`, ref, blockLines)
+	if err != nil {
+		return 0, err
+	}
+	lines := make([]sealedLine, 0, blockLines)
+	for rows.Next() {
+		var l sealedLine
+		if err := rows.Scan(&l.seq, &l.tsNS, &l.stream, &l.level, &l.raw); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		lines = append(lines, l)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	// A partial run stays hot: sealing it would give up most of the compression,
+	// since a block earns its ratio from the lines it holds together.
+	if len(lines) < blockLines {
+		return 0, nil
+	}
+
+	payload, filter, summary, err := s.codec.pack(lines)
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO log_blocks
+			(container_ref, ts_min_ns, ts_max_ns, seq_min, seq_max,
+			 lines, level_mask, raw_bytes, dedup_filter, payload)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		ref, summary.tsMinNS, summary.tsMaxNS, summary.seqMin, summary.seqMax,
+		summary.lines, summary.levelMask, summary.rawBytes, filter, payload,
+	); err != nil {
+		return 0, err
+	}
+
+	seqs := make([]any, 0, len(lines)+1)
+	for _, l := range lines {
+		seqs = append(seqs, l.seq)
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(seqs)), ",")
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM log_lines WHERE container_ref = ? AND seq IN ("+placeholders+")",
+		append([]any{ref}, seqs...)...); err != nil {
+		return 0, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE containers
+		SET stored_bytes = max(0, stored_bytes - ? + ?)
+		WHERE id = ?`, summary.rawBytes, int64(len(payload)), ref); err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+
+	if summary.tsMaxNS > state.sealedMaxTS[ref] {
+		state.sealedMaxTS[ref] = summary.tsMaxNS
+	}
+	return len(lines), nil
 }

--- a/server/internal/logstore/ingest.go
+++ b/server/internal/logstore/ingest.go
@@ -484,49 +484,52 @@ func (s *Store) sealedHasLine(ctx context.Context, tx *sql.Tx, state *writerStat
 		return false, nil
 	}
 
+	// The payload is deliberately not selected here. This runs once per line of a
+	// backfill re-read, and reading a block's compressed blob is far more
+	// expensive than testing its filter; only the survivors are worth fetching.
 	rows, err := tx.QueryContext(ctx, `
-		SELECT rowid, dedup_filter, payload FROM log_blocks
+		SELECT rowid, dedup_filter FROM log_blocks
 		WHERE container_ref = ? AND ts_min_ns <= ? AND ts_max_ns >= ?`,
 		ref, l.tsNS, l.tsNS)
 	if err != nil {
 		return false, err
 	}
 
-	type candidate struct {
-		rowid   int64
-		payload []byte
-	}
-	var candidates []candidate
+	var candidates []int64
 	key := lineKey(l.tsNS, l.stream, l.raw)
 	for rows.Next() {
 		var (
-			rowid   int64
-			filter  []byte
-			payload []byte
+			rowid  int64
+			filter []byte
 		)
-		if err := rows.Scan(&rowid, &filter, &payload); err != nil {
+		if err := rows.Scan(&rowid, &filter); err != nil {
 			rows.Close()
 			return false, err
 		}
 		if !filterMayContain(filter, key) {
 			continue
 		}
-		candidates = append(candidates, candidate{rowid: rowid, payload: payload})
+		candidates = append(candidates, rowid)
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
 		return false, err
 	}
 
-	for _, c := range candidates {
+	for _, rowid := range candidates {
 		lines := state.unpacked
-		if state.unpackedRowid != c.rowid {
+		if state.unpackedRowid != rowid {
+			var payload []byte
+			if err := tx.QueryRowContext(ctx,
+				"SELECT payload FROM log_blocks WHERE rowid = ?", rowid).Scan(&payload); err != nil {
+				return false, err
+			}
 			var err error
-			lines, state.scratch, err = s.codec.unpack(c.payload, state.scratch)
+			lines, state.scratch, err = s.codec.unpack(payload, state.scratch)
 			if err != nil {
 				return false, err
 			}
-			state.unpacked, state.unpackedRowid = lines, c.rowid
+			state.unpacked, state.unpackedRowid = lines, rowid
 		}
 		for _, sl := range lines {
 			if sl.tsNS == l.tsNS && sl.stream == l.stream && sl.raw == l.raw {
@@ -584,13 +587,25 @@ func (s *Store) sealOneBlock(ref int64, state *writerState) (int, error) {
 		return 0, err
 	}
 	lines := make([]sealedLine, 0, blockLines)
+	rawBytes := int64(0)
+	full := false
 	for rows.Next() {
 		var l sealedLine
 		if err := rows.Scan(&l.seq, &l.tsNS, &l.stream, &l.level, &l.raw); err != nil {
 			rows.Close()
 			return 0, err
 		}
+		// A block is also full once it holds enough text, so a container that
+		// logs very long lines cannot build one too large to read back. The
+		// line that would cross the cap starts the next block instead; a single
+		// line larger than the cap still gets a block of its own, and pack
+		// refuses anything the decoder could not read back.
+		if len(lines) > 0 && rawBytes+int64(len(l.raw)) > maxBlockRawBytes {
+			full = true
+			break
+		}
 		lines = append(lines, l)
+		rawBytes += int64(len(l.raw))
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
@@ -598,7 +613,7 @@ func (s *Store) sealOneBlock(ref int64, state *writerState) (int, error) {
 	}
 	// A partial run stays hot: sealing it would give up most of the compression,
 	// since a block earns its ratio from the lines it holds together.
-	if len(lines) < blockLines {
+	if !full && len(lines) < blockLines {
 		return 0, nil
 	}
 

--- a/server/internal/logstore/janitor.go
+++ b/server/internal/logstore/janitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"math"
 	"strings"
 	"time"
 )
@@ -188,23 +189,50 @@ func (s *Store) oldestLine(ctx context.Context, refs []int64) (int64, bool, erro
 // evictOldest frees at least excess bytes from one logical container, oldest
 // first, and returns how many bytes it actually freed.
 //
-// Sealed blocks go first because they hold the older history: a generation's
-// hot lines are the ones it has not accumulated a full block of yet, so they
-// are its newest. Only once a generation has no blocks left does eviction fall
-// through to its hot lines, which is also the path a container too young to
-// have sealed anything takes.
+// Sealed blocks usually hold the older history, but not always: a backfill
+// re-read lands *older* lines in the hot table after newer history has been
+// sealed. So each round compares the two sources' oldest timestamps, evicts
+// from whichever is older, and bounds that sweep at the other source's oldest
+// data — one call can therefore never remove anything newer than what the
+// other table still holds. The caller loops until the excess is freed.
 func (s *Store) evictOldest(ctx context.Context, refs []int64, excess int64) (int64, error) {
-	freed, err := s.evictOldestBlocks(ctx, refs, excess)
-	if err != nil || freed > 0 {
-		return freed, err
+	placeholders, args := refArgs(refs)
+
+	var oldestHot, oldestBlock sql.NullInt64
+	err := s.db.QueryRowContext(ctx,
+		"SELECT MIN(ts_ns) FROM log_lines WHERE container_ref IN ("+placeholders+")", args...).Scan(&oldestHot)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, err
 	}
-	return s.evictOldestHotLines(ctx, refs, excess)
+	err = s.db.QueryRowContext(ctx,
+		"SELECT MIN(ts_min_ns) FROM log_blocks WHERE container_ref IN ("+placeholders+")", args...).Scan(&oldestBlock)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, err
+	}
+
+	const unbounded = int64(math.MaxInt64)
+	switch {
+	case oldestBlock.Valid && (!oldestHot.Valid || oldestBlock.Int64 <= oldestHot.Int64):
+		bound := unbounded
+		if oldestHot.Valid {
+			bound = oldestHot.Int64
+		}
+		return s.evictOldestBlocks(ctx, refs, excess, bound)
+	case oldestHot.Valid:
+		bound := unbounded
+		if oldestBlock.Valid {
+			bound = oldestBlock.Int64
+		}
+		return s.evictOldestHotLines(ctx, refs, excess, bound)
+	}
+	return 0, nil
 }
 
 // evictOldestBlocks deletes whole blocks, which is what makes retention cheap:
 // one row carries a thousand lines, so freeing a megabyte touches a handful of
-// rows instead of thousands.
-func (s *Store) evictOldestBlocks(ctx context.Context, refs []int64, excess int64) (int64, error) {
+// rows instead of thousands. Blocks starting after boundTS are left alone: the
+// hot table still holds older lines, and those must go first.
+func (s *Store) evictOldestBlocks(ctx context.Context, refs []int64, excess, boundTS int64) (int64, error) {
 	placeholders, args := refArgs(refs)
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -215,8 +243,9 @@ func (s *Store) evictOldestBlocks(ctx context.Context, refs []int64, excess int6
 
 	rows, err := tx.QueryContext(ctx,
 		"SELECT rowid, container_ref, length(payload) + length(dedup_filter) FROM log_blocks"+
-			" WHERE container_ref IN ("+placeholders+") ORDER BY ts_min_ns, seq_min LIMIT ?",
-		append(args, deleteChunk)...)
+			" WHERE container_ref IN ("+placeholders+") AND ts_min_ns <= ?"+
+			" ORDER BY ts_min_ns, seq_min LIMIT ?",
+		append(args, boundTS, deleteChunk)...)
 	if err != nil {
 		return 0, err
 	}
@@ -277,7 +306,10 @@ func (s *Store) evictOldestBlocks(ctx context.Context, refs []int64, excess int6
 // as a deferred read-then-write transaction it would fail with
 // SQLITE_BUSY_SNAPSHOT whenever a line was ingested between its SELECT and its
 // DELETE, so retention would stop working exactly when the store is busiest.
-func (s *Store) evictOldestHotLines(ctx context.Context, refs []int64, excess int64) (int64, error) {
+//
+// Lines after boundTS are left alone: a sealed block still holds older history,
+// and that must go first.
+func (s *Store) evictOldestHotLines(ctx context.Context, refs []int64, excess, boundTS int64) (int64, error) {
 	placeholders, args := refArgs(refs)
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -288,8 +320,9 @@ func (s *Store) evictOldestHotLines(ctx context.Context, refs []int64, excess in
 
 	rows, err := tx.QueryContext(ctx,
 		"SELECT rowid, container_ref, length(CAST(raw AS BLOB)) FROM log_lines"+
-			" WHERE container_ref IN ("+placeholders+") ORDER BY ts_ns, rowid LIMIT ?",
-		append(args, deleteChunk)...)
+			" WHERE container_ref IN ("+placeholders+") AND ts_ns <= ?"+
+			" ORDER BY ts_ns, rowid LIMIT ?",
+		append(args, boundTS, deleteChunk)...)
 	if err != nil {
 		return 0, err
 	}

--- a/server/internal/logstore/janitor.go
+++ b/server/internal/logstore/janitor.go
@@ -161,27 +161,123 @@ func (s *Store) oldestGroup(ctx context.Context, groups []logicalGroup) (int, er
 
 func (s *Store) oldestLine(ctx context.Context, refs []int64) (int64, bool, error) {
 	placeholders, args := refArgs(refs)
-	var ts sql.NullInt64
+
+	var hot, sealed sql.NullInt64
 	err := s.db.QueryRowContext(ctx,
-		"SELECT MIN(ts_ns) FROM log_lines WHERE container_ref IN ("+placeholders+")", args...).Scan(&ts)
+		"SELECT MIN(ts_ns) FROM log_lines WHERE container_ref IN ("+placeholders+")", args...).Scan(&hot)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return 0, false, err
 	}
-	return ts.Int64, ts.Valid, nil
+	err = s.db.QueryRowContext(ctx,
+		"SELECT MIN(ts_min_ns) FROM log_blocks WHERE container_ref IN ("+placeholders+")", args...).Scan(&sealed)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, false, err
+	}
+
+	switch {
+	case hot.Valid && sealed.Valid:
+		return min(hot.Int64, sealed.Int64), true, nil
+	case hot.Valid:
+		return hot.Int64, true, nil
+	case sealed.Valid:
+		return sealed.Int64, true, nil
+	}
+	return 0, false, nil
 }
 
-// evictOldest deletes the oldest lines of one logical container until it has
-// freed excess bytes, reading at most deleteChunk rows so one transaction can
-// never hold the write lock long enough to stall ingestion (the caller loops
-// if more is needed). It returns how many bytes it freed. The row deletion and
-// the stored_bytes adjustment share a transaction, and stored_bytes is updated
-// relative to its current value so it composes with concurrent ingestion.
+// evictOldest frees at least excess bytes from one logical container, oldest
+// first, and returns how many bytes it actually freed.
+//
+// Sealed blocks go first because they hold the older history: a generation's
+// hot lines are the ones it has not accumulated a full block of yet, so they
+// are its newest. Only once a generation has no blocks left does eviction fall
+// through to its hot lines, which is also the path a container too young to
+// have sealed anything takes.
+func (s *Store) evictOldest(ctx context.Context, refs []int64, excess int64) (int64, error) {
+	freed, err := s.evictOldestBlocks(ctx, refs, excess)
+	if err != nil || freed > 0 {
+		return freed, err
+	}
+	return s.evictOldestHotLines(ctx, refs, excess)
+}
+
+// evictOldestBlocks deletes whole blocks, which is what makes retention cheap:
+// one row carries a thousand lines, so freeing a megabyte touches a handful of
+// rows instead of thousands.
+func (s *Store) evictOldestBlocks(ctx context.Context, refs []int64, excess int64) (int64, error) {
+	placeholders, args := refArgs(refs)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx,
+		"SELECT rowid, container_ref, length(payload) + length(dedup_filter) FROM log_blocks"+
+			" WHERE container_ref IN ("+placeholders+") ORDER BY ts_min_ns, seq_min LIMIT ?",
+		append(args, deleteChunk)...)
+	if err != nil {
+		return 0, err
+	}
+	var (
+		rowids []any
+		freed  int64
+		perRef = make(map[int64]int64)
+	)
+	for rows.Next() {
+		var rowid, ref, size int64
+		if err := rows.Scan(&rowid, &ref, &size); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		rowids = append(rowids, rowid)
+		perRef[ref] += size
+		freed += size
+		if freed >= excess {
+			break
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	if len(rowids) == 0 {
+		return 0, nil
+	}
+
+	rowPlaceholders := strings.TrimSuffix(strings.Repeat("?,", len(rowids)), ",")
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM log_blocks WHERE rowid IN ("+rowPlaceholders+")", rowids...); err != nil {
+		return 0, err
+	}
+	for ref, size := range perRef {
+		if _, err := tx.ExecContext(ctx,
+			"UPDATE containers SET stored_bytes = max(0, stored_bytes - ?) WHERE id = ?", size, ref); err != nil {
+			return 0, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	s.evictions.Add(1)
+	return freed, nil
+}
+
+// evictOldestHotLines deletes the oldest unsealed lines of one logical
+// container until it has freed excess bytes, reading at most deleteChunk rows so
+// one transaction can never hold the write lock long enough to stall ingestion
+// (the caller loops if more is needed). It returns how many bytes it freed. The
+// row deletion and the stored_bytes adjustment share a transaction, and
+// stored_bytes is updated relative to its current value so it composes with
+// concurrent ingestion.
 //
 // The transaction takes the write lock up front (_txlock=immediate on the DSN):
 // as a deferred read-then-write transaction it would fail with
 // SQLITE_BUSY_SNAPSHOT whenever a line was ingested between its SELECT and its
 // DELETE, so retention would stop working exactly when the store is busiest.
-func (s *Store) evictOldest(ctx context.Context, refs []int64, excess int64) (int64, error) {
+func (s *Store) evictOldestHotLines(ctx context.Context, refs []int64, excess int64) (int64, error) {
 	placeholders, args := refArgs(refs)
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -256,7 +352,8 @@ func (s *Store) pruneEmptyGenerations(ctx context.Context) error {
 	_, err := s.db.ExecContext(ctx, `
 		DELETE FROM containers
 		WHERE removed_ms IS NOT NULL
-		  AND NOT EXISTS (SELECT 1 FROM log_lines WHERE container_ref = containers.id)`)
+		  AND NOT EXISTS (SELECT 1 FROM log_lines WHERE container_ref = containers.id)
+		  AND NOT EXISTS (SELECT 1 FROM log_blocks WHERE container_ref = containers.id)`)
 	return err
 }
 

--- a/server/internal/logstore/logstore_test.go
+++ b/server/internal/logstore/logstore_test.go
@@ -61,9 +61,21 @@ func writeEntries(t *testing.T, s *Store, key genKey, name string, entries ...mo
 			line: lineFromEntry(entry),
 		})
 	}
-	if err := s.commit(batch, map[genKey]int64{}); err != nil {
+	if err := s.commit(batch, mustWriterState(t, s)); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
+}
+
+// mustWriterState rebuilds the writer's between-batch state from the database,
+// so a helper that commits one batch continues the sequence numbering the store
+// already holds instead of restarting it.
+func mustWriterState(t *testing.T, s *Store) *writerState {
+	t.Helper()
+	state, err := s.loadWriterState()
+	if err != nil {
+		t.Fatalf("load writer state: %v", err)
+	}
+	return state
 }
 
 // markInitialBackfillDone models the ordered completion marker the writer
@@ -75,7 +87,7 @@ func markInitialBackfillDone(t *testing.T, s *Store, key genKey, name string) {
 		key:      key,
 		name:     name,
 		complete: true,
-	}}, map[genKey]int64{}); err != nil {
+	}}, mustWriterState(t, s)); err != nil {
 		t.Fatalf("mark initial backfill done: %v", err)
 	}
 }
@@ -1116,13 +1128,13 @@ func TestMigrationFromV1AddsTheForeignKey(t *testing.T) {
 
 // commitThrough writes a batch through the writer's own generation-id cache,
 // the way writeLoop does across batches.
-func commitThrough(t *testing.T, s *Store, refs map[genKey]int64, key genKey, name string, entries ...models.LogEntry) {
+func commitThrough(t *testing.T, s *Store, state *writerState, key genKey, name string, entries ...models.LogEntry) {
 	t.Helper()
 	batch := make([]ingestMsg, 0, len(entries))
 	for _, entry := range entries {
 		batch = append(batch, ingestMsg{kind: msgLine, key: key, name: name, line: lineFromEntry(entry)})
 	}
-	if err := s.commit(batch, refs); err != nil {
+	if err := s.commit(batch, state); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
 }
@@ -1138,7 +1150,7 @@ func commitThrough(t *testing.T, s *Store, refs map[genKey]int64, key genKey, na
 func TestFailedCommitDoesNotPoisonTheRefCache(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
-	refs := map[genKey]int64{} // the writer's cache, alive across batches
+	state := mustWriterState(t, store) // the writer's cache, alive across batches
 	alpha := genKey{"local", "container-a"}
 	beta := genKey{"local", "container-b"}
 
@@ -1153,11 +1165,11 @@ func TestFailedCommitDoesNotPoisonTheRefCache(t *testing.T) {
 		kind: msgLine, key: alpha, name: "alpha",
 		line: lineFromEntry(entryAt(baseTime, "stdout", "alpha line 1")),
 	}}
-	if err := store.commit(batch, refs); err == nil {
+	if err := store.commit(batch, state); err == nil {
 		t.Fatal("the batch must fail while the trigger is installed")
 	}
-	if len(refs) != 0 {
-		t.Fatalf("a rolled-back transaction published %v into the ref cache: SQLite reuses that rowid", refs)
+	if len(state.refs) != 0 {
+		t.Fatalf("a rolled-back transaction published %v into the ref cache: SQLite reuses that rowid", state.refs)
 	}
 	if _, err := store.db.Exec("DROP TRIGGER fail_writes"); err != nil {
 		t.Fatalf("drop trigger: %v", err)
@@ -1165,9 +1177,9 @@ func TestFailedCommitDoesNotPoisonTheRefCache(t *testing.T) {
 
 	// A different container is created next and takes the rowid the rolled-back
 	// row had been handed.
-	commitThrough(t, store, refs, beta, "beta", entryAt(baseTime.Add(time.Second), "stdout", "beta line 1"))
+	commitThrough(t, store, state, beta, "beta", entryAt(baseTime.Add(time.Second), "stdout", "beta line 1"))
 	// alpha writes again, through the same cache.
-	commitThrough(t, store, refs, alpha, "alpha", entryAt(baseTime.Add(2*time.Second), "stdout", "alpha line 2"))
+	commitThrough(t, store, state, alpha, "alpha", entryAt(baseTime.Add(2*time.Second), "stdout", "alpha line 2"))
 
 	page, err := store.Query(ctx, LogQuery{Container: "beta"})
 	if err != nil {

--- a/server/internal/logstore/purge.go
+++ b/server/internal/logstore/purge.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 )
@@ -57,7 +58,7 @@ func (s *Store) DeleteContainer(ctx context.Context, host, name string) (int64, 
 		return 0, ErrContainerNotFound
 	}
 
-	// Lines first: log_lines.container_ref references containers(id).
+	// Lines and blocks first: both reference containers(id).
 	placeholders, args := refArgs(refs)
 	result, err := tx.ExecContext(ctx,
 		"DELETE FROM log_lines WHERE container_ref IN ("+placeholders+")", args...)
@@ -66,6 +67,15 @@ func (s *Store) DeleteContainer(ctx context.Context, host, name string) (int64, 
 	}
 	deleted, err := result.RowsAffected()
 	if err != nil {
+		return 0, err
+	}
+	sealed, err := countSealedLines(ctx, tx, placeholders, args)
+	if err != nil {
+		return 0, err
+	}
+	deleted += sealed
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM log_blocks WHERE container_ref IN ("+placeholders+")", args...); err != nil {
 		return 0, err
 	}
 	if _, err := tx.ExecContext(ctx,
@@ -87,6 +97,19 @@ func (s *Store) DeleteContainer(ctx context.Context, host, name string) (int64, 
 	return deleted, nil
 }
 
+// countSealedLines totals the lines held inside the generations' sealed blocks,
+// so a purge reports every line it removed rather than only the hot ones.
+func countSealedLines(ctx context.Context, tx *sql.Tx, placeholders string, args []any) (int64, error) {
+	var total sql.NullInt64
+	err := tx.QueryRowContext(ctx,
+		"SELECT SUM(lines) FROM log_blocks WHERE container_ref IN ("+placeholders+")", args...).
+		Scan(&total)
+	if err != nil {
+		return 0, err
+	}
+	return total.Int64, nil
+}
+
 // invalidate publishes purged generations to the writer and forgets their
 // backfill state, so a gap or resume point recorded before the purge cannot
 // re-read the deleted window back out of the engine.
@@ -106,11 +129,15 @@ func (s *Store) invalidate(keys []genKey) {
 // dropInvalidated evicts purged generations from the writer's ref cache. The
 // writer calls it inside its write transaction, so the keys it drops are
 // exactly those of the deletions that already committed.
-func (s *Store) dropInvalidated(refs map[genKey]int64) {
+func (s *Store) dropInvalidated(state *writerState) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for key := range s.invalidated {
-		delete(refs, key)
+		if ref, ok := state.refs[key]; ok {
+			delete(state.hot, ref)
+			delete(state.sealedMaxTS, ref)
+		}
+		delete(state.refs, key)
 		delete(s.invalidated, key)
 	}
 }

--- a/server/internal/logstore/purge_test.go
+++ b/server/internal/logstore/purge_test.go
@@ -151,7 +151,7 @@ func TestDeleteContainerUnknown(t *testing.T) {
 func TestDeleteContainerInvalidatesWriterCache(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
-	refs := map[genKey]int64{}
+	state := mustWriterState(t, store)
 
 	web := genKey{"local", "aaa"}
 	commit := func(key genKey, name string, entries ...models.LogEntry) {
@@ -160,13 +160,13 @@ func TestDeleteContainerInvalidatesWriterCache(t *testing.T) {
 		for _, entry := range entries {
 			batch = append(batch, ingestMsg{kind: msgLine, key: key, name: name, line: lineFromEntry(entry)})
 		}
-		if err := store.commit(batch, refs); err != nil {
+		if err := store.commit(batch, state); err != nil {
 			t.Fatalf("commit: %v", err)
 		}
 	}
 
 	commit(web, "web", entryAt(baseTime, "stdout", "before purge"))
-	before := refs[web]
+	before := state.refs[web]
 	if before == 0 {
 		t.Fatal("the writer did not cache the live generation, so this test proves nothing")
 	}
@@ -183,7 +183,7 @@ func TestDeleteContainerInvalidatesWriterCache(t *testing.T) {
 	// generation of *web*, never under db.
 	commit(web, "web", entryAt(baseTime.Add(2*time.Second), "stdout", "after purge"))
 
-	if got := refs[web]; got == before {
+	if got := state.refs[web]; got == before {
 		t.Fatalf("the writer still caches the purged generation id %d", got)
 	}
 

--- a/server/internal/logstore/query.go
+++ b/server/internal/logstore/query.go
@@ -164,10 +164,14 @@ type lineSpan struct {
 	newest time.Time
 }
 
-// lineSpans reports the stored time range of every generation that has lines.
+// lineSpans reports the stored time range of every generation that has lines,
+// covering both the hot table and the sealed blocks. A block's bounds are stored
+// alongside it, so the full range costs no decompression.
 func (s *Store) lineSpans(ctx context.Context) (map[int64]lineSpan, error) {
-	rows, err := s.db.QueryContext(ctx,
-		"SELECT container_ref, MIN(ts_ns), MAX(ts_ns) FROM log_lines GROUP BY container_ref")
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT container_ref, MIN(ts_ns), MAX(ts_ns) FROM log_lines GROUP BY container_ref
+		UNION ALL
+		SELECT container_ref, MIN(ts_min_ns), MAX(ts_max_ns) FROM log_blocks GROUP BY container_ref`)
 	if err != nil {
 		return nil, err
 	}
@@ -179,10 +183,14 @@ func (s *Store) lineSpans(ctx context.Context) (map[int64]lineSpan, error) {
 		if err := rows.Scan(&ref, &oldest, &newest); err != nil {
 			return nil, err
 		}
-		spans[ref] = lineSpan{
-			oldest: time.Unix(0, oldest).UTC(),
-			newest: time.Unix(0, newest).UTC(),
+		span, seen := spans[ref]
+		if !seen || time.Unix(0, oldest).UTC().Before(span.oldest) {
+			span.oldest = time.Unix(0, oldest).UTC()
 		}
+		if !seen || time.Unix(0, newest).UTC().After(span.newest) {
+			span.newest = time.Unix(0, newest).UTC()
+		}
+		spans[ref] = span
 	}
 	return spans, rows.Err()
 }
@@ -235,11 +243,11 @@ func (s *Store) Query(ctx context.Context, q LogQuery) (LogPage, error) {
 		hasPos bool
 	)
 	if q.Cursor != "" {
-		tsNS, rowid, err := decodeCursor(q.Cursor)
+		tsNS, seq, err := decodeCursor(q.Cursor)
 		if err != nil {
 			return LogPage{}, err
 		}
-		from, hasPos = cursorPos{tsNS: tsNS, rowid: rowid}, true
+		from, hasPos = cursorPos{tsNS: tsNS, seq: seq}, true
 	}
 
 	// One extra entry beyond the page is what proves an older page exists, and
@@ -318,14 +326,25 @@ func newPage(entries []models.LogEntry, anchors []cursorPos, limit int) LogPage 
 	cut := len(entries) - limit
 	return LogPage{
 		Entries:    entries[cut:],
-		NextCursor: encodeCursor(anchors[cut].tsNS, anchors[cut].rowid),
+		NextCursor: encodeCursor(anchors[cut].tsNS, anchors[cut].seq),
 	}
 }
 
-// cursorPos is the keyset position of one stored row.
+// cursorPos is the keyset position of one stored line: its timestamp and its
+// store-wide sequence number. seq keeps the position stable when the line moves
+// from the hot table into a sealed block, where it no longer has a rowid.
 type cursorPos struct {
-	tsNS  int64
-	rowid int64
+	tsNS int64
+	seq  int64
+}
+
+// newer reports whether p sorts before other in the newest-first order pages
+// are read in.
+func (p cursorPos) newer(other cursorPos) bool {
+	if p.tsNS != other.tsNS {
+		return p.tsNS > other.tsNS
+	}
+	return p.seq > other.seq
 }
 
 // storedRow is one scanned row: the entry it parses to and where it sits.
@@ -334,8 +353,38 @@ type storedRow struct {
 	pos   cursorPos
 }
 
-// scanRows reads one chunk of rows, newest-first, strictly older than from.
+// scanRows reads one chunk of lines, newest-first, strictly older than from.
+//
+// Lines live in two places — the hot table holds what has not been sealed yet,
+// sealed blocks hold everything older — and a generation's hot lines are not
+// always newer than another generation's sealed ones. So both sources are read
+// and merged. Taking the newest chunk of the union is exact: each source
+// contributed its own newest chunk, so nothing that belongs in the result was
+// left behind.
 func (s *Store) scanRows(ctx context.Context, refs []int64, q LogQuery, from cursorPos, hasPos bool, chunk int, byRef map[int64]generation) ([]storedRow, error) {
+	hot, err := s.scanHotRows(ctx, refs, q, from, hasPos, chunk, byRef)
+	if err != nil {
+		return nil, err
+	}
+	sealed, err := s.scanSealedRows(ctx, refs, q, from, hasPos, chunk, byRef)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := make([]storedRow, 0, len(hot)+len(sealed))
+	merged = append(merged, hot...)
+	merged = append(merged, sealed...)
+	sort.SliceStable(merged, func(i, j int) bool {
+		return merged[i].pos.newer(merged[j].pos)
+	})
+	if len(merged) > chunk {
+		merged = merged[:chunk]
+	}
+	return merged, nil
+}
+
+// scanHotRows reads unsealed lines straight out of log_lines.
+func (s *Store) scanHotRows(ctx context.Context, refs []int64, q LogQuery, from cursorPos, hasPos bool, chunk int, byRef map[int64]generation) ([]storedRow, error) {
 	statement, args := buildSelect(refs, q, from, hasPos, chunk)
 
 	rows, err := s.db.QueryContext(ctx, statement, args...)
@@ -347,21 +396,99 @@ func (s *Store) scanRows(ctx context.Context, refs []int64, q LogQuery, from cur
 	scanned := make([]storedRow, 0, chunk)
 	for rows.Next() {
 		var (
-			rowid  int64
+			seq    int64
 			ref    int64
 			tsNS   int64
 			stream int
 			raw    string
 		)
-		if err := rows.Scan(&rowid, &ref, &tsNS, &stream, &raw); err != nil {
+		if err := rows.Scan(&seq, &ref, &tsNS, &stream, &raw); err != nil {
 			return nil, err
 		}
 		scanned = append(scanned, storedRow{
 			entry: entryFromRow(tsNS, stream, raw, byRef[ref]),
-			pos:   cursorPos{tsNS: tsNS, rowid: rowid},
+			pos:   cursorPos{tsNS: tsNS, seq: seq},
 		})
 	}
 	return scanned, rows.Err()
+}
+
+// scanSealedRows reads compressed blocks newest-first, stopping as soon as it
+// holds a full chunk of lines. Blocks outside the query's time window, or
+// entirely newer than the cursor, are ruled out by their stored bounds and are
+// never decompressed.
+func (s *Store) scanSealedRows(ctx context.Context, refs []int64, q LogQuery, from cursorPos, hasPos bool, chunk int, byRef map[int64]generation) ([]storedRow, error) {
+	placeholders, args := refArgs(refs)
+	where := []string{"container_ref IN (" + placeholders + ")"}
+	if !q.Since.IsZero() {
+		where = append(where, "ts_max_ns >= ?")
+		args = append(args, q.Since.UnixNano())
+	}
+	if !q.Until.IsZero() {
+		where = append(where, "ts_min_ns <= ?")
+		args = append(args, q.Until.UnixNano())
+	}
+	if hasPos {
+		// A block every one of whose lines is newer than the cursor holds
+		// nothing this page can use.
+		where = append(where, "(ts_min_ns < ? OR (ts_min_ns = ? AND seq_min < ?))")
+		args = append(args, from.tsNS, from.tsNS, from.seq)
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT container_ref, payload FROM log_blocks WHERE "+strings.Join(where, " AND ")+
+			" ORDER BY ts_max_ns DESC, seq_max DESC", args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		scanned []storedRow
+		scratch []byte
+	)
+	for rows.Next() {
+		var (
+			ref     int64
+			payload []byte
+		)
+		if err := rows.Scan(&ref, &payload); err != nil {
+			return nil, err
+		}
+		lines, next, err := s.codec.unpack(payload, scratch)
+		if err != nil {
+			return nil, err
+		}
+		scratch = next
+
+		gen := byRef[ref]
+		for i := len(lines) - 1; i >= 0; i-- { // newest-first within the block
+			l := lines[i]
+			pos := cursorPos{tsNS: l.tsNS, seq: l.seq}
+			if hasPos && !from.newer(pos) {
+				continue
+			}
+			if !q.Since.IsZero() && l.tsNS < q.Since.UnixNano() {
+				continue
+			}
+			if !q.Until.IsZero() && l.tsNS > q.Until.UnixNano() {
+				continue
+			}
+			scanned = append(scanned, storedRow{
+				entry: entryFromRow(l.tsNS, l.stream, l.raw, gen),
+				pos:   pos,
+			})
+		}
+		// Blocks arrive newest-first, so once a chunk is full every line still
+		// unread is older than what has been collected.
+		if len(scanned) >= chunk {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return scanned, nil
 }
 
 // generations resolves a logical container name to its generation rows. An
@@ -412,14 +539,14 @@ func buildSelect(refs []int64, q LogQuery, from cursorPos, hasPos bool, chunk in
 		args = append(args, q.Until.UnixNano())
 	}
 	if hasPos {
-		where = append(where, "(ts_ns < ? OR (ts_ns = ? AND rowid < ?))")
-		args = append(args, from.tsNS, from.tsNS, from.rowid)
+		where = append(where, "(ts_ns < ? OR (ts_ns = ? AND seq < ?))")
+		args = append(args, from.tsNS, from.tsNS, from.seq)
 	}
 	args = append(args, chunk)
 
-	statement := "SELECT rowid, container_ref, ts_ns, stream, raw FROM log_lines WHERE " +
+	statement := "SELECT seq, container_ref, ts_ns, stream, raw FROM log_lines WHERE " +
 		strings.Join(where, " AND ") +
-		" ORDER BY ts_ns DESC, rowid DESC LIMIT ?"
+		" ORDER BY ts_ns DESC, seq DESC LIMIT ?"
 	return statement, args
 }
 
@@ -552,10 +679,11 @@ func groupRows(rows []storedRow) ([]models.LogEntry, []cursorPos, int) {
 }
 
 // encodeCursor renders the keyset position of the oldest entry on a page.
-// (ts_ns, rowid) is unique and immutable, so pages stay stable while new lines
-// are ingested.
-func encodeCursor(tsNS, rowid int64) string {
-	return base64.RawURLEncoding.EncodeToString(fmt.Appendf(nil, "%d:%d", tsNS, rowid))
+// (ts_ns, seq) is unique and immutable — a line keeps its sequence number when
+// it is sealed into a block — so pages stay stable while new lines are ingested
+// and while older ones are compressed.
+func encodeCursor(tsNS, seq int64) string {
+	return base64.RawURLEncoding.EncodeToString(fmt.Appendf(nil, "%d:%d", tsNS, seq))
 }
 
 func decodeCursor(cursor string) (int64, int64, error) {
@@ -563,7 +691,7 @@ func decodeCursor(cursor string) (int64, int64, error) {
 	if err != nil {
 		return 0, 0, ErrInvalidCursor
 	}
-	tsPart, rowPart, ok := strings.Cut(string(decoded), ":")
+	tsPart, seqPart, ok := strings.Cut(string(decoded), ":")
 	if !ok {
 		return 0, 0, ErrInvalidCursor
 	}
@@ -571,9 +699,9 @@ func decodeCursor(cursor string) (int64, int64, error) {
 	if err != nil {
 		return 0, 0, ErrInvalidCursor
 	}
-	rowid, err := strconv.ParseInt(rowPart, 10, 64)
+	seq, err := strconv.ParseInt(seqPart, 10, 64)
 	if err != nil {
 		return 0, 0, ErrInvalidCursor
 	}
-	return tsNS, rowid, nil
+	return tsNS, seq, nil
 }

--- a/server/internal/logstore/query.go
+++ b/server/internal/logstore/query.go
@@ -436,8 +436,8 @@ func (s *Store) scanSealedRows(ctx context.Context, refs []int64, q LogQuery, fr
 	}
 
 	rows, err := s.db.QueryContext(ctx,
-		"SELECT container_ref, payload FROM log_blocks WHERE "+strings.Join(where, " AND ")+
-			" ORDER BY ts_max_ns DESC, seq_max DESC", args...)
+		"SELECT container_ref, ts_max_ns, seq_max, payload FROM log_blocks WHERE "+
+			strings.Join(where, " AND ")+" ORDER BY ts_max_ns DESC, seq_max DESC", args...)
 	if err != nil {
 		return nil, err
 	}
@@ -450,11 +450,30 @@ func (s *Store) scanSealedRows(ctx context.Context, refs []int64, q LogQuery, fr
 	for rows.Next() {
 		var (
 			ref     int64
+			tsMax   int64
+			seqMax  int64
 			payload []byte
 		)
-		if err := rows.Scan(&ref, &payload); err != nil {
+		if err := rows.Scan(&ref, &tsMax, &seqMax, &payload); err != nil {
 			return nil, err
 		}
+
+		// Blocks arrive ordered by their newest line, but a backfill re-read
+		// makes their time ranges overlap, so a later block can still hold lines
+		// newer than ones already collected. Stopping on count alone would drop
+		// those, and the cursor would then page straight past them. Stop only
+		// once this block's newest possible position is older than the chunk
+		// boundary, which is the point nothing further can qualify.
+		if len(scanned) >= chunk {
+			sort.SliceStable(scanned, func(i, j int) bool {
+				return scanned[i].pos.newer(scanned[j].pos)
+			})
+			scanned = scanned[:chunk]
+			if !(cursorPos{tsNS: tsMax, seq: seqMax}).newer(scanned[chunk-1].pos) {
+				break
+			}
+		}
+
 		lines, next, err := s.codec.unpack(payload, scratch)
 		if err != nil {
 			return nil, err
@@ -478,11 +497,6 @@ func (s *Store) scanSealedRows(ctx context.Context, refs []int64, q LogQuery, fr
 				entry: entryFromRow(l.tsNS, l.stream, l.raw, gen),
 				pos:   pos,
 			})
-		}
-		// Blocks arrive newest-first, so once a chunk is full every line still
-		// unread is older than what has been collected.
-		if len(scanned) >= chunk {
-			break
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/server/internal/logstore/schema.go
+++ b/server/internal/logstore/schema.go
@@ -8,7 +8,7 @@ import (
 
 // schemaVersion is the current schema generation, tracked in PRAGMA
 // user_version. Bump it and add a migration step when the schema changes.
-const schemaVersion = 3
+const schemaVersion = 4
 
 // schemaV1 is the initial schema.
 //
@@ -87,6 +87,50 @@ ALTER TABLE containers
 ADD COLUMN initial_backfill_done INTEGER NOT NULL DEFAULT 0;
 `
 
+// schemaV4 adds sealed blocks. log_lines stays exactly as it was and becomes
+// the hot table: lines land there first so they are queryable the moment they
+// commit, and the writer seals each full run of blockLines into one compressed
+// row of log_blocks. A container therefore holds at most blockLines uncompressed
+// lines at a time, and everything older costs roughly a tenth as much disk.
+//
+// seq is a store-wide monotonic line number. It orders lines that share a
+// timestamp, and it keeps doing so after a line moves into a block, where its
+// rowid no longer exists — which is what lets one keyset cursor page across both
+// tables. Existing rows adopt their rowid, which is already insertion-ordered
+// and unique within the table.
+//
+// stored_bytes changes meaning here, from "raw log bytes" to "bytes this
+// generation occupies", so the retention caps keep bounding the file rather
+// than the history. Existing rows are already counted in raw bytes and are
+// still hot, so they need no restatement; sealing subtracts the raw bytes it
+// removes and adds the payload it writes.
+const schemaV4 = `
+ALTER TABLE log_lines ADD COLUMN seq INTEGER NOT NULL DEFAULT 0;
+UPDATE log_lines SET seq = rowid;
+
+DROP INDEX log_lines_container_ts;
+CREATE INDEX log_lines_container_ts ON log_lines(container_ref, ts_ns, seq);
+
+CREATE TABLE log_blocks (
+  container_ref INTEGER NOT NULL REFERENCES containers(id),
+  ts_min_ns     INTEGER NOT NULL,
+  ts_max_ns     INTEGER NOT NULL,
+  seq_min       INTEGER NOT NULL,
+  seq_max       INTEGER NOT NULL,
+  lines         INTEGER NOT NULL,
+  -- level_mask carries one bit per severity and raw_bytes the uncompressed
+  -- size, so a level filter and the history summary both work without
+  -- decompressing anything.
+  level_mask    INTEGER NOT NULL,
+  raw_bytes     INTEGER NOT NULL,
+  -- dedup_filter rules out lines a backfill re-read has already stored; see
+  -- block.go.
+  dedup_filter  BLOB NOT NULL,
+  payload       BLOB NOT NULL
+);
+CREATE INDEX log_blocks_container_ts ON log_blocks(container_ref, ts_max_ns);
+`
+
 // initSchema creates the schema on a fresh database and is a no-op on an
 // already-current one. Unknown (newer) versions are rejected rather than
 // silently downgraded. A fresh database walks the same migration path as an
@@ -123,6 +167,11 @@ func initSchema(ctx context.Context, db *sql.DB) error {
 	if version < 3 {
 		if _, err := tx.ExecContext(ctx, schemaV3); err != nil {
 			return fmt.Errorf("migrate schema to version 3: %w", err)
+		}
+	}
+	if version < 4 {
+		if _, err := tx.ExecContext(ctx, schemaV4); err != nil {
+			return fmt.Errorf("migrate schema to version 4: %w", err)
 		}
 	}
 

--- a/server/internal/logstore/schema.go
+++ b/server/internal/logstore/schema.go
@@ -129,6 +129,9 @@ CREATE TABLE log_blocks (
   payload       BLOB NOT NULL
 );
 CREATE INDEX log_blocks_container_ts ON log_blocks(container_ref, ts_max_ns);
+-- The writer reads MAX(seq_max) at startup; without this it scans the table,
+-- and every row it touches drags a compressed payload's pages with it.
+CREATE INDEX log_blocks_seq ON log_blocks(seq_max);
 `
 
 // initSchema creates the schema on a fresh database and is a no-op on an

--- a/server/internal/logstore/store.go
+++ b/server/internal/logstore/store.go
@@ -94,6 +94,9 @@ type Store struct {
 	db     *sql.DB
 	path   string
 	limits Limits
+	// codec packs and unpacks sealed blocks. Its encoder and decoder are safe
+	// for concurrent use, so the writer and every reader share one.
+	codec *blockCodec
 
 	ingestCh chan ingestMsg
 	// retainCh signals the writer to run a retention sweep between batches. It is
@@ -214,10 +217,17 @@ func Open(path string, limits Limits) (*Store, error) {
 		return nil, err
 	}
 
+	codec, err := newBlockCodec()
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+
 	return &Store{
 		db:          db,
 		path:        path,
 		limits:      limits,
+		codec:       codec,
 		ingestCh:    make(chan ingestMsg, ingestBuffer),
 		retainCh:    make(chan struct{}, 1),
 		resume:      make(map[genKey]resumePoint),
@@ -488,6 +498,7 @@ func (s *Store) Wait() {
 
 // Close releases the database. Call it after Wait.
 func (s *Store) Close() error {
+	s.codec.close()
 	return s.db.Close()
 }
 

--- a/server/internal/logstore/stress.go
+++ b/server/internal/logstore/stress.go
@@ -1,6 +1,9 @@
 package logstore
 
-import "context"
+import (
+	"context"
+	"database/sql"
+)
 
 // This file exposes a tiny, read-only measurement surface consumed ONLY by the
 // out-of-tree stress harness (server/cmd/logstore-stress). It adds no behavior
@@ -24,9 +27,15 @@ func (s *Store) Committed() int64 {
 }
 
 // CountLines reports how many log lines are currently retained in the database
-// (i.e. after retention eviction). Stress/measurement use only.
+// (i.e. after retention eviction), counting sealed blocks as well as the hot
+// table. Stress/measurement use only.
 func (s *Store) CountLines(ctx context.Context) (int64, error) {
-	var n int64
-	err := s.db.QueryRowContext(ctx, "SELECT count(*) FROM log_lines").Scan(&n)
-	return n, err
+	var hot, sealed sql.NullInt64
+	if err := s.db.QueryRowContext(ctx, "SELECT count(*) FROM log_lines").Scan(&hot); err != nil {
+		return 0, err
+	}
+	if err := s.db.QueryRowContext(ctx, "SELECT SUM(lines) FROM log_blocks").Scan(&sealed); err != nil {
+		return 0, err
+	}
+	return hot.Int64 + sealed.Int64, nil
 }


### PR DESCRIPTION
Stored logs are one SQLite row per line, uncompressed. Measured across five real log corpora, the database ends up about 28% larger than the log text itself, because every row carries a header and an index entry.

Lines still land in `log_lines` and stay queryable the moment they commit. The writer now seals each full run of 1000 into one compressed row of `log_blocks`. Inside a block the fields are grouped rather than interleaved, and the engine's timestamp prefix is lifted out and delta-encoded, which roughly halves the payload again.

## Result

Stress harness, same 5 MB cap, 1.2M lines in 60s:

| | before | after |
|---|---|---|
| lines retained under the cap | 34,952 | 430,823 |
| commit rate | 19,998/s | 19,960/s |
| dropped | 0 | 0 |
| heap peak | 7.9 MB | 15.3 MB |

**12.3x more history per byte** on the synthetic stress corpus, where the dedup filter is a large share of each compressed block. On real Docker output, where payloads are larger, the size-based measurement gives 16.4x; across messier corpora the floor was 8x. Full-history search also gets faster (122ms to 43ms over 77k lines) since SQLite reads far fewer pages.

Note the file on disk does not shrink — SQLite reuses freed pages rather than returning them. The caps bound `stored_bytes`, and that is what now holds 16x more.

## Two invariants that needed care

- **Lines stay byte-for-byte what the engine sent.** Rebuilding a lifted timestamp with Go's `RFC3339Nano` is wrong for about one line in ten (it trims trailing zeros). Packing verifies the rebuild against the original bytes and keeps the line whole when it would not match. Zero fallbacks on real Docker output.
- **Dedup can no longer seek a sealed line by index.** Each block carries a bloom filter over its line keys: a negative rules the block out, a positive costs one decompression and an exact check. Live ingestion never consults a block, since its timestamps are newer than anything sealed.

Retention evicts whole blocks oldest-first and falls through to hot lines. `stored_bytes` now counts what a generation occupies rather than its raw text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compressed storage for older log history, reducing retained storage usage.
  * Search, level, time-range filters, and pagination now work consistently across active and archived logs.
  * Improved duplicate detection across archived history.
  * Added reliable sequence ordering across restarts and out-of-order arrivals.
* **Bug Fixes**
  * Retention and container deletion now remove archived log data correctly.
  * Log counts include both active and archived entries.
  * Existing databases migrate automatically while preserving stored logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
